### PR TITLE
bluetooth: adapter: Solve the problem of scanmode setting failure

### DIFF
--- a/service/stacks/zephyr/sal_adapter_classic_interface.c
+++ b/service/stacks/zephyr/sal_adapter_classic_interface.c
@@ -713,6 +713,7 @@ static void STACK_CALL(set_scan_mode)(void* args)
     sal_adapter_req_t* req = args;
     bool iscan = false;
     bool pscan = false;
+    int ret;
 
     switch (req->adpt.scanmode.scan_mode) {
     case BT_SCAN_MODE_NONE:
@@ -730,18 +731,10 @@ static void STACK_CALL(set_scan_mode)(void* args)
         break;
     }
 
-    int ret = bt_br_set_connectable(pscan);
+    ret = bt_br_set_visibility(iscan, pscan);
     if (ret != 0 && ret != -EALREADY) {
-        BT_LOGE("%s set connectable failed:%d", __func__, ret);
+        BT_LOGE("%s set scanmode failed:%d", __func__, ret);
         return;
-    }
-
-    if (iscan) {
-        ret = bt_br_set_discoverable(iscan);
-        if (ret != 0 && ret != -EALREADY) {
-            BT_LOGE("%s set discoverable failed:%d", __func__, ret);
-            return;
-        }
     }
 
     if (ret == 0)


### PR DESCRIPTION
bug: v/55642

rootcause: When the discoverable mode changes and iscan=false, bt_br_set_discoverable will not be called. Additionally, when the discoverable or connectable mode changes, it does not necessarily mean that the value of scanmode in storage will change.