### PR TITLE
bluetooth: a2dp: Fix A2DP stuttering issue.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -454,11 +454,13 @@ config BLUETOOTH_TOOLS
 
 choice
 	prompt "select bt vendor"
-	default BLUETOOTH_VENDOR_BES
+	default BLUETOOTH_VENDOR_NONE
 	config BLUETOOTH_VENDOR_BES
 		bool "bluetooth vendor BES"
 	config BLUETOOTH_VENDOR_ACTIONS
 		bool "bluetooth vendor ACTIONS"
+	config BLUETOOTH_VENDOR_NONE
+		bool "bluetooth vendor NONE"
 endchoice
 
 config BLUETOOTH_FEATURE


### PR DESCRIPTION
bug: v/54099

rootcause: Before playing music, a vendor specific command is sent, but when using the dongle, the controller does not recognize this command and responds slowly, causing audio packets to accumulate in the HCI, resulting in music stuttering.

