### PR TITLE
Implementing switch to Socket scheme for SPP.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -7,6 +7,7 @@ bootstrap_go_package {
     ],
     srcs: [
           "frameworkBluetooth.go",
+          "frameworkBluetoothBin.go",
     ],
     pluginFor: ["soong_build"],
 }
@@ -74,7 +75,7 @@ frameworkBluetooth_cc_library {
     ],
 }
 
-cc_binary {
+frameworkBluetooth_cc_binary {
     name : "bttool",
 
     srcs : [

--- a/Kconfig
+++ b/Kconfig
@@ -261,6 +261,11 @@ config BLUETOOTH_SPP_MAX_CONNECTIONS
 config BLUETOOTH_SPP_SERVER_MAX_CONNECTIONS
 	int "SPP server max connections"
 	default 8
+
+config BLUETOOTH_SPP_RPMSG_NET
+	bool "SPP rpmsg net support"
+	default n
+	depends on NET_RPMSG
 endif
 
 config BLUETOOTH_HID_DEVICE

--- a/framework/api/bt_spp.c
+++ b/framework/api/bt_spp.c
@@ -29,18 +29,21 @@ static spp_interface_t* get_profile_service(void)
     return (spp_interface_t*)service_manager_get_profile(PROFILE_SPP);
 }
 
-void* BTSYMBOLS(bt_spp_register_app)(bt_instance_t* ins, const spp_callbacks_t* callbacks)
+void* BTSYMBOLS(bt_spp_register_app_with_name)(bt_instance_t* ins, const char* name, const spp_callbacks_t* callbacks)
 {
     spp_interface_t* profile = get_profile_service();
 
-    return profile->register_app(NULL, NULL, SPP_PORT_TYPE_TTY, callbacks);
+    return profile->register_app(NULL, name, callbacks);
+}
+
+void* BTSYMBOLS(bt_spp_register_app)(bt_instance_t* ins, const spp_callbacks_t* callbacks)
+{
+    return BTSYMBOLS(bt_spp_register_app_with_name)(ins, NULL, callbacks);
 }
 
 void* BTSYMBOLS(bt_spp_register_app_ext)(bt_instance_t* ins, const char* name, int port_type, const spp_callbacks_t* callbacks)
 {
-    spp_interface_t* profile = get_profile_service();
-
-    return profile->register_app(NULL, name, port_type, callbacks);
+    return BTSYMBOLS(bt_spp_register_app_with_name)(ins, name, callbacks);
 }
 
 bt_status_t BTSYMBOLS(bt_spp_unregister_app)(bt_instance_t* ins, void* handle)

--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -143,6 +143,7 @@ static void euv_alloc_callback(uv_handle_t* handle, size_t size, uv_buf_t* buf)
 static void euv_read_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
 {
     euv_read_t* reader;
+    bool release;
 
     if (!stream->data) {
         BT_LOGE("%s, stream data null", __func__);
@@ -150,9 +151,14 @@ static void euv_read_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_t
     }
 
     reader = (euv_read_t*)stream->data;
+    release = !reader->alloc_cb;
 
     if (reader->read_cb)
         reader->read_cb((euv_pipe_t*)stream, (const uint8_t*)buf->base, nread);
+
+    if (release) {
+        free(buf->base);
+    }
 }
 
 static void euv_write_callback(uv_write_t* req, int status)

--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -438,6 +438,11 @@ void euv_pipe_close(euv_pipe_t* handle)
         return;
     }
 
+    if (uv_is_closing((uv_handle_t*)&handle->srv_pipe[handle->mode])) {
+        BT_LOGE("%s, uv_is_closing", __func__);
+        return;
+    }
+
     euv_pipe_disconnect(handle);
 
     handle->srv_pipe[handle->mode].data = handle;
@@ -448,6 +453,11 @@ void euv_pipe_disconnect(euv_pipe_t* handle)
 {
     if (!handle) {
         BT_LOGE("%s, invalid arg", __func__);
+        return;
+    }
+
+    if (uv_is_closing((uv_handle_t*)&handle->cli_pipe)) {
+        BT_LOGE("%s, uv_is_closing", __func__);
         return;
     }
 
@@ -470,6 +480,11 @@ void euv_pipe_close2(euv_pipe_t* handle)
         mode = EUV_PIPE_TYPE_SERVER_LOCAL;
     } else {
         BT_LOGE("%s, invalid mode", __func__);
+        return;
+    }
+
+    if (uv_is_closing((uv_handle_t*)&handle->srv_pipe[mode])) {
+        BT_LOGE("%s, uv_is_closing", __func__);
         return;
     }
 

--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -1,0 +1,444 @@
+/****************************************************************************
+ *  Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "bt_debug.h"
+#include "euv_pipe.h"
+#include "uv.h"
+
+#ifndef CONFIG_EUV_PIPE_MAX_CONNEXTIONS
+#define CONFIG_EUV_PIPE_MAX_CONNEXTIONS 4
+#endif
+
+typedef struct {
+    uv_write_t req;
+    uint8_t* buffer;
+    euv_write_cb write_cb;
+} euv_write_t;
+
+typedef struct {
+    euv_read_cb read_cb;
+    euv_alloc_cb alloc_cb;
+    uint16_t read_size;
+} euv_read_t;
+
+typedef struct {
+    uv_connect_t req;
+    euv_connect_cb connect_cb;
+    void* data;
+} euv_connect_t;
+
+static void euv_pipe_listen_callback(uv_stream_t* stream, int status)
+{
+    euv_pipe_t* handle;
+    euv_connect_t* creq;
+    int err;
+
+    handle = stream->data;
+    creq = handle->data;
+
+    err = uv_pipe_init(stream->loop, &handle->cli_pipe, 0);
+    if (err != 0) {
+        BT_LOGE("%s, srv_pipe init failed: %s", __func__, uv_strerror(err));
+        return;
+    }
+
+    err = uv_accept(stream, (uv_stream_t*)&handle->cli_pipe);
+    if (err != 0) {
+        BT_LOGE("%s, srv_pipe accept failed: %s", __func__, uv_strerror(err));
+        return;
+    }
+
+    if (creq->connect_cb) {
+        creq->connect_cb(handle, status, creq->data);
+    }
+}
+
+static void euv_local_listen_callback(uv_stream_t* stream, int status)
+{
+    euv_pipe_t* handle;
+
+    if (status < 0) {
+        BT_LOGE("%s,uv listen error: %s", __func__, uv_strerror(status));
+        return;
+    }
+
+    handle = stream->data;
+    handle->mode = EUV_PIPE_TYPE_SERVER_LOCAL;
+
+    euv_pipe_listen_callback(stream, status);
+}
+
+#ifdef CONFIG_NET_RPMSG
+static void euv_rpmsg_listen_callback(uv_stream_t* stream, int status)
+{
+    euv_pipe_t* handle;
+
+    if (status < 0) {
+        BT_LOGE("%s,uv listen error: %s", __func__, uv_strerror(status));
+        return;
+    }
+
+    handle = stream->data;
+    handle->mode = EUV_PIPE_TYPE_SERVER_RPMSG;
+
+    euv_pipe_listen_callback(stream, status);
+}
+#endif
+
+static void euv_close_callback(uv_handle_t* hdl)
+{
+    euv_pipe_t* handle = hdl->data;
+
+    if (!handle) {
+        BT_LOGE("%s, handle null", __func__);
+        return;
+    }
+
+    free(handle->data);
+    handle->data = NULL;
+}
+
+static void euv_alloc_callback(uv_handle_t* handle, size_t size, uv_buf_t* buf)
+{
+    euv_read_t* reader;
+
+    if (!handle->data) {
+        BT_LOGE("%s, handle data null", __func__);
+        return;
+    }
+
+    reader = (euv_read_t*)handle->data;
+
+    if (reader->alloc_cb)
+        reader->alloc_cb((euv_pipe_t*)handle, (uint8_t**)&buf->base, &buf->len);
+    else {
+        buf->base = malloc(reader->read_size);
+        buf->len = reader->read_size;
+    }
+}
+
+static void euv_read_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
+{
+    euv_read_t* reader;
+
+    if (!stream->data) {
+        BT_LOGE("%s, stream data null", __func__);
+        return;
+    }
+
+    reader = (euv_read_t*)stream->data;
+
+    if (reader->read_cb)
+        reader->read_cb((euv_pipe_t*)stream, (const uint8_t*)buf->base, nread);
+}
+
+static void euv_write_callback(uv_write_t* req, int status)
+{
+    euv_write_t* wreq = (euv_write_t*)req;
+
+    if (wreq->write_cb)
+        wreq->write_cb((euv_pipe_t*)wreq->req.data, wreq->buffer, status);
+
+    free(wreq);
+}
+
+int euv_pipe_read_start(euv_pipe_t* handle, uint16_t read_size, euv_read_cb read_cb, euv_alloc_cb alloc_cb)
+{
+    euv_read_t* reader;
+    int ret;
+
+    if (uv_is_active((uv_handle_t*)&handle->cli_pipe)) {
+        BT_LOGE("%s, client is active", __func__);
+        return 0;
+    }
+
+    reader = malloc(sizeof(euv_read_t));
+    if (!reader) {
+        BT_LOGE("%s, reader malloc fail", __func__);
+        return -ENOMEM;
+    }
+
+    reader->read_cb = read_cb;
+    reader->alloc_cb = alloc_cb;
+    reader->read_size = read_size;
+    handle->cli_pipe.data = reader;
+
+    ret = uv_read_start((uv_stream_t*)&handle->cli_pipe, euv_alloc_callback, euv_read_callback);
+    if (ret != 0) {
+        BT_LOGE("%s, read start err:%d", __func__, ret);
+        handle->cli_pipe.data = NULL;
+        free(reader);
+    }
+
+    return ret;
+}
+
+int euv_pipe_read_stop(euv_pipe_t* handle)
+{
+    if (!handle) {
+        BT_LOGE("%s, handle null", __func__);
+        return -EINVAL;
+    }
+
+    free(handle->cli_pipe.data);
+    handle->cli_pipe.data = NULL;
+
+    if (uv_is_active((uv_handle_t*)&handle->cli_pipe))
+        return uv_read_stop((uv_stream_t*)&handle->cli_pipe);
+
+    return 0;
+}
+
+int euv_pipe_write(euv_pipe_t* handle, uint8_t* buffer, int length, euv_write_cb cb)
+{
+    uv_buf_t buf;
+    euv_write_t* wreq;
+    int ret;
+
+    if (!handle) {
+        BT_LOGE("%s, handle null", __func__);
+        return -EINVAL;
+    }
+
+    wreq = (euv_write_t*)malloc(sizeof(euv_write_t));
+    if (!wreq)
+        return -ENOMEM;
+
+    wreq->req.data = (void*)handle;
+    wreq->buffer = buffer;
+    wreq->write_cb = cb;
+    buf = uv_buf_init((char*)buffer, length);
+
+    ret = uv_write(&wreq->req, (uv_stream_t*)&handle->cli_pipe, &buf, 1, euv_write_callback);
+    if (ret != 0) {
+        BT_LOGE("%s, write err:%d", __func__, ret);
+        free(wreq);
+    }
+
+    return ret;
+}
+
+static void euv_connect_callback(uv_connect_t* req, int status)
+{
+    euv_connect_t* creq = (euv_connect_t*)req;
+
+    if (creq->connect_cb)
+        creq->connect_cb(creq->req.data, status, creq->data);
+
+    free(req);
+}
+
+euv_pipe_t* euv_pipe_connect(uv_loop_t* loop, const char* server_path, euv_connect_cb cb, void* user_data)
+{
+    euv_pipe_t* handle;
+    euv_connect_t* creq;
+    int err;
+
+    if (!loop || !server_path) {
+        BT_LOGE("%s, invalid arg", __func__);
+        return NULL;
+    }
+
+    handle = (euv_pipe_t*)zalloc(sizeof(euv_pipe_t));
+    if (!handle) {
+        BT_LOGE("%s, zalloc fail", __func__);
+        return NULL;
+    }
+
+    err = uv_pipe_init(loop, &handle->cli_pipe, 0);
+    if (err != 0) {
+        BT_LOGE("%s, srv_pipe init failed: %s", __func__, uv_strerror(err));
+        goto err_out;
+    }
+
+    creq = zalloc(sizeof(euv_connect_t));
+    if (!creq) {
+        BT_LOGE("%s, zalloc failed", __func__);
+        goto err_out;
+    }
+
+    creq->connect_cb = cb;
+    creq->data = user_data;
+    creq->req.data = handle;
+
+    uv_pipe_connect(&creq->req, &handle->cli_pipe, server_path, euv_connect_callback);
+    return handle;
+
+err_out:
+    free(handle);
+    return NULL;
+}
+
+#ifdef CONFIG_NET_RPMSG
+euv_pipe_t* euv_rpmsg_pipe_connect(uv_loop_t* loop, const char* server_path, const char* cpu_name, euv_connect_cb cb, void* user_data)
+{
+    euv_pipe_t* handle;
+    euv_connect_t* creq;
+    int err;
+
+    if (!loop || !server_path) {
+        BT_LOGE("%s, invalid arg", __func__);
+        return NULL;
+    }
+
+    handle = (euv_pipe_t*)zalloc(sizeof(euv_pipe_t));
+    if (!handle) {
+        BT_LOGE("%s, zalloc fail", __func__);
+        return NULL;
+    }
+
+    err = uv_pipe_init(loop, &handle->cli_pipe, 0);
+    if (err != 0) {
+        BT_LOGE("%s, srv_pipe init failed: %s", __func__, uv_strerror(err));
+        goto err_out;
+    }
+
+    creq = zalloc(sizeof(euv_connect_t));
+    if (!creq) {
+        BT_LOGE("%s, zalloc failed", __func__);
+        goto err_out;
+    }
+
+    creq->connect_cb = cb;
+    creq->data = user_data;
+    creq->req.data = handle;
+
+    uv_pipe_rpmsg_connect(&creq->req, &handle->cli_pipe, server_path, cpu_name, euv_connect_callback);
+    return handle;
+
+err_out:
+    free(handle);
+    return NULL;
+}
+#endif
+
+euv_pipe_t* euv_pipe_open(uv_loop_t* loop, const char* server_path, euv_connect_cb cb, void* user_data)
+{
+    euv_pipe_t* handle;
+    euv_connect_t* creq;
+    int err;
+    uv_fs_t fs;
+
+    if (!loop || !server_path) {
+        BT_LOGE("%s, invalid arg", __func__);
+        return NULL;
+    }
+
+    handle = (euv_pipe_t*)zalloc(sizeof(euv_pipe_t));
+    if (!handle) {
+        BT_LOGE("%s, zalloc handle fail", __func__);
+        return NULL;
+    }
+
+    creq = (euv_connect_t*)zalloc(sizeof(euv_connect_t));
+    if (!creq) {
+        BT_LOGE("%s, zalloc creq fail", __func__);
+        goto errout_with_handle;
+    }
+
+    creq->data = user_data;
+    creq->connect_cb = cb;
+    handle->data = creq;
+
+    err = uv_pipe_init(loop, &handle->srv_pipe[EUV_PIPE_TYPE_SERVER_LOCAL], 0);
+    if (err != 0) {
+        BT_LOGE("%s, srv_pipe init failed: %s", __func__, uv_strerror(err));
+        goto errout_with_creq;
+    }
+
+    err = uv_fs_unlink(loop, &fs, server_path, NULL);
+    if (err != 0 && err != UV_ENOENT) {
+        BT_LOGE("%s, srv_pipe unlink failed: %s", __func__, uv_strerror(err));
+        goto errout_with_creq;
+    }
+
+    err = uv_pipe_bind(&handle->srv_pipe[EUV_PIPE_TYPE_SERVER_LOCAL], server_path);
+    if (err != 0) {
+        BT_LOGE("%s, srv_pipe bind failed: %s", __func__, uv_strerror(err));
+        goto errout_with_creq;
+    }
+
+    handle->srv_pipe[EUV_PIPE_TYPE_SERVER_LOCAL].data = handle;
+
+    err = uv_listen((uv_stream_t*)&handle->srv_pipe[EUV_PIPE_TYPE_SERVER_LOCAL], CONFIG_EUV_PIPE_MAX_CONNEXTIONS, euv_local_listen_callback);
+    if (err != 0) {
+        BT_LOGE("%s, srv_pipe listen failed: %s", __func__, uv_strerror(err));
+        goto errout_with_creq;
+    }
+
+#ifdef CONFIG_NET_RPMSG
+    /* start RPMSG server */
+    err = uv_pipe_init(loop, &handle->srv_pipe[EUV_PIPE_TYPE_SERVER_RPMSG], 0);
+    if (err != 0) {
+        BT_LOGE("%s, rpmsg srv_pipe init failed: %s", __func__, uv_strerror(err));
+        goto errout_with_creq;
+    }
+
+    err = uv_pipe_rpmsg_bind(&handle->srv_pipe[EUV_PIPE_TYPE_SERVER_RPMSG], server_path, "");
+    if (err != 0) {
+        BT_LOGE("%s, rpmsg srv_pipe bind failed: %s", __func__, uv_strerror(err));
+        goto errout_with_creq;
+    }
+
+    handle->srv_pipe[EUV_PIPE_TYPE_SERVER_RPMSG].data = handle;
+    err = uv_listen((uv_stream_t*)&handle->srv_pipe[EUV_PIPE_TYPE_SERVER_RPMSG], CONFIG_EUV_PIPE_MAX_CONNEXTIONS, euv_rpmsg_listen_callback);
+    if (err != 0) {
+        BT_LOGE("%s, rpmsg srv_pipe listen failed: %s", __func__, uv_strerror(err));
+        goto errout_with_creq;
+    }
+#endif
+
+    return handle;
+
+errout_with_creq:
+    free(creq);
+errout_with_handle:
+    free(handle);
+    return NULL;
+}
+
+void euv_pipe_close(euv_pipe_t* handle)
+{
+    if (!handle) {
+        BT_LOGE("%s, invalid arg", __func__);
+        return;
+    }
+
+    euv_pipe_disconnect(handle);
+
+    handle->srv_pipe[handle->mode].data = handle;
+    uv_close((uv_handle_t*)&handle->srv_pipe[handle->mode], euv_close_callback);
+}
+
+void euv_pipe_disconnect(euv_pipe_t* handle)
+{
+    if (!handle) {
+        BT_LOGE("%s, invalid arg", __func__);
+        return;
+    }
+
+    handle->cli_pipe.data = handle;
+    uv_close((uv_handle_t*)&handle->cli_pipe, euv_close_callback);
+}

