### PR TITLE
GAP: Supplement missing adapter binding status updates

### DIFF
--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -2747,6 +2747,7 @@ bt_status_t adapter_pair_request_reply(bt_address_t* addr, bool accept)
     bt_status_t status;
     status = bt_sal_pair_reply(PRIMARY_ADAPTER, addr, accept ? 0 : HCI_ERR_PAIRING_NOT_ALLOWED);
     if (status == BT_STATUS_SUCCESS && accept) {
+        device_set_bond_state(device, BOND_STATE_BONDING);
         /* callback bonding */
         CALLBACK_FOREACH(CBLIST, adapter_callbacks_t, on_bond_state_changed,
             addr, BT_TRANSPORT_BREDR, BOND_STATE_BONDING, false);


### PR DESCRIPTION
bug:v/43859

rootcause: The binding status of the adapter was not updated when the binding status change event was triggered.
