### PR TITLE
A2DP sink: Switch stream.ready to false when A2DP sink is disconnected.

### DIFF
--- a/service/profiles/a2dp/sink/a2dp_sink_audio.c
+++ b/service/profiles/a2dp/sink/a2dp_sink_audio.c
@@ -230,6 +230,11 @@ bool a2dp_sink_on_connection_changed(bool connected)
     if (connected) {
         a2dp_control_update_audio_config(CONFIG_BLUETOOTH_AUDIO_TRANS_ID_SINK_CTRL, 1);
     } else {
+        /* When disconnected, the Media framework should send AUDIO_CTRL_CMD_STOP to notify us that
+        it is no longer ready to receive data via audio data channel. However, due to a logic issue,
+        the media currently cannot send AUDIO_CTRL_CMD_STOP upon disconnection. As a workaround,
+        we are proactively setting sink_stream.ready to false in such scenario.  */
+        sink_stream.ready = false;
         a2dp_sink_on_stopped();
         a2dp_control_update_audio_config(CONFIG_BLUETOOTH_AUDIO_TRANS_ID_SINK_CTRL, 0);
     }


### PR DESCRIPTION
bug: v/53677

rootcause:When the A2DP sink disconnects, it does not send the A2DP_CTRL_CMD_STOP command. As a result, the bluetoothd daemon does not receive the STOP action, and the stream.ready flag is not reset. If stream.ready remains unreset, during the next connection, audio data may start being sent to the media layer before the media component issues the A2DP_CTRL_CMD_START command. This could lead to unintended audio streaming behavior.

## Summary

A2DP sink: Switch stream.ready to false when A2DP sink is disconnected.

