### PR TITLE
framework/avrcp: add metadata support for avrcp control in BT Service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,10 @@ if(CONFIG_BLUETOOTH)
       list(APPEND CSRCS ${BLUETOOTH_DIR}/tools/a2dp_source.c)
     endif()
 
+    if(CONFIG_BLUETOOTH_AVRCP_CONTROL)
+      list(APPEND CSRCS ${BLUETOOTH_DIR}/tools/avrcp_control.c)
+    endif()
+
     if(CONFIG_BLUETOOTH_GATT)
       list(APPEND CSRCS ${BLUETOOTH_DIR}/tools/gatt_client.c)
       list(APPEND CSRCS ${BLUETOOTH_DIR}/tools/gatt_server.c)

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,9 @@ endif #CONFIG_BLUETOOTH_A2DP_SINK
 ifeq ($(CONFIG_BLUETOOTH_A2DP_SOURCE), y)
 	CSRCS += tools/a2dp_source.c
 endif #CONFIG_BLUETOOTH_A2DP_SOURCE
+ifeq ($(CONFIG_BLUETOOTH_AVRCP_CONTROL), y)
+	CSRCS += tools/avrcp_control.c
+endif #CONFIG_BLUETOOTH_AVRCP_CONTROL
 ifeq ($(CONFIG_BLUETOOTH_GATT), y)
 	CSRCS += tools/gatt_client.c
 	CSRCS += tools/gatt_server.c

--- a/framework/api/bt_avrcp_control.c
+++ b/framework/api/bt_avrcp_control.c
@@ -19,6 +19,7 @@
 
 #include "avrcp_control_service.h"
 #include "bt_avrcp_control.h"
+#include "bt_internal.h"
 #include "bt_profile.h"
 #include "service_manager.h"
 #include "utils/log.h"
@@ -28,16 +29,23 @@ static avrcp_control_interface_t* get_profile_service(void)
     return (avrcp_control_interface_t*)service_manager_get_profile(PROFILE_AVRCP_CT);
 }
 
-void* bt_avrcp_control_register_callbacks(bt_instance_t* ins, const avrcp_control_callbacks_t* callbacks)
+void* BTSYMBOLS(bt_avrcp_control_register_callbacks)(bt_instance_t* ins, const avrcp_control_callbacks_t* callbacks)
 {
     avrcp_control_interface_t* profile = get_profile_service();
 
     return profile->register_callbacks(NULL, callbacks);
 }
 
-bool bt_avrcp_control_unregister_callbacks(bt_instance_t* ins, void* cookie)
+bool BTSYMBOLS(bt_avrcp_control_unregister_callbacks)(bt_instance_t* ins, void* cookie)
 {
     avrcp_control_interface_t* profile = get_profile_service();
 
     return profile->unregister_callbacks(NULL, cookie);
+}
+
+bt_status_t BTSYMBOLS(bt_avrcp_control_get_element_attributes)(bt_instance_t* ins, bt_address_t* addr)
+{
+    avrcp_control_interface_t* profile = get_profile_service();
+
+    return profile->avrcp_control_get_element_attributes(addr);
 }

