### PR TITLE
Avoid assigning large variables on the stack

### DIFF
--- a/service/profiles/a2dp/a2dp_state_machine.c
+++ b/service/profiles/a2dp/a2dp_state_machine.c
@@ -809,8 +809,15 @@ static bt_status_t a2dp_send_active_link_cmd(a2dp_state_machine_t* a2dp_sm, bool
     uint16_t ocf;
     size_t size;
     uint8_t* payload;
+    bt_status_t status;
     acl_bandwitdh_config_t config = { 0 };
-    uint8_t cmd[CONFIG_VSC_MAX_LEN];
+    uint8_t* cmd;
+
+    cmd = zalloc(CONFIG_VSC_MAX_LEN);
+    if (!cmd) {
+        BT_LOGE("allocate memory failed");
+        return BT_STATUS_NOMEM;
+    }
 
     config.acl_hdl = a2dp_sm->acl_handle;
     if (is_start) {
@@ -819,13 +826,15 @@ static bt_status_t a2dp_send_active_link_cmd(a2dp_state_machine_t* a2dp_sm, bool
             config.bandwidth / 1000, config.acl_hdl);
         if (!acl_bandwidth_config_builder(&config, cmd, &size)) {
             BT_LOGE("A2DP config bandwidth failed");
-            return BT_STATUS_FAIL;
+            status = BT_STATUS_FAIL;
+            goto out;
         }
     } else {
         BT_LOGD("remove bandwidth config for connection 0x%04x", config.acl_hdl);
         if (!acl_bandwidth_deconfig_builder(&config, cmd, &size)) {
             BT_LOGE("A2DP deconfig bandwidth failed");
-            return BT_STATUS_FAIL;
+            status = BT_STATUS_FAIL;
+            goto out;
         }
     }
 
@@ -834,7 +843,10 @@ static bt_status_t a2dp_send_active_link_cmd(a2dp_state_machine_t* a2dp_sm, bool
     STREAM_TO_UINT16(ocf, payload);
     size -= sizeof(ogf) + sizeof(ocf);
 
-    return bt_sal_send_hci_command(PRIMARY_ADAPTER, ogf, ocf, size, payload, NULL /* TODO: add callback */, a2dp_sm);
+    status = bt_sal_send_hci_command(PRIMARY_ADAPTER, ogf, ocf, size, payload, NULL /* TODO: add callback */, a2dp_sm);
+out:
+    free(cmd);
+    return status;
 }
 
 static void started_enter(state_machine_t* sm)

--- a/service/profiles/audio_interface/audio_transport.c
+++ b/service/profiles/audio_interface/audio_transport.c
@@ -266,7 +266,7 @@ bool audio_transport_open(audio_transport_t* transport, uint8_t ch_id,
     const char* path, transport_event_cb_t cb)
 {
     transport_channel_t* ch;
-    uv_fs_t fs;
+    uv_fs_t* fs;
     int ret;
 
     if (ch_id >= AUDIO_TRANS_CH_NUM || !transport)
@@ -287,8 +287,14 @@ bool audio_transport_open(audio_transport_t* transport, uint8_t ch_id,
         return false;
     }
 
+    fs = malloc(sizeof(uv_fs_t));
+    if (!fs) {
+        BT_LOGE("%s malloc failed", __func__);
+        return false;
+    }
+
     ch->svr_pipe->data = ch;
-    ret = uv_fs_unlink(transport->loop, &fs, path, NULL);
+    ret = uv_fs_unlink(transport->loop, fs, path, NULL);
     if (ret != 0 && ret != UV_ENOENT) {
         BT_LOGE("unlink error: %s", uv_strerror(ret));
         goto error;
@@ -312,11 +318,13 @@ bool audio_transport_open(audio_transport_t* transport, uint8_t ch_id,
     ch->ch_id = ch_id;
     ch->event_cb = cb;
     ch->ipc_handle = (void*)transport;
+    free(fs);
 
     BT_LOGD("%s path{%d}[%s] success", __func__, ch_id, path);
 
     return true;
 error:
+    free(fs);
     audio_transport_channel_close(ch);
     return false;
 }

--- a/service/profiles/hfp_ag/hfp_ag_state_machine.c
+++ b/service/profiles/hfp_ag/hfp_ag_state_machine.c
@@ -919,9 +919,17 @@ static bt_status_t ag_offload_send_cmd(ag_state_machine_t* agsm, bool is_start)
     uint8_t ogf;
     uint16_t ocf;
     size_t size;
+    bt_status_t status;
     uint8_t* payload;
     hfp_offload_config_t config = { 0 };
-    uint8_t offload[CONFIG_VSC_MAX_LEN];
+    uint8_t* offload;
+
+    offload = zalloc(CONFIG_VSC_MAX_LEN);
+
+    if (!offload) {
+        BT_LOGE("HFP HF offload alloc failed");
+        return BT_STATUS_NOMEM;
+    }
 
     config.sco_hdl = agsm->sco_conn_handle;
     config.sco_codec = agsm->codec;
@@ -942,7 +950,10 @@ static bt_status_t ag_offload_send_cmd(ag_state_machine_t* agsm, bool is_start)
     STREAM_TO_UINT16(ocf, payload);
     size -= sizeof(ogf) + sizeof(ocf);
 
-    return bt_sal_send_hci_command(PRIMARY_ADAPTER, ogf, ocf, size, payload, bt_hci_event_callback, agsm);
+    status = bt_sal_send_hci_command(PRIMARY_ADAPTER, ogf, ocf, size, payload, bt_hci_event_callback, agsm);
+    free(offload);
+
+    return status;
 }
 
 static bool is_virtual_call_allowed(state_machine_t* sm)

--- a/service/profiles/hfp_hf/hfp_hf_state_machine.c
+++ b/service/profiles/hfp_hf/hfp_hf_state_machine.c
@@ -423,9 +423,17 @@ static bt_status_t hf_offload_send_cmd(hf_state_machine_t* hfsm, bool is_start)
     uint8_t ogf;
     uint16_t ocf;
     size_t size;
+    bt_status_t status;
     uint8_t* payload;
     hfp_offload_config_t config = { 0 };
-    uint8_t offload[CONFIG_VSC_MAX_LEN];
+    uint8_t* offload;
+
+    offload = zalloc(CONFIG_VSC_MAX_LEN);
+
+    if (!offload) {
+        BT_LOGE("HFP HF offload alloc failed");
+        return BT_STATUS_NOMEM;
+    }
 
     config.sco_hdl = hfsm->sco_conn_handle;
     config.sco_codec = hfsm->codec;
@@ -445,8 +453,11 @@ static bt_status_t hf_offload_send_cmd(hf_state_machine_t* hfsm, bool is_start)
     STREAM_TO_UINT8(ogf, payload);
     STREAM_TO_UINT16(ocf, payload);
     size -= sizeof(ogf) + sizeof(ocf);
+ 
+    status = bt_sal_send_hci_command(PRIMARY_ADAPTER, ogf, ocf, size, payload, bt_hci_event_callback, hfsm);
+    free(offload);
 
-    return bt_sal_send_hci_command(PRIMARY_ADAPTER, ogf, ocf, size, payload, bt_hci_event_callback, hfsm);
+    return status;
 }
 
 static bool check_hfp_allowed(hf_state_machine_t* hfsm)

--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -542,7 +542,7 @@ static void process_ssp_request_evt(bt_address_t* addr, uint8_t transport,
 static void process_bond_state_change_evt(bt_address_t* addr, bond_state_t state,
     uint8_t transport, bool is_ctkd)
 {
-    remote_device_properties_t remote;
+    remote_device_properties_t* remote;
     bt_device_t* device;
 
     adapter_lock();
@@ -550,8 +550,15 @@ static void process_bond_state_change_evt(bt_address_t* addr, bond_state_t state
         device = adapter_find_create_classic_device(addr);
         if (state == BOND_STATE_BONDED) {
             device_set_bond_state(device, BOND_STATE_BONDED);
-            bt_sal_get_remote_device_info(PRIMARY_ADAPTER, addr, &remote);
-            device_set_device_type(device, remote.device_type);
+            remote = (remote_device_properties_t*)malloc(sizeof(remote_device_properties_t));
+            if (!remote) {
+                BT_LOGE("%s, malloc failed", __func__);
+                return;
+            }
+
+            bt_sal_get_remote_device_info(PRIMARY_ADAPTER, addr, remote);
+            device_set_device_type(device, remote->device_type);
+            free(remote);
             /* update bonded device info */
             adapter_update_bonded_device();
             // device_set_connection_state(device, CONNECTION_STATE_ENCRYPTED_BREDR);


### PR DESCRIPTION

## Summary

Change several large variables to be allocated on the heap to avoid allocating too large variables on the stack, further reducing the stack size of the Bluetooth thread