--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include "bt_config.h"
 #include "bt_debug.h"
 #include "euv_pipe.h"
 #include "uv.h"

--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -352,6 +352,8 @@ euv_pipe_t* euv_pipe_open(uv_loop_t* loop, const char* server_path, euv_connect_
         return NULL;
     }
 
+    handle->mode = EUV_PIPE_TYPE_UNKNOWN;
+
     creq = (euv_connect_t*)zalloc(sizeof(euv_connect_t));
     if (!creq) {
         BT_LOGE("%s, zalloc creq fail", __func__);
@@ -423,6 +425,15 @@ void euv_pipe_close(euv_pipe_t* handle)
 {
     if (!handle) {
         BT_LOGE("%s, invalid arg", __func__);
+        return;
+    }
+
+    if (handle->mode == EUV_PIPE_TYPE_UNKNOWN) {
+        BT_LOGE("%s, unkown mode", __func__);
+        handle->srv_pipe[EUV_PIPE_TYPE_SERVER_LOCAL].data = handle;
+        uv_close((uv_handle_t*)&handle->srv_pipe[EUV_PIPE_TYPE_SERVER_LOCAL], euv_close_callback);
+        handle->srv_pipe[EUV_PIPE_TYPE_SERVER_RPMSG].data = NULL;
+        uv_close((uv_handle_t*)&handle->srv_pipe[EUV_PIPE_TYPE_SERVER_RPMSG], euv_close_callback);
         return;
     }
 

--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -480,6 +480,7 @@ void euv_pipe_disconnect(euv_pipe_t* handle)
     uv_close((uv_handle_t*)&handle->cli_pipe, euv_close_callback);
 }
 
+#ifdef CONFIG_NET_RPMSG
 void euv_pipe_close2(euv_pipe_t* handle)
 {
     euv_pipe_mode_t mode;
@@ -506,3 +507,4 @@ void euv_pipe_close2(euv_pipe_t* handle)
     handle->srv_pipe[mode].data = NULL;
     uv_close((uv_handle_t*)&handle->srv_pipe[mode], euv_close_callback);
 }
+#endif

--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -442,3 +442,25 @@ void euv_pipe_disconnect(euv_pipe_t* handle)
     handle->cli_pipe.data = handle;
     uv_close((uv_handle_t*)&handle->cli_pipe, euv_close_callback);
 }
