### PR TITLE
Fix: compiling warning

### DIFF
--- a/service/stacks/zephyr/sal_adapter_classic_interface.c
+++ b/service/stacks/zephyr/sal_adapter_classic_interface.c
@@ -570,7 +570,7 @@ static void STACK_CALL(set_device_class)(void* args)
 {
     sal_adapter_req_t* req = args;
 
-    BT_LOGD("%s: %d", __func__, req->adpt.cod);
+    BT_LOGD("%s: %lu", __func__, req->adpt.cod);
     SAL_CHECK(bt_set_class_of_device(req->adpt.cod), 0);
 }
 


### PR DESCRIPTION
bug: v/51418

1. Fix compiling warning. Print uint32_t as "%lu".
