### PR TITLE
[bugfix]:  fix type mismatch for GATT cookie of socket ipc

### DIFF
--- a/framework/socket/bt_gattc.c
+++ b/framework/socket/bt_gattc.c
@@ -66,7 +66,7 @@ bt_status_t bt_gattc_create_connect(bt_instance_t* ins, gattc_handle_t* phandle,
         goto fail;
     }
 
-    gattc_remote->cookie = INT2PTR(void*) packet.gattc_r.handle;
+    gattc_remote->cookie = packet.gattc_r.handle;
     gattc_remote->user_phandle = phandle;
     bt_list_add_tail(ins->gattc_remote_list, gattc_remote);
 

--- a/framework/socket/bt_gatts.c
+++ b/framework/socket/bt_gatts.c
@@ -45,7 +45,7 @@ static bt_gatts_remote_t* gatts_remote_new(bt_instance_t* ins, gatts_callbacks_t
 
     remote->ins = ins;
     remote->callbacks = callbacks;
-    remote->cookie = NULL;
+    remote->cookie = 0;
 
     return remote;
 }
@@ -91,7 +91,7 @@ bt_status_t bt_gatts_register_service(bt_instance_t* ins, gatts_handle_t* phandl
         goto fail;
     }
 
-    gatts_remote->cookie = INT2PTR(void*) packet.gatts_r.handle;
+    gatts_remote->cookie = packet.gatts_r.handle;
     gatts_remote->user_phandle = phandle;
     bt_list_add_tail(ins->gatts_remote_list, gatts_remote);
 

--- a/service/ipc/socket/include/bt_message_gattc.h
+++ b/service/ipc/socket/include/bt_message_gattc.h
@@ -66,7 +66,7 @@ BT_GATT_CLIENT_MESSAGE_START,
     typedef struct {
         bt_instance_t* ins;
         gattc_callbacks_t* callbacks;
-        void* cookie;
+        uint64_t cookie;
         void** user_phandle;
     } bt_gattc_remote_t;
 

--- a/service/ipc/socket/include/bt_message_gatts.h
+++ b/service/ipc/socket/include/bt_message_gatts.h
@@ -61,7 +61,7 @@ BT_GATT_SERVER_MESSAGE_START,
     typedef struct {
         bt_instance_t* ins;
         gatts_callbacks_t* callbacks;
-        void* cookie;
+        uint64_t cookie;
         void** user_phandle;
         bt_list_t* db_list;
     } bt_gatts_remote_t;

--- a/service/ipc/socket/src/bt_socket_gattc.c
+++ b/service/ipc/socket/src/bt_socket_gattc.c
@@ -82,7 +82,7 @@ static void on_connected_cb(gattc_handle_t conn_handle, bt_address_t* addr)
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     memcpy(&packet.gattc_cb._on_connected.addr, addr, sizeof(bt_address_t));
     bt_socket_server_send(gattc_remote->ins, &packet, BT_GATT_CLIENT_ON_CONNECTED);
 }
@@ -90,7 +90,7 @@ static void on_disconnected_cb(gattc_handle_t conn_handle, bt_address_t* addr)
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     memcpy(&packet.gattc_cb._on_disconnected.addr, addr, sizeof(bt_address_t));
     bt_socket_server_send(gattc_remote->ins, &packet, BT_GATT_CLIENT_ON_DISCONNECTED);
 }
