### PR TITLE
sal: set pairing_confirm cb to NULL by default

### DIFF
--- a/service/stacks/zephyr/sal_adapter_classic_interface.c
+++ b/service/stacks/zephyr/sal_adapter_classic_interface.c
@@ -155,7 +155,6 @@ static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
 
 static struct bt_conn_auth_cb g_conn_auth_cbs = {
     .cancel = zblue_on_cancel,
-    .pairing_confirm = zblue_on_pairing_confirm,
     .pincode_entry = zblue_on_pincode_entry
 };
 
@@ -627,27 +626,32 @@ bt_status_t bt_sal_set_io_capability(bt_controller_id_t id, bt_io_capability_t c
         g_conn_auth_cbs.passkey_display = zblue_on_passkey_display;
         g_conn_auth_cbs.passkey_entry = NULL;
         g_conn_auth_cbs.passkey_confirm = NULL;
+        g_conn_auth_cbs.pairing_confirm = NULL;
         break;
     case BT_IO_CAPABILITY_DISPLAYYESNO:
         g_conn_auth_cbs.passkey_display = zblue_on_passkey_display;
         g_conn_auth_cbs.passkey_entry = NULL;
         g_conn_auth_cbs.passkey_confirm = zblue_on_passkey_confirm;
+        g_conn_auth_cbs.pairing_confirm = zblue_on_pairing_confirm;
         break;
     case BT_IO_CAPABILITY_KEYBOARDONLY:
         g_conn_auth_cbs.passkey_display = NULL;
         g_conn_auth_cbs.passkey_entry = zblue_on_passkey_entry;
         g_conn_auth_cbs.passkey_confirm = NULL;
+        g_conn_auth_cbs.pairing_confirm = NULL;
         break;
     case BT_IO_CAPABILITY_KEYBOARDDISPLAY:
         g_conn_auth_cbs.passkey_display = zblue_on_passkey_display;
         g_conn_auth_cbs.passkey_entry = zblue_on_passkey_entry;
         g_conn_auth_cbs.passkey_confirm = zblue_on_passkey_confirm;
+        g_conn_auth_cbs.pairing_confirm = zblue_on_pairing_confirm;
         break;
     case BT_IO_CAPABILITY_NOINPUTNOOUTPUT:
     default:
         g_conn_auth_cbs.passkey_display = NULL;
         g_conn_auth_cbs.passkey_entry = NULL;
         g_conn_auth_cbs.passkey_confirm = NULL;
+        g_conn_auth_cbs.pairing_confirm = NULL;
         break;
     }
 


### PR DESCRIPTION
bug: v/53803

SSP just work pairing confirm dont notify app

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Fix pairing behavior mismatch issue .*

## Impact

*SSP.*

## Testing

*CI.*