--- a/framework/include/bluetooth.h
+++ b/framework/include/bluetooth.h
@@ -449,10 +449,12 @@ typedef struct bt_instance {
     callbacks_list_t* a2dp_sink_callbacks;
     callbacks_list_t* a2dp_source_callbacks;
     callbacks_list_t* avrcp_target_callbacks;
+    callbacks_list_t* avrcp_control_callbacks;
     void* adapter_cookie;
     void* a2dp_sink_cookie;
     void* a2dp_source_cookie;
     void* avrcp_target_cookie;
+    void* avrcp_control_cookie;
 
     callbacks_list_t* hfp_ag_callbacks;
     callbacks_list_t* hfp_hf_callbacks;

--- a/framework/include/bt_avrcp.h
+++ b/framework/include/bt_avrcp.h
@@ -21,6 +21,16 @@
 #include "bt_addr.h"
 #include "bt_device.h"
 
+#define AVRCP_MAX_ATTR_COUNT 9
+#define AVRCP_ATTR_MAX_TIELE_LEN 64
+#define AVRCP_ATTR_MAX_ARTIST_LEN 64
+#define AVRCP_ATTR_MAX_ALBUM_LEN 0
+#define AVRCP_ATTR_MAX_TRACK_NUMBER_LEN 0
+#define AVRCP_ATTR_MAX_TOTAL_TRACK_NUMBER_LEN 0
+#define AVRCP_ATTR_MAX_GENER_LEN 0
+#define AVRCP_ATTR_MAX_PLAYING_TIMES_LEN 0
+#define AVRCP_ATTR_MAX_COVER_ART_HANDLE_LEN 0
+
 typedef enum {
     PASSTHROUGH_CMD_ID_SELECT,
     PASSTHROUGH_CMD_ID_UP,
@@ -132,6 +142,17 @@ typedef enum {
     AVRCP_RESPONSE_SKIPPED,
     AVRCP_RESPONSE_TIMEOUT
 } avrcp_response_t;
+
+typedef enum {
+    AVRCP_ATTR_TITLE = 1,
+    AVRCP_ATTR_ARTIST_NAME,
+    AVRCP_ATTR_ALBUM_NAME,
+    AVRCP_ATTR_TRACK_NUMBER,
+    AVRCP_ATTR_TOTAL_NUMBER_OF_TRACKS,
+    AVRCP_ATTR_GENRE,
+    AVRCP_ATTR_PLAYING_TIME_MS,
+    AVRCP_ATTR_COVER_ART_HANDLE
+} avrcp_media_attr_type_t;
 
 typedef void (*avrcp_connection_state_callback)(void* cookie, bt_address_t* addr, profile_connection_state_t state);
 

--- a/framework/include/bt_avrcp_control.h
+++ b/framework/include/bt_avrcp_control.h
@@ -18,12 +18,63 @@
 
 #include "bt_avrcp.h"
 
+/**
+ * @cond
+ */
+
+typedef struct {
+    uint32_t attr_id;
+    uint16_t chr_set;
+    uint8_t* text;
+} avrcp_element_attr_val_t;
+
+typedef struct {
+    uint8_t title[AVRCP_ATTR_MAX_TIELE_LEN + 1];
+    uint8_t artist[AVRCP_ATTR_MAX_ARTIST_LEN + 1];
+    uint8_t album[AVRCP_ATTR_MAX_ALBUM_LEN + 1];
+    uint8_t track_number[AVRCP_ATTR_MAX_TRACK_NUMBER_LEN + 1];
+    uint8_t total_track_number[AVRCP_ATTR_MAX_TOTAL_TRACK_NUMBER_LEN + 1];
+    uint8_t gener[AVRCP_ATTR_MAX_GENER_LEN + 1];
+    uint8_t playing_time_ms[AVRCP_ATTR_MAX_PLAYING_TIMES_LEN + 1];
+    uint8_t cover_art_handle[AVRCP_ATTR_MAX_COVER_ART_HANDLE_LEN + 1];
+} avrcp_socket_element_attr_val_t;
+
+typedef void (*avrcp_get_element_attribute_cb)(void* cookie, bt_address_t* addr, uint8_t attrs_count, avrcp_element_attr_val_t* attrs);
 typedef struct {
     size_t size;
     avrcp_connection_state_callback connection_state_cb;
+    avrcp_get_element_attribute_cb get_element_attribute_cb;
 } avrcp_control_callbacks_t;
 
-void* bt_avrcp_control_register_callbacks(bt_instance_t* ins, const avrcp_control_callbacks_t* callbacks);
-bool bt_avrcp_control_unregister_callbacks(bt_instance_t* ins, void* cookie);
+/**
+ * @endcond
+ */
+
+/**
+ * @brief Register callback functions to AVRCP Control
+ *
+ * @param ins - Bluetooth client instance.
+ * @param callbacks - AVRCP Control callback functions.
+ * @return void* - Callbacks cookie.
+ */
+void* BTSYMBOLS(bt_avrcp_control_register_callbacks)(bt_instance_t* ins, const avrcp_control_callbacks_t* callbacks);
+
+/**
+ * @brief Unregister callback functions to AVRCP Control
+ *
+ * @param ins - Bluetooth client instance.
+ * @param cookie - Callbacks cookie.
+ * @return bool - True, if unregister success, false otherwise.
+ */
+bool BTSYMBOLS(bt_avrcp_control_unregister_callbacks)(bt_instance_t* ins, void* cookie);
+
+/**
+ * @brief Get element attribute from peer device.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param addr - Remote BT address.
+ * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ */
+bt_status_t BTSYMBOLS(bt_avrcp_control_get_element_attributes)(bt_instance_t* ins, bt_address_t* addr);
 
 #endif /* __BT_AVRCP_CONTROL_H__ */

--- a/framework/socket/bt_avrcp_control.c
+++ b/framework/socket/bt_avrcp_control.c
@@ -1,0 +1,102 @@
+/****************************************************************************
+ *  Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#define LOG_TAG "avrcp_control_api"
+
+#include <stdint.h>
+
+#include "bt_avrcp_control.h"
+#include "bt_socket.h"
+
+void* bt_avrcp_control_register_callbacks(bt_instance_t* ins, const avrcp_control_callbacks_t* callbacks)
+{
+    bt_message_packet_t packet;
+    bt_status_t status;
+    void* handle;
+
+    BT_SOCKET_INS_VALID(ins, NULL);
+
+    if (ins->avrcp_control_callbacks != NULL) {
+        handle = bt_remote_callbacks_register(ins->avrcp_control_callbacks, NULL, (void*)callbacks);
+        return handle;
+    }
+
+    ins->avrcp_control_callbacks = bt_callbacks_list_new(CONFIG_BLUETOOTH_MAX_REGISTER_NUM);
+
+#ifdef CONFIG_BLUETOOTH_FEATURE
+    handle = bt_remote_callbacks_register(ins->avrcp_control_callbacks, ins, (void*)callbacks);
+#else
+    handle = bt_remote_callbacks_register(ins->avrcp_control_callbacks, NULL, (void*)callbacks);
+#endif
+
+    if (handle == NULL) {
+        bt_callbacks_list_free(ins->avrcp_control_callbacks);
+        ins->avrcp_control_callbacks = NULL;
+        return handle;
+    }
+
+    status = bt_socket_client_sendrecv(ins, &packet, BT_AVRCP_CONTROL_REGISTER_CALLBACKS);
+    if (status != BT_STATUS_SUCCESS || packet.avrcp_control_r.status != BT_STATUS_SUCCESS) {
+        bt_callbacks_list_free(ins->avrcp_control_callbacks);
+        ins->avrcp_control_callbacks = NULL;
+        return NULL;
+    }
+
+    return handle;
+}
+
+bool bt_avrcp_control_unregister_callbacks(bt_instance_t* ins, void* cookie)
+{
+    bt_message_packet_t packet;
+    bt_status_t status;
+    callbacks_list_t* cbsl;
+
+    BT_SOCKET_INS_VALID(ins, false);
+
+    if (!ins->avrcp_control_callbacks)
+        return false;
+
+    bt_remote_callbacks_unregister(ins->avrcp_control_callbacks, NULL, cookie);
+    if (bt_callbacks_list_count(ins->avrcp_control_callbacks) > 0) {
+        return true;
+    }
+
+    cbsl = ins->avrcp_control_callbacks;
+    ins->avrcp_control_callbacks = NULL;
+    bt_socket_client_free_callbacks(ins, cbsl);
+
+    status = bt_socket_client_sendrecv(ins, &packet, BT_AVRCP_CONTROL_UNREGISTER_CALLBACKS);
+    if (status != BT_STATUS_SUCCESS || packet.avrcp_control_r.status != BT_STATUS_SUCCESS) {
+        return false;
+    }
+
+    return true;
+}
+
+bt_status_t bt_avrcp_control_get_element_attributes(bt_instance_t* ins, bt_address_t* addr)
+{
+    bt_message_packet_t packet;
+    bt_status_t status;
+
+    BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
+
+    memcpy(&packet.avrcp_control_pl._bt_avrcp_control_get_element_attribute.addr, addr, sizeof(packet.avrcp_control_pl._bt_avrcp_control_get_element_attribute.addr));
+    status = bt_socket_client_sendrecv(ins, &packet, BT_AVRCP_CONTROL_GET_ELEMENT_ATTRIBUTES);
+    if (status != BT_STATUS_SUCCESS) {
+        return status;
+    }
+
+    return packet.avrcp_control_r.status;
+}

--- a/service/ipc/socket/include/bt_message.h
+++ b/service/ipc/socket/include/bt_message.h
@@ -29,6 +29,7 @@ extern "C" {
 #include "bt_message_a2dp_source.h"
 #include "bt_message_adapter.h"
 #include "bt_message_advertiser.h"
+#include "bt_message_avrcp_control.h"
 #include "bt_message_avrcp_target.h"
 #include "bt_message_device.h"
 #include "bt_message_gattc.h"
@@ -51,6 +52,7 @@ typedef enum {
 #include "bt_message_a2dp_source.h"
 #include "bt_message_adapter.h"
 #include "bt_message_advertiser.h"
+#include "bt_message_avrcp_control.h"
 #include "bt_message_avrcp_target.h"
 #include "bt_message_device.h"
 #include "bt_message_gattc.h"
@@ -71,6 +73,7 @@ typedef enum {
 #include "bt_message_a2dp_source.h"
 #include "bt_message_adapter.h"
 #include "bt_message_advertiser.h"
+#include "bt_message_avrcp_control.h"
 #include "bt_message_avrcp_target.h"
 #include "bt_message_device.h"
 #include "bt_message_gattc.h"
@@ -98,6 +101,7 @@ typedef struct
         bt_a2dp_sink_result_t a2dp_sink_r;
         bt_a2dp_source_result_t a2dp_source_r;
         bt_avrcp_target_result_t avrcp_target_r;
+        bt_avrcp_control_result_t avrcp_control_r;
         bt_hfp_ag_result_t hfp_ag_r;
         bt_hfp_hf_result_t hfp_hf_r;
         bt_advertiser_result_t adv_r;
@@ -125,6 +129,8 @@ typedef struct
 
         bt_message_avrcp_target_t avrcp_target_pl;
         bt_message_avrcp_target_callbacks_t avrcp_target_cb;
+        bt_message_avrcp_control_t avrcp_control_pl;
+        bt_message_avrcp_control_callbacks_t avrcp_control_cb;
 
         bt_message_hfp_ag_t hfp_ag_pl;
         bt_message_hfp_ag_callbacks_t hfp_ag_cb;

--- a/service/ipc/socket/include/bt_message_avrcp_control.h
+++ b/service/ipc/socket/include/bt_message_avrcp_control.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *  Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+#ifdef __BT_MESSAGE_CODE__
+BT_AVRCP_CONTROL_MESSAGE_START,
+    BT_AVRCP_CONTROL_REGISTER_CALLBACKS,
+    BT_AVRCP_CONTROL_UNREGISTER_CALLBACKS,
+    BT_AVRCP_CONTROL_GET_ELEMENT_ATTRIBUTES,
+    BT_AVRCP_CONTROL_MESSAGE_END,
+#endif
+
+#ifdef __BT_CALLBACK_CODE__
+    BT_AVRCP_CONTROL_CALLBACK_START,
+    BT_AVRCP_CONTROL_ON_CONNECTION_STATE_CHANGED,
+    BT_AVRCP_CONTROL_ON_GET_ELEMENT_ATTRIBUTES_REQUEST,
+    BT_AVRCP_CONTROL_CALLBACK_END,
+#endif
+
+#ifndef _BT_MESSAGE_AVRCP_CONTROL_H__
+#define _BT_MESSAGE_AVRCP_CONTROL_H__
+
+#ifdef __cplusplus
+    extern "C"
+{
+#endif
+
+#include "bt_avrcp_control.h"
+
+    typedef union {
+        uint8_t status; /* bt_status_t */
+        uint8_t value_bool; /* boolean */
+    } bt_avrcp_control_result_t;
+
+    typedef union {
+        struct {
+            bt_address_t addr;
+        } _bt_avrcp_control_get_element_attribute;
+    } bt_message_avrcp_control_t;
+
+    typedef union {
+        struct {
+            bt_address_t addr;
+            uint8_t state; /* profile_connection_state_t */
+        } _on_connection_state_changed;
+
+        struct {
+            bt_address_t addr;
+            uint8_t attrs_count;
+            uint32_t types[AVRCP_MAX_ATTR_COUNT];
+            uint16_t chr_sets[AVRCP_MAX_ATTR_COUNT];
+            avrcp_socket_element_attr_val_t values;
+        } _bt_avrcp_control_get_element_attribute;
+    } bt_message_avrcp_control_callbacks_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BT_MESSAGE_AVRCP_CONTROL_H__ */

--- a/service/ipc/socket/include/bt_socket.h
+++ b/service/ipc/socket/include/bt_socket.h
@@ -110,6 +110,13 @@ void bt_socket_server_avrcp_target_process(service_poll_t* poll,
 int bt_socket_client_avrcp_target_callback(service_poll_t* poll,
     int fd, bt_instance_t* ins, bt_message_packet_t* packet);
 
+/* AVRCP Control */
+void bt_socket_server_avrcp_control_process(service_poll_t* poll,
+    int fd, bt_instance_t* ins, bt_message_packet_t* packet);
+
+int bt_socket_client_avrcp_control_callback(service_poll_t* poll,
+    int fd, bt_instance_t* ins, bt_message_packet_t* packet);
+
 /* HFP */
 void bt_socket_server_hfp_ag_process(service_poll_t* poll,
     int fd, bt_instance_t* ins, bt_message_packet_t* packet);

--- a/service/ipc/socket/src/bt_socket_avrcp_control.c
+++ b/service/ipc/socket/src/bt_socket_avrcp_control.c
@@ -231,6 +231,8 @@ int bt_socket_client_avrcp_control_callback(service_poll_t* poll,
             &packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.addr,
             packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.attrs_count,
             attrs);
+
+        free(attrs);
     }
 
     break;

--- a/service/ipc/socket/src/bt_socket_avrcp_control.c
+++ b/service/ipc/socket/src/bt_socket_avrcp_control.c
@@ -1,0 +1,243 @@
+/****************************************************************************
+ *  Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+#include <errno.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include "bt_internal.h"
+
+#include "avrcp_control_service.h"
+#include "bluetooth.h"
+#include "bt_avrcp_control.h"
+#include "bt_message.h"
+#include "bt_socket.h"
+#include "callbacks_list.h"
+#include "service_loop.h"
+#include "service_manager.h"
+#include "utils/log.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define CALLBACK_FOREACH(_list, _struct, _cback, ...) \
+    BT_CALLBACK_FOREACH(_list, _struct, _cback, ##__VA_ARGS__)
+#define CBLIST (ins->avrcp_control_callbacks)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#if defined(CONFIG_BLUETOOTH_SERVER) && defined(__NuttX__)
+static void on_connection_state_changed_cb(void* cookie, bt_address_t* addr, profile_connection_state_t state)
+{
+    bt_message_packet_t packet = { 0 };
+    bt_instance_t* ins = cookie;
+
+    memcpy(&packet.avrcp_control_cb._on_connection_state_changed.addr, addr, sizeof(bt_address_t));
+    packet.avrcp_control_cb._on_connection_state_changed.state = state;
+    bt_socket_server_send(ins, &packet, BT_AVRCP_CONTROL_ON_CONNECTION_STATE_CHANGED);
+}
+
+static void on_get_element_attribute_cb(void* cookie, bt_address_t* addr, uint8_t attrs_count, avrcp_element_attr_val_t* attrs)
+{
+    bt_message_packet_t packet = { 0 };
+    bt_instance_t* ins = cookie;
+
+    memcpy(&packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.addr, addr, sizeof(bt_address_t));
+    packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.attrs_count = attrs_count;
+
+    for (int i = 0; i < attrs_count; i++) {
+        packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.types[i] = attrs[i].attr_id;
+        packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.chr_sets[i] = attrs[i].chr_set;
+        switch (attrs[i].attr_id) {
+        case AVRCP_ATTR_TITLE:
+            if (attrs[i].text == NULL) {
+                BT_LOGD("%s, title is null", __func__);
+                packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.title[0] = '\0';
+                break;
+            }
+
+            BT_LOGD("%s, title:%s", __func__, (char*)attrs[i].text);
+            strlcpy((char*)packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.title, (char*)attrs[i].text, MIN(strlen((char*)attrs[i].text) + 1, AVRCP_ATTR_MAX_TIELE_LEN));
+            break;
+        case AVRCP_ATTR_ARTIST_NAME:
+            if (attrs[i].text == NULL) {
+                BT_LOGD("%s, artist is null", __func__);
+                packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.artist[0] = '\0';
+                break;
+            }
+
+            BT_LOGD("%s, artist:%s", __func__, (char*)attrs[i].text);
+            strlcpy((char*)packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.artist, (char*)attrs[i].text, MIN(strlen((char*)attrs[i].text) + 1, AVRCP_ATTR_MAX_ARTIST_LEN));
+            break;
+        case AVRCP_ATTR_ALBUM_NAME:
+            packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.album[0] = '\0';
+            break;
+        case AVRCP_ATTR_TRACK_NUMBER:
+            packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.track_number[0] = '\0';
+            break;
+        case AVRCP_ATTR_TOTAL_NUMBER_OF_TRACKS:
+            packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.total_track_number[0] = '\0';
+            break;
+        case AVRCP_ATTR_GENRE:
+            packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.gener[0] = '\0';
+            break;
+        case AVRCP_ATTR_PLAYING_TIME_MS:
+            packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.playing_time_ms[0] = '\0';
+            break;
+        case AVRCP_ATTR_COVER_ART_HANDLE:
+            packet.avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.cover_art_handle[0] = '\0';
+            break;
+        default:
+            break;
+        }
+    }
+
+    bt_socket_server_send(ins, &packet, BT_AVRCP_CONTROL_ON_GET_ELEMENT_ATTRIBUTES_REQUEST);
+}
+
+const static avrcp_control_callbacks_t g_avrcp_control_cbs = {
+    .size = sizeof(avrcp_control_callbacks_t),
+    .connection_state_cb = on_connection_state_changed_cb,
+    .get_element_attribute_cb = on_get_element_attribute_cb,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void bt_socket_server_avrcp_control_process(service_poll_t* poll,
+    int fd, bt_instance_t* ins, bt_message_packet_t* packet)
+{
+    avrcp_control_interface_t* profile;
+
+    switch (packet->code) {
+    case BT_AVRCP_CONTROL_REGISTER_CALLBACKS:
+        if (ins->avrcp_control_cookie == NULL) {
+            profile = (avrcp_control_interface_t*)service_manager_get_profile(PROFILE_AVRCP_CT);
+            if (profile) {
+                ins->avrcp_control_cookie = profile->register_callbacks(ins, &g_avrcp_control_cbs);
+                if (ins->avrcp_control_cookie) {
+                    packet->avrcp_control_r.status = BT_STATUS_SUCCESS;
+                } else {
+                    packet->avrcp_control_r.status = BT_STATUS_NO_RESOURCES;
+                }
+            } else {
+                packet->avrcp_control_r.status = BT_STATUS_SERVICE_NOT_FOUND;
+            }
+        } else {
+            packet->avrcp_control_r.status = BT_STATUS_BUSY;
+        }
+        break;
+    case BT_AVRCP_CONTROL_UNREGISTER_CALLBACKS:
+        if (ins->avrcp_control_cookie) {
+            profile = (avrcp_control_interface_t*)service_manager_get_profile(PROFILE_AVRCP_CT);
+            if (profile)
+                profile->unregister_callbacks((void**)&ins, ins->avrcp_control_cookie);
+            ins->avrcp_control_cookie = NULL;
+            packet->avrcp_control_r.status = BT_STATUS_SUCCESS;
+        } else {
+            packet->avrcp_control_r.status = BT_STATUS_NOT_FOUND;
+        }
+        break;
+    case BT_AVRCP_CONTROL_GET_ELEMENT_ATTRIBUTES:
+        packet->avrcp_control_r.status = BTSYMBOLS(bt_avrcp_control_get_element_attributes)(ins,
+            &packet->avrcp_control_pl._bt_avrcp_control_get_element_attribute.addr);
+        break;
+    default:
+        break;
+    }
+}
+
+#endif
+
+int bt_socket_client_avrcp_control_callback(service_poll_t* poll,
+    int fd, bt_instance_t* ins, bt_message_packet_t* packet)
+{
+    switch (packet->code) {
+    case BT_AVRCP_CONTROL_ON_CONNECTION_STATE_CHANGED:
+        CALLBACK_FOREACH(CBLIST, avrcp_control_callbacks_t,
+            connection_state_cb,
+            &packet->avrcp_control_cb._on_connection_state_changed.addr,
+            packet->avrcp_control_cb._on_connection_state_changed.state);
+        break;
+    case BT_AVRCP_CONTROL_ON_GET_ELEMENT_ATTRIBUTES_REQUEST: {
+        avrcp_element_attr_val_t* attrs = NULL;
+        attrs = (avrcp_element_attr_val_t*)malloc(sizeof(avrcp_element_attr_val_t) * packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.attrs_count);
+        for (int i = 0; i < packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.attrs_count; i++) {
+            attrs[i].attr_id = packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.types[i];
+            attrs[i].chr_set = packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.chr_sets[i];
+            switch (attrs[i].attr_id) {
+            case AVRCP_ATTR_TITLE:
+                attrs[i].text = packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.title;
+                break;
+            case AVRCP_ATTR_ARTIST_NAME:
+                attrs[i].text = packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.values.artist;
+                break;
+            case AVRCP_ATTR_ALBUM_NAME:
+                attrs[i].text = NULL;
+                break;
+            case AVRCP_ATTR_TRACK_NUMBER:
+                attrs[i].text = NULL;
+                break;
+            case AVRCP_ATTR_TOTAL_NUMBER_OF_TRACKS:
+                attrs[i].text = NULL;
+                break;
+            case AVRCP_ATTR_GENRE:
+                attrs[i].text = NULL;
+                break;
+            case AVRCP_ATTR_PLAYING_TIME_MS:
+                attrs[i].text = NULL;
+                break;
+            case AVRCP_ATTR_COVER_ART_HANDLE:
+                attrs[i].text = NULL;
+                break;
+            default:
+                break;
+            }
+        }
+        CALLBACK_FOREACH(CBLIST, avrcp_control_callbacks_t,
+            get_element_attribute_cb,
+            &packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.addr,
+            packet->avrcp_control_cb._bt_avrcp_control_get_element_attribute.attrs_count,
+            attrs);
+    }
+
+    break;
+
+    default:
+        return BT_STATUS_PARM_INVALID;
+    }
+
+    return BT_STATUS_SUCCESS;
+}

--- a/service/ipc/socket/src/bt_socket_client.c
+++ b/service/ipc/socket/src/bt_socket_client.c
@@ -96,6 +96,10 @@ static void bt_socket_client_msg_process(bt_client_msg_t* msg)
     } else if (msg->packet.code > BT_AVRCP_TARGET_CALLBACK_START && msg->packet.code < BT_AVRCP_TARGET_CALLBACK_END) {
         bt_socket_client_avrcp_target_callback(NULL, -1, msg->ins, &msg->packet);
 #endif
+#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+    } else if (msg->packet.code > BT_AVRCP_CONTROL_CALLBACK_START && msg->packet.code < BT_AVRCP_CONTROL_CALLBACK_END) {
+        bt_socket_client_avrcp_control_callback(NULL, -1, msg->ins, &msg->packet);
+#endif
 #ifdef CONFIG_BLUETOOTH_BLE_ADV
     } else if (packet->code > BT_ADVERTISER_CALLBACK_START && packet->code < BT_ADVERTISER_CALLBACK_END) {
         bt_socket_client_advertiser_callback(NULL, -1, msg->ins, packet);

--- a/service/ipc/socket/src/bt_socket_server.c
+++ b/service/ipc/socket/src/bt_socket_server.c
@@ -180,6 +180,10 @@ static int bt_socket_server_receive(service_poll_t* poll, int fd, void* userdata
     } else if (packet->code > BT_AVRCP_TARGET_MESSAGE_START && packet->code < BT_AVRCP_TARGET_MESSAGE_END) {
         bt_socket_server_avrcp_target_process(poll, fd, ins, packet);
 #endif
+#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+    } else if (packet->code > BT_AVRCP_CONTROL_MESSAGE_START && packet->code < BT_AVRCP_CONTROL_MESSAGE_END) {
+        bt_socket_server_avrcp_control_process(poll, fd, ins, packet);
+#endif
     } else if (packet->code > BT_HFP_AG_MESSAGE_START && packet->code < BT_HFP_AG_MESSAGE_END) {
         bt_socket_server_hfp_ag_process(poll, fd, ins, packet);
     } else if (packet->code > BT_HFP_HF_MESSAGE_START && packet->code < BT_HFP_HF_MESSAGE_END) {

--- a/service/profiles/avrcp/avrcp_msg.c
+++ b/service/profiles/avrcp/avrcp_msg.c
@@ -52,5 +52,14 @@ avrcp_msg_t* avrcp_msg_new(rc_msg_id_t msg, bt_address_t* bd_addr)
 
 void avrcp_msg_destory(avrcp_msg_t* avrcp_msg)
 {
+    if (avrcp_msg->id == AVRC_GET_ELEMENT_ATTR_REQ) {
+        for (int i = 0; i < avrcp_msg->data.attrs.count; i++) {
+            if (avrcp_msg->data.attrs.attrs[i] != NULL) {
+                free(avrcp_msg->data.attrs.attrs[i]);
+                avrcp_msg->data.attrs.attrs[i] = NULL;
+            }
+        }
+    }
+
     free(avrcp_msg);
 }

--- a/service/profiles/avrcp/avrcp_msg.h
+++ b/service/profiles/avrcp/avrcp_msg.h
@@ -103,6 +103,13 @@ typedef struct {
 } rc_absvol_t;
 
 typedef struct {
+    uint8_t count;
+    uint32_t types[AVRCP_MAX_ATTR_COUNT];
+    uint16_t chr_sets[AVRCP_MAX_ATTR_COUNT];
+    char* attrs[AVRCP_MAX_ATTR_COUNT];
+} rc_element_attrs_t;
+
+typedef struct {
     bt_address_t addr;
     rc_msg_id_t id;
     uint8_t role;
@@ -115,6 +122,7 @@ typedef struct {
         rc_capabilities_t cap;
         rc_notification_rsp_t notify_rsp;
         rc_absvol_t absvol;
+        rc_element_attrs_t attrs;
         void* context;
     } data;
 } avrcp_msg_t;

--- a/service/profiles/avrcp/control/avrcp_control_service.c
+++ b/service/profiles/avrcp/control/avrcp_control_service.c
@@ -364,6 +364,9 @@ static void handle_avrcp_get_capability_response(avrcp_msg_t* msg)
         case NOTIFICATION_EVT_VOLUME_CHANGED:
             /* don't work on controller role */
             break;
+        case NOTIFICATION_EVT_TRACK_CHANGED:
+            bt_sal_avrcp_control_register_notification(addr, *cap, 0);
+            break;
         default:
             break;
         }
