### PR TITLE
AVRCP CT: If the volume is the same, the system returns and does not set the volume.

### DIFF
--- a/service/profiles/avrcp/control/avrcp_control_service.c
+++ b/service/profiles/avrcp/control/avrcp_control_service.c
@@ -451,6 +451,9 @@ static void handle_avrcp_set_absolute_volume(avrcp_msg_t* msg)
 
     if (media_volume != curr_volume) {
         device->set_abs_vol_cnt++;
+    } else {
+        uv_mutex_unlock(&device->lock);
+        return;
     }
 
     uv_mutex_unlock(&device->lock);

--- a/service/profiles/avrcp/control/avrcp_control_service.c
+++ b/service/profiles/avrcp/control/avrcp_control_service.c
@@ -21,8 +21,8 @@
 #include <unistd.h>
 
 #include "adapter_internel.h"
-#include "avrcp_msg.h"
 #include "avrcp_control_service.h"
+#include "avrcp_msg.h"
 #include "bt_addr.h"
 #include "bt_list.h"
 #include "bt_player.h"


### PR DESCRIPTION
bug: v/55580

rootcause: It doesn't make sense to set the same volume to media.