### PR TITLE
Move the save adapter property to the uv_work thread.

### DIFF
--- a/service/common/storage_property.c
+++ b/service/common/storage_property.c
@@ -62,6 +62,22 @@ typedef struct {
     uint8_t value[0];
 } bt_property_value_t;
 
+static void storage_save_adapter_info(service_work_t* work, void* userdata)
+{
+    adapter_storage_t* adapter = (adapter_storage_t*)userdata;
+    property_set_binary(BT_KVDB_ADAPTERINFO_NAME, adapter->name, sizeof(adapter->name), false);
+    property_set_int32(BT_KVDB_ADAPTERINFO_COD, adapter->class_of_device);
+    property_set_int32(BT_KVDB_ADAPTERINFO_IOCAP, adapter->io_capability);
+    property_set_int32(BT_KVDB_ADAPTERINFO_SCAN, adapter->scan_mode);
+    property_set_int32(BT_KVDB_ADAPTERINFO_BOND, adapter->bondable);
+    property_commit();
+}
+
+static void storage_save_adapter_info_complete(service_work_t* work, void* userdata)
+{
+    free(userdata);
+}
+
 static void storage_commit(service_work_t* work, void* userdata)
 {
     property_commit();
@@ -192,12 +208,21 @@ static void adapter_properties_default(adapter_storage_t* prop)
 
 int bt_storage_save_adapter_info(adapter_storage_t* adapter)
 {
-    property_set_binary(BT_KVDB_ADAPTERINFO_NAME, adapter->name, sizeof(adapter->name), true);
-    property_set_int32_oneway(BT_KVDB_ADAPTERINFO_COD, adapter->class_of_device);
-    property_set_int32_oneway(BT_KVDB_ADAPTERINFO_IOCAP, adapter->io_capability);
-    property_set_int32_oneway(BT_KVDB_ADAPTERINFO_SCAN, adapter->scan_mode);
-    property_set_int32_oneway(BT_KVDB_ADAPTERINFO_BOND, adapter->bondable);
-    service_loop_work(NULL, storage_commit, NULL);
+    adapter_storage_t* adapter_copy;
+
+    adapter_copy = (adapter_storage_t*)malloc(sizeof(adapter_storage_t));
+    if (!adapter_copy) {
+        BT_LOGE("adapter_copy malloc failed!");
+        return -ENOMEM;
+    }
+    memcpy(adapter_copy, adapter, sizeof(adapter_storage_t));
+
+    if (service_loop_work(adapter_copy, storage_save_adapter_info, storage_save_adapter_info_complete) == NULL) {
+        BT_LOGE("service_loop_work failed!");
+        storage_save_adapter_info_complete(NULL, adapter_copy);
+        return -EINVAL;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
bug: v/54729

rootcause:The number of KVDB connections that can be established is limited. If multiple one-way modification operations are triggered rapidly, it may cause the number of connections to exceed the upper limit.

