### PR TITLE
bluetooth: Fix the HFP memory leak issue.

### DIFF
--- a/service/profiles/hfp_ag/hfp_ag_service.c
+++ b/service/profiles/hfp_ag/hfp_ag_service.c
@@ -280,8 +280,10 @@ static void hfp_ag_process_message(void* data)
 {
     hfp_ag_msg_t* msg = (hfp_ag_msg_t*)data;
 
-    if (!g_ag_service.started && msg->event != AG_STARTUP)
+    if (!g_ag_service.started && msg->event != AG_STARTUP) {
+        hfp_ag_msg_destory(msg);
         return;
+    }
 
     switch (msg->event) {
     case AG_STARTUP:

--- a/service/profiles/hfp_hf/hfp_hf_service.c
+++ b/service/profiles/hfp_hf/hfp_hf_service.c
@@ -248,8 +248,10 @@ static void hfp_hf_process_message(void* data)
 {
     hfp_hf_msg_t* msg = (hfp_hf_msg_t*)data;
 
-    if (!g_hfp_service.started && msg->event != HF_STARTUP)
+    if (!g_hfp_service.started && msg->event != HF_STARTUP) {
+        hfp_hf_msg_destroy(msg);
         return;
+    }
 
     switch (msg->event) {
     case HF_STARTUP:


### PR DESCRIPTION
bug: v/57317

rootcause: When shutdown, the started status of HFP is set to false, and subsequent events will not be processed, causing the memory of messages to not be released, leading to memory leaks.

