### PR TITLE
bluetooth: Fixed an issue that whitelist failed to be added again after successfully deleted it.

### DIFF
--- a/service/src/adapter_internel.h
+++ b/service/src/adapter_internel.h
@@ -93,7 +93,7 @@ typedef struct {
         {
             /* data */
             bt_address_t addr;
-            bool is_added;
+            bool is_add;
             bt_status_t status;
         } whitelist;
         struct
@@ -243,7 +243,7 @@ void adapter_on_link_policy_changed(bt_address_t* addr, bt_link_policy_t policy)
 void adapter_on_le_addr_update(bt_address_t* addr, ble_addr_type_t type);
 void adapter_on_le_phy_update(bt_address_t* addr, ble_phy_type_t tx_phy,
     ble_phy_type_t rx_phy, bt_status_t status);
-void adapter_on_whitelist_update(bt_address_t* addr, bool is_added, bt_status_t status);
+void adapter_on_whitelist_update(bt_address_t* addr, bool is_add, bt_status_t status);
 void adapter_on_le_bonded_device_update(remote_device_le_properties_t* props, uint16_t bonded_devices_cnt);
 void adapter_on_le_local_oob_data_got(bt_address_t* addr, bt_128key_t c_val, bt_128key_t r_val);
 

--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -846,7 +846,10 @@ static void process_le_phy_update_evt(bt_address_t* addr, ble_phy_type_t tx_phy,
 static void process_le_whitelist_update_evt(bt_address_t* addr, bool is_add, bt_status_t status)
 {
     bool is_added;
-    BT_LOGD("%s isadded:%d, status:%d", __func__, is_add, status);
+    char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
+
+    bt_addr_ba2str(addr, addr_str);
+    BT_LOGD("%s, %s isadded:%d, status:%d", __func__, addr_str, is_add, status);
 
     if (status != BT_STATUS_SUCCESS) {
         return;
@@ -2510,7 +2513,8 @@ bt_status_t adapter_le_add_whitelist(bt_address_t* addr)
 #ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
     adapter_service_t* adapter = &g_adapter_service;
     bt_device_t* device;
-    BT_LOGD("%s", __func__);
+    char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
+
     adapter_lock();
     if (adapter->adapter_state != BT_ADAPTER_STATE_ON) {
         adapter_unlock();
@@ -2530,6 +2534,9 @@ bt_status_t adapter_le_add_whitelist(bt_address_t* addr)
 
     adapter_unlock();
     return bt_sal_le_add_white_list(PRIMARY_ADAPTER, addr, device_get_address_type(device));
+
+    bt_addr_ba2str(addr, addr_str);
+    BT_LOGD("%s, %s", __func__, addr_str);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif
@@ -2540,6 +2547,7 @@ bt_status_t adapter_le_remove_whitelist(bt_address_t* addr)
 #ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
     adapter_service_t* adapter = &g_adapter_service;
     bt_device_t* device;
+    char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
 
     adapter_lock();
     if (adapter->adapter_state != BT_ADAPTER_STATE_ON) {
@@ -2559,6 +2567,10 @@ bt_status_t adapter_le_remove_whitelist(bt_address_t* addr)
     }
 
     adapter_unlock();
+    
+    bt_addr_ba2str(addr, addr_str);
+    BT_LOGD("%s, %s", __func__, addr_str);
+
     return bt_sal_le_remove_white_list(PRIMARY_ADAPTER, addr, device_get_address_type(device));
 #else
     return BT_STATUS_NOT_SUPPORTED;


### PR DESCRIPTION
# Summary

Fixed an issue that whitelist failed to be added again after successfully deleted it. 

# Impact

'process_le_whitelist_update_evt' callback did not process the device flag. So it's still added state in device lists.