### PR TITLE
HFP: hold +CIEV responses until current call list is updated.

### DIFF
--- a/service/profiles/include/hfp_hf_service.h
+++ b/service/profiles/include/hfp_hf_service.h
@@ -35,12 +35,19 @@ typedef enum {
 
 typedef struct {
     hfp_call_t call_status;
+    hfp_callsetup_t callsetup_status;
+    hfp_callheld_t callheld_status;
+} hfp_hf_call_cache_t;
+
+typedef struct {
+    hfp_call_t call_status;
     uint64_t call_timestamp_us;
     hfp_callsetup_t callsetup_status;
     uint64_t callsetup_timestamp_us;
     hfp_callheld_t callheld_status;
     uint64_t callheld_timestamp_us;
     uint64_t dialing_timestamp_us;
+    hfp_hf_call_cache_t last_reported;
 #ifdef CONFIG_HFP_HF_WEBCHAT_BLOCKER
     uint64_t webchat_flag_timestamp_us;
 #endif


### PR DESCRIPTION
HFP: hold +CIEV responses until current call list is updated.

bug: v/52252

Rootcause: Android behavior requires AT+CLCC command only after +CIEV received, and shall not be updated when not requested.

Signed-off-by: Zihao Gao <[gaozihao@xiaomi.com](mailto:gaozihao@xiaomi.com)>