### PR TITLE
HFP AG sent an incorrect callheld parameter in the +CIND response

### DIFF
--- a/framework/include/bt_hfp.h
+++ b/framework/include/bt_hfp.h
@@ -60,6 +60,7 @@ typedef enum {
 
 typedef enum {
     HFP_CALLHELD_NONE = 0,
+    HFP_CALLHELD_HELD_AND_ACTIVE,
     HFP_CALLHELD_HELD,
 } hfp_callheld_t;
 

--- a/service/profiles/hfp_ag/hfp_ag_state_machine.c
+++ b/service/profiles/hfp_ag/hfp_ag_state_machine.c
@@ -313,7 +313,7 @@ static void process_cind_request(ag_state_machine_t* agsm)
     resp.battery = 5;
     tele_service_get_phone_state(&num_active, &num_held, &call_state);
     resp.call = num_active ? HFP_CALL_CALLS_IN_PROGRESS : HFP_CALL_NO_CALLS_IN_PROGRESS;
-    resp.call_held = num_held ? HFP_CALLHELD_HELD : HFP_CALLHELD_NONE;
+    resp.call_held = num_held ? (num_active ? HFP_CALLHELD_HELD_AND_ACTIVE : HFP_CALLHELD_HELD) : HFP_CALLHELD_NONE;
     resp.call_setup = callstate_to_callsetup(call_state);
     BT_LOGD("AT+CIND=? response");
     bt_sal_hfp_ag_cind_response(&agsm->addr, &resp);


### PR DESCRIPTION
Issue: In the CIND response, according to the HFP specification, callheld has three states, as shown in the figure below. However, Vela BT defines only two states, and the call held state is inconsistent with the specification.
![image](https://github.com/user-attachments/assets/e859f119-d3e5-4887-adaa-4cf58b7cae6e)

Suggestion:According to Bluedroid, as long as there is an active call or a held call, it is considered as "call in progress." I couldn't find any relevant regulations in the HFP spec. Please check whether modifications are needed.