+
+void euv_pipe_close2(euv_pipe_t* handle)
+{
+    euv_pipe_mode_t mode;
+
+    if (!handle) {
+        BT_LOGE("%s, invalid arg", __func__);
+        return;
+    }
+
+    if (handle->mode == EUV_PIPE_TYPE_SERVER_LOCAL) {
+        mode = EUV_PIPE_TYPE_SERVER_RPMSG;
+    } else if (handle->mode == EUV_PIPE_TYPE_SERVER_RPMSG) {
+        mode = EUV_PIPE_TYPE_SERVER_LOCAL;
+    } else {
+        BT_LOGE("%s, invalid mode", __func__);
+        return;
+    }
+
+    handle->srv_pipe[mode].data = NULL;
+    uv_close((uv_handle_t*)&handle->srv_pipe[mode], euv_close_callback);
+}

--- a/framework/include/bt_config.h
+++ b/framework/include/bt_config.h
@@ -15,7 +15,6 @@
 
 #elif defined(ANDROID)
 
-#define CONFIG_NET_RPMSG 1
 #define CONFIG_LIB_BLUELET 1
 #define CONFIG_QBUF_COUNT 20
 #define CONFIG_BREDR 1
@@ -95,9 +94,19 @@
 #define CONFIG_BLUETOOTH_TOOLS 1
 #define CONFIG_BLUETOOTH_VENDOR_BES 1
 
