### PR TITLE
After processing the AVRC_GET_ELEMENT_ATTRIBUTES_RSP message, the AVR…

### DIFF
--- a/service/profiles/avrcp/avrcp_msg.c
+++ b/service/profiles/avrcp/avrcp_msg.c
@@ -52,7 +52,7 @@ avrcp_msg_t* avrcp_msg_new(rc_msg_id_t msg, bt_address_t* bd_addr)
 
 void avrcp_msg_destory(avrcp_msg_t* avrcp_msg)
 {
-    if (avrcp_msg->id == AVRC_GET_ELEMENT_ATTR_REQ) {
+    if (avrcp_msg->id == AVRC_GET_ELEMENT_ATTRIBUTES_RSP) {
         for (int i = 0; i < avrcp_msg->data.attrs.count; i++) {
             if (avrcp_msg->data.attrs.attrs[i] != NULL) {
                 free(avrcp_msg->data.attrs.attrs[i]);


### PR DESCRIPTION
## Summary

After processing the AVRC_GET_ELEMENT_ATTRIBUTES_RSP message, the AVRCP CT service not  free the allocated memory, which leads to memory leaks.

## Impact

This update improves the stability and efficiency of the AVRCP CT service by preventing memory leaks. 

## Testing

The fix was verified on the NuttX platform using the appropriate board configuration