@@ -410,6 +413,11 @@ static void handle_avrcp_register_notification_response(avrcp_msg_t* msg)
     }
     case NOTIFICATION_EVT_VOLUME_CHANGED: {
         /* don't work on controller role */
+        break;
+    }
+    case NOTIFICATION_EVT_TRACK_CHANGED: {
+        BT_LOGD("track changed, get track info now...");
+        bt_sal_avrcp_control_get_element_attributes(addr, 0, NULL);
         break;
     }
     default:

--- a/service/profiles/include/avrcp_control_service.h
+++ b/service/profiles/include/avrcp_control_service.h
@@ -45,6 +45,9 @@ typedef struct {
     /** notify volume changed */
     bt_status_t (*volume_changed_notify)(bt_address_t* bd_addr, uint8_t volume);
 
+    /** get element attributes */
+    bt_status_t (*avrcp_control_get_element_attributes)(bt_address_t* bd_addr);
+
 } avrcp_control_interface_t;
 
 /*

--- a/tools/avrcp_control.c
+++ b/tools/avrcp_control.c
@@ -1,0 +1,130 @@
+/****************************************************************************
+ *  Copyright (C) 2023 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "bluetooth.h"
+#include "bt_adapter.h"
+#include "bt_avrcp_control.h"
+#include "bt_tools.h"
+
+static int getattrs_cmd(void* handle, int argc, char* argv[]);
+
+static bt_command_t g_avrcp_control_tables[] = {
+    { "getattrs", getattrs_cmd, 0, "\"get element attributes from the peer device, params: <address>\"" },
+};
+
+static void usage(void)
+{
+    printf("Usage:\n");
+    printf("\taddress: peer device address like 00:01:02:03:04:05\n");
+    printf("Commands:\n");
+    for (int i = 0; i < ARRAY_SIZE(g_avrcp_control_tables); i++) {
+        printf("\t%-8s\t%s\n", g_avrcp_control_tables[i].cmd, g_avrcp_control_tables[i].help);
+    }
+}
+
+static void* control_cbks_cookie = NULL;
+
+static void avrcp_control_connection_state_cb(void* cookie, bt_address_t* addr, profile_connection_state_t state)
+{
+    PRINT_ADDR("avrcp_control_connection_state_cb, addr:%s, state:%d", addr, state);
+}
+
+static void avrcp_control_get_element_attribute_cb(void* cookie, bt_address_t* addr, uint8_t attrs_count, avrcp_element_attr_val_t* attrs)
+{
+    PRINT_ADDR("avrcp_control_get_element_attribute_cb, addr:%s, count:%d", addr, attrs_count);
+    for (int i = 0; i < attrs_count; i++) {
+        switch (attrs[i].attr_id) {
+        case AVRCP_ATTR_TITLE:
+            printf("title:%s, charsetID:%d\n", attrs[i].text, attrs[i].chr_set);
+            break;
+        case AVRCP_ATTR_ARTIST_NAME:
+            printf("artist:%s, charsetID:%d\n", attrs[i].text, attrs[i].chr_set);
+            break;
+        case AVRCP_ATTR_ALBUM_NAME:
+            printf("album:%s, charsetID:%d\n", attrs[i].text, attrs[i].chr_set);
+            break;
+        case AVRCP_ATTR_TRACK_NUMBER:
+            printf("track number:%s, charsetID:%d\n", attrs[i].text, attrs[i].chr_set);
+            break;
+        case AVRCP_ATTR_TOTAL_NUMBER_OF_TRACKS:
+            printf("total track number:%s, charsetID:%d\n", attrs[i].text, attrs[i].chr_set);
+            break;
+        case AVRCP_ATTR_GENRE:
+            printf("genre:%s, charsetID:%d\n", attrs[i].text, attrs[i].chr_set);
+            break;
+        case AVRCP_ATTR_PLAYING_TIME_MS:
+            printf("playing time:%s, charsetID:%d\n", attrs[i].text, attrs[i].chr_set);
+            break;
+        case AVRCP_ATTR_COVER_ART_HANDLE:
+            printf("cover art handle:%s, charsetID:%d\n", attrs[i].text, attrs[i].chr_set);
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+static const avrcp_control_callbacks_t avrcp_control_cbs = {
+    sizeof(avrcp_control_cbs),
+    avrcp_control_connection_state_cb,
+    avrcp_control_get_element_attribute_cb,
+};
+
+int avrcp_control_commond_init(void* handle)
+{
+    control_cbks_cookie = bt_avrcp_control_register_callbacks(handle, &avrcp_control_cbs);
+
+    return 0;
+}
+
+int avrcp_control_commond_uninit(void* handle)
+{
+    bt_avrcp_control_unregister_callbacks(handle, control_cbks_cookie);
+
+    return 0;
+}
+
+int avrcp_control_command_exec(void* handle, int argc, char* argv[])
+{
+    int ret = CMD_USAGE_FAULT;
+
+    if (argc > 0)
+        ret = execute_command_in_table(handle, g_avrcp_control_tables, ARRAY_SIZE(g_avrcp_control_tables), argc, argv);
+
+    if (ret < 0)
+        usage();
+
+    return ret;
+}
+
+static int getattrs_cmd(void* handle, int argc, char* argv[])
+{
+    if (argc < 1)
+        return CMD_PARAM_NOT_ENOUGH;
+
+    bt_address_t addr;
+    if (bt_addr_str2ba(argv[0], &addr) < 0)
+        return CMD_INVALID_ADDR;
+
+    if (bt_avrcp_control_get_element_attributes(handle, &addr) != BT_STATUS_SUCCESS)
+        return CMD_ERROR;
+
+    return CMD_OK;
+}

--- a/tools/bt_tools.c
+++ b/tools/bt_tools.c
@@ -176,6 +176,9 @@ static bt_command_t g_cmd_tables[] = {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
     { "a2dpsrc", a2dp_src_command_exec, 0, "a2dp source cmd,    input \'a2dpsrc\' show usage" },
 #endif
+#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+    { "avrcpct", avrcp_control_command_exec, 0, "avrcp control cmd,    input \'avrcpct\' show usage" },
+#endif
 #ifdef CONFIG_BLUETOOTH_HFP_HF
     { "hf", hfp_hf_command_exec, 0, "hands-free cmd,    input \'hf\' show usage" },
 #endif
@@ -284,6 +287,9 @@ static void bt_tool_init(void* handle)
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
     a2dp_src_commond_init(handle);
 #endif
+#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+    avrcp_control_commond_init(handle);
+#endif
 #ifdef CONFIG_BLUETOOTH_HFP_HF
     hfp_hf_commond_init(handle);
 #endif
@@ -343,6 +349,9 @@ static void bt_tool_uninit(void* handle)
 #endif
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
     a2dp_src_commond_uninit(handle);
+#endif
+#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+    avrcp_control_commond_uninit(handle);
 #endif
 #ifdef CONFIG_BLUETOOTH_HFP_HF
     hfp_hf_commond_uninit(handle);

--- a/tools/bt_tools.h
+++ b/tools/bt_tools.h
@@ -97,6 +97,10 @@ int a2dp_src_commond_init(void* handle);
 int a2dp_src_commond_uninit(void* handle);
 int a2dp_src_command_exec(void* handle, int argc, char* argv[]);
 
+int avrcp_control_commond_init(void* handle);
+int avrcp_control_commond_uninit(void* handle);
+int avrcp_control_command_exec(void* handle, int argc, char* argv[]);
+
 int hfp_hf_commond_init(void* handle);
 int hfp_hf_commond_uninit(void* handle);
 int hfp_hf_command_exec(void* handle, int argc, char* argv[]);


### PR DESCRIPTION
bug: v/42362

Rootcause: Avrcp control lacks metadata interface, add get metadata interface and callback for avrcp control