+// Socket: via RPMsg
+#define CONFIG_NET_RPMSG 1
+
 // Socket: via IPv4
 //#define CONFIG_NET_IPv4 1
+//#define CONFIG_BLUETOOTH_NET_IPv4 1
 #define CONFIG_INADDR_LOOPBACK 0x0A000202
+
+// SPP via RPMsg UART "/dev/ttyDROID"
+//#define CONFIG_RPMSG_UART 1
+
+// SPP via RPMsg socket/pipe
+#define CONFIG_BLUETOOTH_SPP_RPMSG_NET 1
 
 /********************* O95 Project Only *********************/
 #if defined(ANDROID_12)

--- a/framework/include/bt_spp.h
+++ b/framework/include/bt_spp.h
@@ -31,6 +31,10 @@ extern "C" {
 #endif
 
 /**
+ * @cond
+ */
+
+/**
  * @brief Unknow server channel number
  *
  */
@@ -52,37 +56,88 @@ typedef enum {
 } spp_proxy_state_t;
 
 /**
- * @brief Spp connection state callback
+ * @brief Callback used to notify SPP connection states.
  *
- * @param handle - spp app handle, the return value of bt_spp_register_app.
- * @param addr - address of peer device.
- * @param scn - server channel number, range in <1-28>.
- * @param port - unique port of connection.
- * @param state - spp connection state
+ * When the SPP connection state changes, this callback will be triggered.
+ * SPP connection states include DISCONNECTED, CONNECTING, CONNECTED, and
+ * DISCONNECTING. After the callback is triggered, the application will be
+ * notified with the APP handle corresponding to the SPP connection state,
+ * the Bluetooth address of the peer device, the server channel number used
+ * for the SPP connection, the SPP connection port, and the latest SPP connection
+ * state.
+ *
+ * @param handle - SPP APP handle, the return value of bt_spp_register_app.
+ * @param addr - The Bluetooth address of the peer device.
+ * @param scn - Server channel number, range in 1-28.
+ * @param port - The The unique port of connection.
+ * @param state - SPP connection state
+ *
+ * **Example:**
+ * @code
+void spp_connection_state_cb(void* handle, bt_address_t* addr,
+    uint16_t scn, uint16_t port,
+    profile_connection_state_t state)
+{
+    printf("spp_connection_state_cb, state: %d\n", state);
+}
+ * @endcode
  */
 typedef void (*spp_connection_state_callback)(void* handle, bt_address_t* addr,
     uint16_t scn, uint16_t port,
     profile_connection_state_t state);
 
 /**
- * @brief Spp pty opened notification [deprecated]
+ * @brief Callback used to notify SPP PTY open. [deprecated]
  *
- * @param handle - spp app handle, the return value of bt_spp_register_app.
- * @param addr - address of peer device.
- * @param scn - server channel number, range in <1-28>.
- * @param port - unique port of connection.
- * @param name - pty slave device name, like "/dev/pts/0"
+ * After a successful establishment of the SPP connection, the PTY will be
+ * opened. If the PTY is successfully opened, this callback will be triggered
+ * to notify the application that the PTY has been opened.The APP handle
+ * corresponding to the SPP connection, the Bluetooth address of the peer device,
+ * the server channel number, the connection port, and the PTY name also be
+ * notified.
+ *
+ * @note This callback is deprecated, use spp_proxy_state_callback instead.
+ *
+ * @param handle - SPP APP handle, the return value of bt_spp_register_app.
+ * @param addr - The Bluetooth address of the peer device.
+ * @param scn - Server channel number, range in 1-28.
+ * @param port - The unique port of connection.
+ * @param name - PTY slave device name, like "/dev/pts/0"
+ *
+ * **Example:**
+ * @code
+void spp_pty_open_cb(void* handle, bt_address_t* addr, uint16_t scn, uint16_t port, char* name)
+{
+    printf("spp_pty_open_cb, scn: %d, port: %d, name: %s\n", scn, port, name);
+}
+ * @endcode
  */
 typedef void (*spp_pty_open_callback)(void* handle, bt_address_t* addr, uint16_t scn, uint16_t port, char* name);
 
 /**
- * @brief Spp proxy state notification
+ * @brief Callback used to notify SPP proxy states.
  *
- * @param handle - spp app handle, the return value of bt_spp_register_app.
- * @param addr - address of peer device.
- * @param scn - server channel number, range in <1-28>.
- * @param port - unique port of connection.
- * @param name - proxy name, like "btspp-srv0"
+ * When the SPP proxy state changes, this callback will be triggered. The SPP
+ * proxy states include CONNECTED and DISCONNECTED. After the callback is triggered,
+ * the application will be notified with the APP handle corresponding to the SPP
+ * proxy state, the Bluetooth address of the peer device, the server channel number
+ * used for the SPP connection, the SPP connection port, and the latest SPP proxy
+ * state.
+ *
+ * @param handle - SPP APP handle, the return value of bt_spp_register_app.
+ * @param addr - The Bluetooth address of the peer device.
+ * @param state - SPP proxy state.
+ * @param scn - Server channel number, range in 1-28.
+ * @param port - The unique port of connection.
+ * @param name - Proxy name, like "btspp-srv0"
+ *
+ * **Example:**
+ * @code
+void spp_proxy_state_cb(void* handle, bt_address_t* addr, spp_proxy_state_t state, uint16_t scn, uint16_t port, char* name)
+{
+    printf("spp_proxy_state_cb, state: %d, scn: %d, port: %d, name: %s\n", state, scn, port, name);
+}
+ * @endcode
  */
 typedef void (*spp_proxy_state_callback)(void* handle, bt_address_t* addr, spp_proxy_state_t state, uint16_t scn, uint16_t port, char* name);
 
@@ -98,88 +153,304 @@ typedef struct {
 } spp_callbacks_t;
 
 /**
- * @brief Register spp app
+ * @endcond
+ */
+
+/**
+ * @brief Register an SPP service for applications.
  *
- * @param ins - bluetooth client instance.
- * @param callbacks - spp callback functions.
- * @return void* - spp app handle, NULL on failure.
+ * The application can register an SPP service through this function. Before using
+ * this function, the application should prepare callback functions for receiving
+ * SPP connection states notifications and SPP proxy states notifications or PTY open
+ * information notifications to register the service. After calling this function,
+ * the application will receive a handle to identify the application entity in the
+ * SPP service, which is used by the SPP service to find the corresponding application.
+ *
+ * @note It should be noted that the callback used for PTY open is not recommended, the
+ *       callback used for SPP proxy states is recommended.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param callbacks - SPP callback functions.
+ * @return void* - SPP APP handle, NULL represents fail.
+ *
+ * **Example:**
+ * @code
+void* spp_handle;
+const static spp_callbacks_t callbacks = {
+    .size = sizeof(spp_callbacks_t),
+    .connection_state_cb = spp_connection_state_cb,
+    .spp_proxy_state_cb = spp_proxy_state_cb,
+};
+
+void app_init_spp_1(bt_instance_t* ins)
+{
+    spp_handle = bt_spp_register_app(ins, &callbacks);
+    if(!spp_handle)
+        printf("register spp app failed\n");
+    else
+        printf("register spp app success\n");
+}
+ * @endcode
  */
 void* BTSYMBOLS(bt_spp_register_app)(bt_instance_t* ins, const spp_callbacks_t* callbacks);
 
 /**
- * @brief Register spp app with params
+ * @brief Register an SPP service with specified extended parameters for applications.
  *
- * @param ins - bluetooth client instance.
- * @param callbacks - spp callback functions.
- * @param name - spp app name.
- * @param port_type - spp port type.
- * @return void* - spp app handle, NULL on failure.
+ * The application can register the SPP service with the specified name and port
+ * type used in the SPP service through this function. Before using this function,
+ * the application should prepare callback functions for receiving SPP connection
+ * states notifications and SPP proxy states notifications or PTY open information
+ * notifications to register the service. After calling this function, the application
+ * will receive a handle to identify the application entity in the SPP service, which
+ * is used by the SPP service to find the corresponding application.
+ *
+ * @note It should be noted that the callback used for PTY open is not recommended, the
+ *       callback used for SPP proxy states is recommended.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param callbacks - SPP callback functions.
+ * @param name - SPP application name.
+ * @param port_type - SPP port type used in SPP service, not used.
+ * @return void* - SPP application handle, NULL represents fail.
+ *
+ * **Example:**
+ * @code
+void* spp_handle;
+const static spp_callbacks_t callbacks = {
+    .size = sizeof(spp_callbacks_t),
+    .connection_state_cb = spp_connection_state_cb,
+    .spp_proxy_state_cb = spp_proxy_state_cb,
+};
+
+void app_init_spp_2(bt_instance_t* ins)
+{
+    char* name = "spp_app_name";
+
+    spp_handle = bt_spp_register_app_ext(ins, name, 0, &callbacks);
+    if(!spp_handle)
+        printf("register spp app failed\n");
+    else
+        printf("register spp app success\n");
+}
+ * @endcode
  */
 void* BTSYMBOLS(bt_spp_register_app_ext)(bt_instance_t* ins, const char* name, int port_type, const spp_callbacks_t* callbacks);
 
 /**
- * @brief Register spp app with name
+ * @brief Register an SPP service with specified parameters for applications.
  *
- * @param ins - bluetooth client instance.
- * @param name - spp app name.
- * @param callbacks - spp callback functions.
- * @return void* - spp app handle, NULL on failure.
+ * The application can register the SPP service with the specified name and port
+ * type used in the SPP service through this function. Before using this function,
+ * the application should prepare callback functions for receiving SPP connection
+ * states notifications and SPP proxy states notifications or PTY open information
+ * notifications to register the service. After calling this function, the application
+ * will obtain a handle to identify the application entity in the SPP service, which
+ * will be used for the SPP service to find the corresponding application.
+ *
+ * @note It should be noted that the callback used for PTY open is not recommended, the
+ *       callback used for SPP proxy states is recommended.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param callbacks - SPP callback functions.
+ * @param name - SPP application name.
+ * @return void* - SPP application handle, NULL represents fail.
+ *
+ * **Example:**
+ * @code
+void* spp_handle;
+const static spp_callbacks_t callbacks = {
+    .size = sizeof(spp_callbacks_t),
+    .connection_state_cb = spp_connection_state_cb,
+    .spp_proxy_state_cb = spp_proxy_state_cb,
+};
+
+void app_init_spp_3(bt_instance_t* ins)
+{
+    char* name = "spp_app_name";
+
+    spp_handle = bt_spp_register_app_with_name(ins, name, &callbacks);
+    if(!spp_handle)
+        printf("register spp app failed\n");
+    else
+        printf("register spp app success\n");
+}
+ * @endcode
  */
 void* BTSYMBOLS(bt_spp_register_app_with_name)(bt_instance_t* ins, const char* name, const spp_callbacks_t* callbacks);
 
 /**
- * @brief Unregister spp app
+ * @brief Unregister SPP service for applications.
  *
- * @param ins - bluetooth client instance.
- * @param handle - spp app handle.
+ * This function is used to unregister the SPP service for an application. Before
+ * using this function, the application should have completed registration
+ * of the Bluetooth service and obtained a valid handle. After the function returns
+ * a successful result, the application have unregistered the SPP service.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param handle - SPP APP handle.
  * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ *
+ * **Example:**
+ * @code
+void app_unregister_spp_app(bt_instance_t* ins, void* handle)
+{
+    bt_status_t status;
+
+    if(spp_handle)
+        return;
+
+    status = bt_spp_unregister_app(ins, spp_handle);
+    if(status != BT_STATUS_SUCCESS)
+        printf("unregister spp app failed\n");
+    else
+        printf("unregister spp app success\n");
+}
+ * @endcode
  */
 bt_status_t BTSYMBOLS(bt_spp_unregister_app)(bt_instance_t* ins, void* handle);
 
 /**
- * @brief Start spp server
+ * @brief Start the SPP server.
  *
- * @param ins - bluetooth client instance.
- * @param handle - spp app handle.
- * @param scn - server channel number, range in <1-28>.
- * @param uuid - server uuid, default:0x1101.
- * @param max_connection - maximum of client connections.
+ * This function is used to start an SPP server for a application. Before
+ * using this function, the application should have completed registration
+ * of the Bluetooth service and obtained a valid handle. In addition, the application
+ * needs to specify the server channel number, UUID and maximum number of supported
+ * connections using this function. After the function returns a successful result,
+ * the application will have started an SPP server that can be connected by SPP clients
+ * on other devices.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param handle - SPP application handle.
+ * @param scn - Server channel number, range in 1-28.
+ * @param uuid - Server uuid, default:0x1101.
+ * @param max_connection - Maximum of client connections.
  * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ *
+ * **Example:**
+ * @code
+void app_start_spp_server(bt_instance_t* ins, void* handle)
+{
+    bt_status_t status;
+    uint16_t scn = 1;
+    bt_uuid_t uuid = {
+        .type = BT_UUID_TYPE_16,
+        .value = {0x11, 0x01},
+    };
+    uint8_t max_connection = 1;
+
+    status = bt_spp_server_start(ins, handle, scn, &uuid, max_connection);
+    if(status != BT_STATUS_SUCCESS)
+        printf("start spp server failed\n");
+    else
+        printf("start spp server success\n");
+}
+ * @endcode
  */
 bt_status_t BTSYMBOLS(bt_spp_server_start)(bt_instance_t* ins, void* handle, uint16_t scn, bt_uuid_t* uuid, uint8_t max_connection);
 
 /**
- * @brief Stop spp server
+ * @brief Stop the SPP server.
  *
- * @param ins - bluetooth client instance.
- * @param handle - spp app handle.
- * @param scn - server channel number, range in <1-28>.
+ * This function is used to stop an SPP server for a application. Before
+ * using this function, the application should have started SPP server.
+ * In addition, the application needs to specify the server channel number using
+ * this function. After the function returns a successful result, the application
+ * will have stopped the SPP server.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param handle - SPP application handle.
+ * @param scn - Server channel number, range in 1-28.
  * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ *
+ * **Example:**
+ * @code
+void app_stop_spp_server(bt_instance_t* ins, void* handle)
+{
+    bt_status_t status;
+    uint16_t scn = 1;
+
+    status = bt_spp_server_stop(ins, handle, scn);
+    if(status != BT_STATUS_SUCCESS)
+        printf("stop spp server failed\n");
+    else
+        printf("stop spp server success\n");
+}
+ * @endcode
  */
 bt_status_t BTSYMBOLS(bt_spp_server_stop)(bt_instance_t* ins, void* handle, uint16_t scn);
 
 /**
- * @brief Connect to spp server
+ * @brief Connect to the SPP server
  *
- * @param[in] ins - bluetooth client instance.
- * @param[in] handle - spp app handle.
- * @param[in] addr - address of peer device.
- * @param[in] scn - server channel number, range in <1-28>.
+ * This function is used to initiate a connection to the SPP server of a specified
+ * device. Before using this function, the application needs to complete SPP service
+ * registration and obtain a valid handle. In addition, when the application uses
+ * this function, it needs to specify the address of the remote device, the server
+ * channel number, UUID, and port used. If this function returns a successful result,
+ * an SPP connection will be established with the remote device.
+ *
+ * @param[in] ins - Bluetooth client instance.
+ * @param[in] handle - SPP application handle.
+ * @param[in] addr - The Bluetooth address of the peer device.
+ * @param[in] scn - Server channel number, range in 1-28.
  *                - UNKNOWN_SERVER_CHANNEL_NUM: Not specify scn.
- * @param[in] uuid - server uuid, default:0x1101.
- * @param[out] port - point to unique port of connection.
+ * @param[in] uuid - Server uuid, default:0x1101.
+ * @param[out] port - The unique port of connection.
  * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ *
+ * **Example:**
+ * @code
+void app_connect_spp_server(bt_instance_t* ins, void* handle)
+{
+    bt_status_t status;
+    bt_address_t addr = {
+        .address = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+    };
+    uint16_t port;
+
+    status = bt_spp_connect(ins, handle, &addr, UNKNOWN_SERVER_CHANNEL_NUM, NULL, &port);
+    if(status != BT_STATUS_SUCCESS)
+        printf("connect spp server failed\n");
+    else
+        printf("connect spp server success\n");
+}
+ * @endcode
  */
 bt_status_t BTSYMBOLS(bt_spp_connect)(bt_instance_t* ins, void* handle, bt_address_t* addr, int16_t scn, bt_uuid_t* uuid, uint16_t* port);
 
 /**
- * @brief Disconnect to spp server
+ * @brief Disconnect to SPP server
  *
- * @param ins - bluetooth client instance.
- * @param handle - spp app handle.
- * @param addr - address of peer device.
- * @param port unique port of connection.
+ * This function is used to initiate an SPP disconnection to a specified device.
+ * Before using this function, an SPP connection should have been successfully
+ * established with the remote device. In addition, the function requires providing
+ * the address of the remote device and the port used.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param handle - SPP application handle.
+ * @param addr - The Bluetooth address of the peer device.
+ * @param port The unique port of connection.
  * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ *
+ * **Example:**
+ * @code
+void app_disconnect_spp_server(bt_instance_t* ins, void* handle)
+{
+    bt_status_t status;
+    bt_address_t addr = {
+        .addr = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+    };
+    uint16_t port = 1;
+
+    status = bt_spp_disconnect(ins, handle, &addr, port);
+    if(status != BT_STATUS_SUCCESS)
+        printf("disconnect spp server failed\n");
+    else
+        printf("disconnect spp server success\n");
+}
+ * @endcode
  */
 bt_status_t BTSYMBOLS(bt_spp_disconnect)(bt_instance_t* ins, void* handle, bt_address_t* addr, uint16_t port);
 

--- a/framework/include/bt_spp.h
+++ b/framework/include/bt_spp.h
@@ -43,18 +43,13 @@ extern "C" {
 #define BT_UUID_SERVCLASS_SERIAL_PORT 0x1101
 
 /**
- * @brief Spp pty mode
+ * @brief Spp proxy state
  *
  */
 typedef enum {
-    SPP_PTY_MODE_NORMAL,
-    SPP_PTY_MODE_RAW
-} spp_pty_mode_t;
-
-typedef enum {
-    SPP_PORT_TYPE_TTY,
-    SPP_PORT_TYPE_RPMSG_UART,
-} spp_port_type_t;
+    SPP_PROXY_STATE_CONNECTED,
+    SPP_PROXY_STATE_DISCONNECTED,
+} spp_proxy_state_t;
 
 /**
  * @brief Spp connection state callback
@@ -70,7 +65,7 @@ typedef void (*spp_connection_state_callback)(void* handle, bt_address_t* addr,
     profile_connection_state_t state);
 
 /**
- * @brief Spp pty opened notification
+ * @brief Spp pty opened notification [deprecated]
  *
  * @param handle - spp app handle, the return value of bt_spp_register_app.
  * @param addr - address of peer device.
@@ -81,13 +76,25 @@ typedef void (*spp_connection_state_callback)(void* handle, bt_address_t* addr,
 typedef void (*spp_pty_open_callback)(void* handle, bt_address_t* addr, uint16_t scn, uint16_t port, char* name);
 
 /**
+ * @brief Spp proxy state notification
+ *
+ * @param handle - spp app handle, the return value of bt_spp_register_app.
+ * @param addr - address of peer device.
+ * @param scn - server channel number, range in <1-28>.
+ * @param port - unique port of connection.
+ * @param name - proxy name, like "btspp-srv0"
+ */
+typedef void (*spp_proxy_state_callback)(void* handle, bt_address_t* addr, spp_proxy_state_t state, uint16_t scn, uint16_t port, char* name);
+
+/**
  * @brief SPP event callbacks structure
  *
  */
 typedef struct {
     size_t size;
-    spp_pty_open_callback pty_open_cb;
+    spp_pty_open_callback pty_open_cb; /* [deprecated] */
     spp_connection_state_callback connection_state_cb;
+    spp_proxy_state_callback proxy_state_cb;
 } spp_callbacks_t;
 
 /**
@@ -109,6 +116,16 @@ void* BTSYMBOLS(bt_spp_register_app)(bt_instance_t* ins, const spp_callbacks_t* 
  * @return void* - spp app handle, NULL on failure.
  */
 void* BTSYMBOLS(bt_spp_register_app_ext)(bt_instance_t* ins, const char* name, int port_type, const spp_callbacks_t* callbacks);
+
+/**
+ * @brief Register spp app with name
+ *
+ * @param ins - bluetooth client instance.
+ * @param name - spp app name.
+ * @param callbacks - spp callback functions.
+ * @return void* - spp app handle, NULL on failure.
+ */
+void* BTSYMBOLS(bt_spp_register_app_with_name)(bt_instance_t* ins, const char* name, const spp_callbacks_t* callbacks);
 
 /**
  * @brief Unregister spp app

--- a/framework/include/euv_pipe.h
+++ b/framework/include/euv_pipe.h
@@ -47,4 +47,5 @@ void euv_pipe_disconnect(euv_pipe_t* handle);
 int euv_pipe_write(euv_pipe_t* handle, uint8_t* buffer, int length, euv_write_cb cb);
 int euv_pipe_read_start(euv_pipe_t* handle, uint16_t read_size, euv_read_cb read_cb, euv_alloc_cb alloc_cb);
 int euv_pipe_read_stop(euv_pipe_t* handle);
+void euv_pipe_close2(euv_pipe_t* handle);
 #endif

--- a/framework/include/euv_pipe.h
+++ b/framework/include/euv_pipe.h
@@ -1,0 +1,50 @@
+/****************************************************************************
+ *  Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+#ifndef __EUV_PIPE_H__
+#define __EUV_PIPE_H__
+#include "uv.h"
+
+typedef enum {
+    EUV_PIPE_TYPE_SERVER_LOCAL,
+    EUV_PIPE_TYPE_SERVER_RPMSG,
+    EUV_PIPE_TYPE_CLIENT_LOCAL,
+    EUV_PIPE_TYPE_CLIENT_RPMSG,
+} euv_pipe_mode_t;
+
+typedef struct euv_pipe {
+    uv_pipe_t cli_pipe;
+    uv_pipe_t srv_pipe[2];
+    euv_pipe_mode_t mode;
+    void* data;
+} euv_pipe_t;
+
+typedef void (*euv_read_cb)(euv_pipe_t* handle, const uint8_t* buf, ssize_t size);
+typedef void (*euv_write_cb)(euv_pipe_t* handle, uint8_t* buf, int status);
+typedef void (*euv_alloc_cb)(euv_pipe_t* handle, uint8_t** buf, size_t* len);
+typedef void (*euv_connect_cb)(euv_pipe_t* handle, int status, void* user_data);
+
+euv_pipe_t* euv_pipe_open(uv_loop_t* loop, const char* path, euv_connect_cb cb, void* user_data);
+void euv_pipe_close(euv_pipe_t* handle);
+euv_pipe_t* euv_pipe_connect(uv_loop_t* loop, const char* path, euv_connect_cb cb, void* user_data);
+#ifdef CONFIG_NET_RPMSG
+euv_pipe_t* euv_rpmsg_pipe_connect(uv_loop_t* loop, const char* path, const char* cpu_name, euv_connect_cb cb, void* user_data);
+#endif
+void euv_pipe_disconnect(euv_pipe_t* handle);
+int euv_pipe_write(euv_pipe_t* handle, uint8_t* buffer, int length, euv_write_cb cb);
+int euv_pipe_read_start(euv_pipe_t* handle, uint16_t read_size, euv_read_cb read_cb, euv_alloc_cb alloc_cb);
+int euv_pipe_read_stop(euv_pipe_t* handle);
+#endif

--- a/framework/include/euv_pipe.h
+++ b/framework/include/euv_pipe.h
@@ -43,10 +43,10 @@ void euv_pipe_close(euv_pipe_t* handle);
 euv_pipe_t* euv_pipe_connect(uv_loop_t* loop, const char* path, euv_connect_cb cb, void* user_data);
 #ifdef CONFIG_NET_RPMSG
 euv_pipe_t* euv_rpmsg_pipe_connect(uv_loop_t* loop, const char* path, const char* cpu_name, euv_connect_cb cb, void* user_data);
+void euv_pipe_close2(euv_pipe_t* handle);
 #endif
 void euv_pipe_disconnect(euv_pipe_t* handle);
 int euv_pipe_write(euv_pipe_t* handle, uint8_t* buffer, int length, euv_write_cb cb);
 int euv_pipe_read_start(euv_pipe_t* handle, uint16_t read_size, euv_read_cb read_cb, euv_alloc_cb alloc_cb);
 int euv_pipe_read_stop(euv_pipe_t* handle);
-void euv_pipe_close2(euv_pipe_t* handle);
 #endif

--- a/framework/include/euv_pipe.h
+++ b/framework/include/euv_pipe.h
@@ -19,6 +19,7 @@
 #include "uv.h"
 
 typedef enum {
+    EUV_PIPE_TYPE_UNKNOWN = -1,
     EUV_PIPE_TYPE_SERVER_LOCAL,
     EUV_PIPE_TYPE_SERVER_RPMSG,
     EUV_PIPE_TYPE_CLIENT_LOCAL,

--- a/framework/socket/bt_spp.c
+++ b/framework/socket/bt_spp.c
@@ -24,7 +24,7 @@
 #include "spp_service.h"
 #include "utils/log.h"
 
-void* bt_spp_register_app_ext(bt_instance_t* ins, const char* name, int port_type, const spp_callbacks_t* callbacks)
+void* bt_spp_register_app_with_name(bt_instance_t* ins, const char* name, const spp_callbacks_t* callbacks)
 {
     bt_message_packet_t packet = { 0 };
     bt_status_t status;
@@ -51,7 +51,6 @@ void* bt_spp_register_app_ext(bt_instance_t* ins, const char* name, int port_typ
     } else
         packet.spp_pl._bt_spp_register_app.name_len = 0;
 
-    packet.spp_pl._bt_spp_register_app.port_type = port_type;
     status = bt_socket_client_sendrecv(ins, &packet, BT_SPP_REGISTER_APP);
     if (status != BT_STATUS_SUCCESS || !packet.spp_r.handle) {
         bt_callbacks_list_free(ins->spp_callbacks);
@@ -64,7 +63,12 @@ void* bt_spp_register_app_ext(bt_instance_t* ins, const char* name, int port_typ
 
 void* bt_spp_register_app(bt_instance_t* ins, const spp_callbacks_t* callbacks)
 {
-    return bt_spp_register_app_ext(ins, NULL, SPP_PORT_TYPE_TTY, callbacks);
+    return bt_spp_register_app_with_name(ins, NULL, callbacks);
+}
+
+void* bt_spp_register_app_ext(bt_instance_t* ins, const char* name, int port_type, const spp_callbacks_t* callbacks)
+{
+    return bt_spp_register_app_with_name(ins, NULL, callbacks);
 }
 
 bt_status_t bt_spp_unregister_app(bt_instance_t* ins, void* handle)

--- a/frameworkBluetoothBin.go
+++ b/frameworkBluetoothBin.go
@@ -1,0 +1,39 @@
+package frameworkBluetooth
+
+import (
+        "android/soong/android"
+        "android/soong/cc"
+)
+
+func init() {
+    android.RegisterModuleType("frameworkBluetooth_cc_binary", frameworkBluetoothBinDefaultsFactory)
+}
+
+func frameworkBluetoothBinDefaultsFactory() (android.Module) {
+    module := cc.BinaryFactory()
+    android.AddLoadHook(module, frameworkBluetoothBinHook)
+    return module
+}
+
+func frameworkBluetoothBinHook(ctx android.LoadHookContext) {
+    //AConfig() function is at build/soong/android/config.go
+
+    Version := ctx.AConfig().PlatformVersionName()
+
+    type props struct {
+        Srcs []string
+        Static_libs []string
+        Shared_libs []string
+        Cflags []string
+    }
+
+    p := &props{}
+
+    if (Version == "12") {
+        p.Cflags = append(p.Cflags, "-DANDROID_12")
+    } else if (Version == "14") {
+        p.Cflags = append(p.Cflags, "-DANDROID_14")
+    }
+
+    ctx.AppendProperties(p)
+}

--- a/service/ipc/socket/include/bt_message_spp.h
+++ b/service/ipc/socket/include/bt_message_spp.h
@@ -27,7 +27,7 @@ BT_SPP_MESSAGE_START,
 
 #ifdef __BT_CALLBACK_CODE__
     BT_SPP_CALLBACK_START,
-    BT_SPP_PTY_OPEN_CB,
+    BT_SPP_PROXY_STATE_CB,
     BT_SPP_CONNECTION_STATE_CB,
     BT_SPP_CALLBACK_END,
 #endif
@@ -52,7 +52,6 @@ BT_SPP_MESSAGE_START,
         struct {
             uint32_t name_len;
             char name[64];
-            int port_type;
         } _bt_spp_register_app;
 
         struct {
@@ -88,10 +87,11 @@ BT_SPP_MESSAGE_START,
         struct {
             uint32_t handle;
             bt_address_t addr;
+            uint8_t state;
             uint16_t scn;
             char name[64];
             uint16_t port;
-        } _pty_open_cb;
+        } _proxy_state_cb;
 
         struct {
             uint32_t handle;

--- a/service/profiles/include/spp_service.h
+++ b/service/profiles/include/spp_service.h
@@ -24,7 +24,7 @@
 
 typedef struct spp_interface {
     size_t size;
-    void* (*register_app)(void* remote, const char* name, int port_type, const spp_callbacks_t* callbacks);
+    void* (*register_app)(void* remote, const char* name, const spp_callbacks_t* callbacks);
     bt_status_t (*unregister_app)(void** remote, void* handle);
     bt_status_t (*server_start)(void* handle, uint16_t scn, bt_uuid_t* uuid, uint8_t max_connection);
     bt_status_t (*server_stop)(void* handle, uint16_t scn);

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -604,8 +604,10 @@ static void spp_proxy_connection_callback(euv_pipe_t* handle, int status, void* 
         return;
     }
 
-    /* close unsed pipe */
+#ifdef CONFIG_NET_RPMSG
+    /* close unused pipe */
     euv_pipe_close2(handle);
+#endif
 
     device = find_spp_device_by_handle(handle);
     if (!device->handle) {

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -377,7 +377,7 @@ static spp_device_t* spp_device_open(spp_device_t* device)
         return NULL;
     }
 
-    sprintf(device->proxy_name, "%s-%d", SPP_PROXY_SERVER_PREF, device->scn);
+    sprintf(device->proxy_name, "%s-%d", SPP_PROXY_SERVER_PREF, device->conn_id);
     device->handle = euv_pipe_open(get_service_uv_loop(), device->proxy_name, spp_proxy_connection_callback, device);
     if (!device->handle) {
         BT_LOGE("spp proxy open fail, proxy_name: %s", device->proxy_name);

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -442,8 +442,10 @@ static void spp_app_cleanup_servers(spp_handle_t* app)
     list_for_every_safe(&g_spp_handle.servers, node, tmp)
     {
         server = (spp_server_t*)node;
-        if (server->app_handle == app)
+        if (server->app_handle == app) {
+            bt_sal_spp_server_stop(STACK_SVR_PORT(server->scn));
             free_server_resource(server);
+        }
     }
 }
 

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -1140,6 +1140,12 @@ static bt_status_t spp_disconnect(void* handle, bt_address_t* addr, uint16_t por
         goto unlock_exit;
     }
 
+    if (bt_addr_compare(&device->addr, addr)) {
+        ret = BT_STATUS_DEVICE_NOT_FOUND;
+        BT_LOGE("%s, addr not match", __func__);
+        goto unlock_exit;
+    }
+
     device->state = PROFILE_STATE_DISCONNECTING;
     bt_sal_spp_disconnect(device->conn_port);
 

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -558,6 +558,7 @@ static void spp_rx_buffer_send(spp_device_t* device)
     struct list_node *node, *tmp;
     spp_rx_buf_t* buf;
 
+    BT_LOGD("spp_rx_buffer_send, rx_list: %d, rx_bytes: %" PRIu32 "", list_length(&device->rx_list), device->rx_bytes);
     list_for_every_safe(&device->rx_list, node, tmp)
     {
         buf = (spp_rx_buf_t*)node;
@@ -566,7 +567,7 @@ static void spp_rx_buffer_send(spp_device_t* device)
             BT_LOGE("Spp write to slave port %d failed", device->conn_port);
             break;
         }
-        spp_dumpbuffer("master write:", buf->buffer, buf->length);
+        spp_dumpbuffer("master buffer write:", buf->buffer, buf->length);
         list_delete(node);
         free(node);
     }
