### PR TITLE
framework/bluetooth: Fixed the problem that bt_device_get_alias metho…

### DIFF
--- a/framework/socket/bt_device.c
+++ b/framework/socket/bt_device.c
@@ -177,7 +177,7 @@ bool bt_device_get_alias(bt_instance_t* ins, bt_address_t* addr, char* alias, ui
     }
 
     strlcpy(alias, packet.devs_pl._bt_device_get_alias.alias,
-        MIN(length, sizeof(packet.devs_pl._bt_device_get_alias.alias) - 1));
+        MIN(length, sizeof(packet.devs_pl._bt_device_get_alias.alias)));
 
     return packet.devs_r.status;
 }


### PR DESCRIPTION
bt_device_get_alias method returns 62 bytes when alias length is 63 bytes, because the length is reduced by 1 when using strlcpy.