@@ -99,7 +99,7 @@ static void on_discovered_cb(gattc_handle_t conn_handle, gatt_status_t status, b
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_discovered.status = status;
     packet.gattc_cb._on_discovered.start_handle = start_handle;
     packet.gattc_cb._on_discovered.end_handle = end_handle;
@@ -120,7 +120,7 @@ static void on_read_cb(gattc_handle_t conn_handle, gatt_status_t status, uint16_
         length = sizeof(packet.gattc_cb._on_read.value);
     }
 
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_read.status = status;
     packet.gattc_cb._on_read.attr_handle = attr_handle;
     packet.gattc_cb._on_read.length = length;
@@ -131,7 +131,7 @@ static void on_written_cb(gattc_handle_t conn_handle, gatt_status_t status, uint
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_written.status = status;
     packet.gattc_cb._on_written.attr_handle = attr_handle;
     bt_socket_server_send(gattc_remote->ins, &packet, BT_GATT_CLIENT_ON_WRITTEN);
@@ -140,7 +140,7 @@ static void on_subscribed_cb(gattc_handle_t conn_handle, gatt_status_t status, u
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_subscribed.status = status;
     packet.gattc_cb._on_subscribed.attr_handle = attr_handle;
     packet.gattc_cb._on_subscribed.enable = enable;
@@ -156,7 +156,7 @@ static void on_notified_cb(gattc_handle_t conn_handle, uint16_t attr_handle, uin
         length = sizeof(packet.gattc_cb._on_notified.value);
     }
 
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_notified.attr_handle = attr_handle;
     packet.gattc_cb._on_notified.length = length;
     memcpy(packet.gattc_cb._on_notified.value, value, length);
@@ -166,7 +166,7 @@ static void on_mtu_updated_cb(gattc_handle_t conn_handle, gatt_status_t status, 
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_mtu_updated.status = status;
     packet.gattc_cb._on_mtu_updated.mtu = mtu;
     bt_socket_server_send(gattc_remote->ins, &packet, BT_GATT_CLIENT_ON_MTU_UPDATED);
@@ -175,7 +175,7 @@ static void on_phy_read_cb(gattc_handle_t conn_handle, ble_phy_type_t tx_phy, bl
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_phy_updated.tx_phy = tx_phy;
     packet.gattc_cb._on_phy_updated.rx_phy = rx_phy;
     bt_socket_server_send(gattc_remote->ins, &packet, BT_GATT_CLIENT_ON_PHY_READ);
@@ -184,7 +184,7 @@ static void on_phy_updated_cb(gattc_handle_t conn_handle, gatt_status_t status, 
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_phy_updated.status = status;
     packet.gattc_cb._on_phy_updated.tx_phy = tx_phy;
     packet.gattc_cb._on_phy_updated.rx_phy = rx_phy;
@@ -194,7 +194,7 @@ static void on_rssi_read_cb(gattc_handle_t conn_handle, gatt_status_t status, in
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_rssi_read.status = status;
     packet.gattc_cb._on_rssi_read.rssi = rssi;
     bt_socket_server_send(gattc_remote->ins, &packet, BT_GATT_CLIENT_ON_RSSI_READ);
@@ -204,7 +204,7 @@ static void on_conn_param_updated_cb(gattc_handle_t conn_handle, bt_status_t sta
 {
     bt_message_packet_t packet = { 0 };
     bt_gattc_remote_t* gattc_remote = if_gattc_get_remote(conn_handle);
-    packet.gattc_cb._on_callback.remote = PTR2INT(uint64_t) gattc_remote->cookie;
+    packet.gattc_cb._on_callback.remote = gattc_remote->cookie;
     packet.gattc_cb._on_conn_param_updated.status = status;
     packet.gattc_cb._on_conn_param_updated.interval = connection_interval;
     packet.gattc_cb._on_conn_param_updated.latency = peripheral_latency;
@@ -241,7 +241,7 @@ void bt_socket_server_gattc_process(service_poll_t* poll, int fd,
         }
 
         gattc_remote->ins = ins;
-        gattc_remote->cookie = INT2PTR(void*) packet->gattc_pl._bt_gattc_create.cookie;
+        gattc_remote->cookie = packet->gattc_pl._bt_gattc_create.cookie;
         packet->gattc_r.status = profile->create_connect(gattc_remote,
             INT2PTR(void**) & packet->gattc_r.handle,
             (gattc_callbacks_t*)&g_gattc_socket_cbs);

--- a/service/ipc/socket/src/bt_socket_gatts.c
+++ b/service/ipc/socket/src/bt_socket_gatts.c
@@ -82,7 +82,7 @@ static void on_connected_cb(gatts_handle_t srv_handle, bt_address_t* addr)
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_connected.addr, addr, sizeof(bt_address_t));
     bt_socket_server_send(gatts_remote->ins, &packet, BT_GATT_SERVER_ON_CONNECTED);
 }
@@ -90,7 +90,7 @@ static void on_disconnected_cb(gatts_handle_t srv_handle, bt_address_t* addr)
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_disconnected.addr, addr, sizeof(bt_address_t));
     bt_socket_server_send(gatts_remote->ins, &packet, BT_GATT_SERVER_ON_DISCONNECTED);
 }
@@ -98,7 +98,7 @@ static void on_attr_table_added_cb(gatts_handle_t srv_handle, gatt_status_t stat
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     packet.gatts_cb._on_attr_table_added.status = status;
     packet.gatts_cb._on_attr_table_added.attr_handle = attr_handle;
     bt_socket_server_send(gatts_remote->ins, &packet, BT_GATT_SERVER_ON_ATTR_TABLE_ADDED);
@@ -107,7 +107,7 @@ static void on_attr_table_removed_cb(gatts_handle_t srv_handle, gatt_status_t st
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     packet.gatts_cb._on_attr_table_removed.status = status;
     packet.gatts_cb._on_attr_table_removed.attr_handle = attr_handle;
     bt_socket_server_send(gatts_remote->ins, &packet, BT_GATT_SERVER_ON_ATTR_TABLE_REMOVED);
@@ -116,7 +116,7 @@ static void on_notify_complete_cb(gatts_handle_t srv_handle, bt_address_t* addr,
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_nofity_complete.addr, addr, sizeof(bt_address_t));
     packet.gatts_cb._on_nofity_complete.status = status;
     packet.gatts_cb._on_nofity_complete.attr_handle = attr_handle;
@@ -126,7 +126,7 @@ static void on_mtu_changed_cb(gatts_handle_t srv_handle, bt_address_t* addr, uin
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_mtu_changed.addr, addr, sizeof(bt_address_t));
     packet.gatts_cb._on_mtu_changed.mtu = mtu;
     bt_socket_server_send(gatts_remote->ins, &packet, BT_GATT_SERVER_ON_MTU_CHANGED);
@@ -135,7 +135,7 @@ static void on_phy_read_cb(gatts_handle_t srv_handle, bt_address_t* addr, ble_ph
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_phy_updated.addr, addr, sizeof(bt_address_t));
     packet.gatts_cb._on_phy_updated.tx_phy = tx_phy;
     packet.gatts_cb._on_phy_updated.rx_phy = rx_phy;
@@ -145,7 +145,7 @@ static void on_phy_updated_cb(gatts_handle_t srv_handle, bt_address_t* addr, gat
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_phy_updated.addr, addr, sizeof(bt_address_t));
     packet.gatts_cb._on_phy_updated.status = status;
     packet.gatts_cb._on_phy_updated.tx_phy = tx_phy;
@@ -156,7 +156,7 @@ static uint16_t on_read_request_cb(gatts_handle_t srv_handle, bt_address_t* addr
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_read_request.addr, addr, sizeof(bt_address_t));
     packet.gatts_cb._on_read_request.attr_handle = attr_handle;
     packet.gatts_cb._on_read_request.req_handle = req_handle;
@@ -173,7 +173,7 @@ static uint16_t on_write_request_cb(gatts_handle_t srv_handle, bt_address_t* add
         length = sizeof(packet.gatts_cb._on_write_request.value);
     }
 
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_write_request.addr, addr, sizeof(bt_address_t));
     packet.gatts_cb._on_write_request.attr_handle = attr_handle;
     packet.gatts_cb._on_write_request.offset = offset;
@@ -187,7 +187,7 @@ static void on_conn_param_changed_cb(gatts_handle_t srv_handle, bt_address_t* ad
 {
     bt_message_packet_t packet = { 0 };
     bt_gatts_remote_t* gatts_remote = if_gatts_get_remote(srv_handle);
-    packet.gatts_cb._on_callback.remote = PTR2INT(uint64_t) gatts_remote->cookie;
+    packet.gatts_cb._on_callback.remote = gatts_remote->cookie;
     memcpy(&packet.gatts_cb._on_conn_param_changed.addr, addr, sizeof(bt_address_t));
     packet.gatts_cb._on_conn_param_changed.interval = connection_interval;
     packet.gatts_cb._on_conn_param_changed.latency = peripheral_latency;
@@ -221,7 +221,7 @@ void bt_socket_server_gatts_process(service_poll_t* poll, int fd,
         }
 
         gatts_remote->ins = ins;
-        gatts_remote->cookie = INT2PTR(void*) packet->gatts_pl._bt_gatts_register.cookie;
+        gatts_remote->cookie = packet->gatts_pl._bt_gatts_register.cookie;
         packet->gatts_r.status = profile->register_service(gatts_remote,
             (void**)&packet->gatts_r.handle,
             (gatts_callbacks_t*)&g_gatts_socket_cbs);


### PR DESCRIPTION
Rootcause: The 32-bit pointer stored by the Vela socket server may truncate the 64-bit pointer from Android client

bug: v/45006