### PR TITLE
64-bit: Fix type mismatch issues.

### DIFF
--- a/framework/include/bt_config.h
+++ b/framework/include/bt_config.h
@@ -1,13 +1,6 @@
 #ifndef __INCLUDE_BT_CONFIG_H
 #define __INCLUDE_BT_CONFIG_H
 
-// Platform: 32-bit or 64-bit
-#if defined(CONFIG_ARCH_ARM64) || defined(ARCH_X86_64) || defined(ANDROID) || (!defined(CONFIG_SIM_M32) && defined(CONFIG_ARCH_SIM))
-#define CONFIG_CPU_BIT64 1
-#elif defined(ARCH_ARM) || defined(ARCH_X86) || defined(__NuttX__)
-#define CONFIG_CPU_BIT32 1
-#endif
-
 // Configuration of Bluetooth Framework/Service/Stack
 #if defined(__NuttX__)
 
@@ -128,6 +121,13 @@
 #define CONFIG_BLUETOOTH_HID_DEVICE 1
 #endif
 
+#endif
+
+// Platform: 32-bit or 64-bit
+#if defined(CONFIG_ARCH_ARM64) || defined(ARCH_X86_64) || defined(ANDROID) || (!defined(CONFIG_SIM_M32) && defined(CONFIG_ARCH_SIM)) || defined(CONFIG_ARCH_X86_64)
+#define CONFIG_CPU_BIT64 1
+#elif defined(ARCH_ARM) || defined(ARCH_X86)
+#define CONFIG_CPU_BIT32 1
 #endif
 
 // ############################################################################

--- a/service/profiles/a2dp/sink/a2dp_sink_audio.c
+++ b/service/profiles/a2dp/sink/a2dp_sink_audio.c
@@ -121,7 +121,7 @@ static void a2dp_sink_audio_handle_timer(service_timer_t* timer, void* arg)
     uint64_t now_us = get_os_timestamp_us();
 #ifndef CONFIG_ARCH_SIM
     if (stream->last_ts && ((now_us - stream->last_ts) > 30000))
-        BT_LOGD("===a2dp cpu busy time:%lld, buff_cnt:%d===", now_us - stream->last_ts, list_length(&sink_stream.packet_queue));
+        BT_LOGD("===a2dp cpu busy time:%"PRIu64", buff_cnt:%zu===", now_us - stream->last_ts, list_length(&sink_stream.packet_queue));
     stream->last_ts = now_us;
 #endif
 


### PR DESCRIPTION
bug:v/50763

Rootcause: On 64-bit platforms, some Log statements have format strings that do not match the variable types.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

64-bit: Fix type mismatch issues.

## Impact

N/A.


## Testing

CI