@@ -610,6 +611,7 @@ static void spp_proxy_connection_callback(euv_pipe_t* handle, int status, void* 
         return;
     }
 
+    BT_LOGD("spp proxy connected, status: %d", status);
     device->proxy_state = SPP_PROXY_STATE_CONNECTED;
     spp_rx_buffer_send(device);
 

--- a/tools/spp.c
+++ b/tools/spp.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "bt_config.h"
 #include "bt_list.h"
 #include "bt_spp.h"
 #include "bt_tools.h"

--- a/tools/spp.c
+++ b/tools/spp.c
@@ -441,7 +441,7 @@ static void spp_disconnect(void* data)
 {
     spp_device_t* device;
     spp_cmd_t* msg = data;
-    bt_address_t addr;
+    char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
 
     device = find_device_by_port(msg->port);
     if (device == NULL) {
@@ -449,9 +449,9 @@ static void spp_disconnect(void* data)
         return;
     }
 
-    bt_addr_set_empty(&addr);
-    bt_spp_disconnect(msg->handle, spp_app_handle, &addr, msg->port);
-    PRINT("%s, port:%d disconnecting", __func__, msg->port);
+    bt_spp_disconnect(msg->handle, spp_app_handle, &msg->addr, msg->port);
+    bt_addr_ba2str(&msg->addr, addr_str);
+    PRINT("%s, address:%s port:%d disconnecting", __func__, addr_str, msg->port);
     free(data);
 }
 
@@ -466,6 +466,7 @@ static int disconnect_cmd(void* handle, int argc, char* argv[])
 
     msg->handle = handle;
     msg->port = atoi(argv[1]);
+    bt_addr_str2ba(argv[0], &msg->addr);
 
     PRINT("%s, address:%s port:%d", __func__, argv[0], msg->port);
     do_in_thread_loop(&spp_thread_loop, spp_disconnect, msg);


### PR DESCRIPTION
## Summary

To support SPP multi-path, a Socket-based solution is adopted to implement communication between SPP server and client.

## Impact

The upper layer application can use the original API to register with SPP, but when the SPP server has already established a connection with the peer device, the application needs to use the new API to complete the connection and data transmission with the SPP server. The specific API can be found in `framework/include/euv_pipe.h`.
