### PR TITLE
Vela-Android: fix IPC disconnect processing

### DIFF
--- a/service/ipc/socket/src/bt_socket_client.c
+++ b/service/ipc/socket/src/bt_socket_client.c
@@ -279,6 +279,7 @@ static void bt_socket_client_handle_event(uv_poll_t* poll, int status, int event
     }
 
     if (status != 0 || events & UV_DISCONNECT) {
+        uv_sem_post(&ins->message_processed);
         thread_loop_remove_poll(poll);
         if (ins && ins->disconnected) {
             BT_LOGE("%s socket disconnect, status = %d, events = %d", __func__, status, events);


### PR DESCRIPTION
bug: v/53702

Rootcause: Android(socket client) becomes blocked indefinitely when awaiting a semaphore, as the Vela(socket server) undergoes an unexpected reboot without properly releasing the semaphore. This failure in semaphore release prevents the client from proceeding with subsequent operations, resulting in a system deadlock.

