### PR TITLE
When bt off is executed, disconnect all acl connections before calling adapter_disable and ensure that they are successfully disconnected.

### DIFF
--- a/service/src/adapter_internel.h
+++ b/service/src/adapter_internel.h
@@ -21,6 +21,7 @@
 #include "bt_adapter.h"
 #include "bt_device.h"
 #include "bt_status.h"
+#include "service_loop.h"
 #include <stdbool.h>
 
 enum {
@@ -187,8 +188,10 @@ enum {
 enum adapter_event {
     SYS_TURN_ON = 0,
     SYS_TURN_OFF,
+    SYS_TURN_OFF_SAFE,
     TURN_ON_BLE,
     TURN_OFF_BLE,
+    SYS_TURN_OFF_SAFE_TIMEOUT,
     /*
         Don't support BREDR-only mode. If the user chooses TURN_ON,
         we turn on ble first by default, and then turn on bt
@@ -201,6 +204,7 @@ enum adapter_event {
     BREDR_DISABLE_TIMEOUT,
     BREDR_ENABLE_PROFILE_TIMEOUT,
     BREDR_DISABLE_PROFILE_TIMEOUT,
+    BREDR_ACL_ALL_DISCONNECTED,
     BLE_ENABLED,
     BLE_DISABLED,
     BLE_PROFILE_ENABLED,
@@ -258,6 +262,7 @@ void adapter_init(void);
 void adapter_cleanup(void);
 bt_status_t adapter_enable(uint8_t opt);
 bt_status_t adapter_disable(uint8_t opt);
+bt_status_t adapter_disable_safe(uint8_t opt);
 bt_adapter_state_t adapter_get_state(void);
 bool adapter_is_le_enabled(void);
 bt_device_type_t adapter_get_type(void);
@@ -312,6 +317,7 @@ bond_state_t adapter_get_remote_bond_state(bt_address_t* addr, bt_transport_t tr
 bool adapter_is_remote_bonded(bt_address_t* addr, bt_transport_t transport);
 bt_status_t adapter_connect(bt_address_t* addr);
 bt_status_t adapter_disconnect(bt_address_t* addr);
+bt_status_t adapter_disconnect_safe(void);
 bt_status_t adapter_le_connect(bt_address_t* addr,
     ble_addr_type_t type,
     ble_connect_params_t* param);

--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -224,6 +224,21 @@ static void adapter_delete_device(void* data)
     device_delete(device);
 }
 
+static bool adapter_check_acl_all_disconnected(void)
+{
+    bt_device_t* device;
+    bt_list_node_t* node;
+
+    for (node = bt_list_head(g_adapter_service.devices); node != NULL; node = bt_list_next(g_adapter_service.devices, node)) {
+        device = (bt_device_t*)bt_list_node(node);
+        if (device_is_connected(device)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 static adapter_remote_event_t* create_remote_event(bt_address_t* addr, uint8_t evt_id)
 {
     adapter_remote_event_t* evt = malloc(sizeof(adapter_remote_event_t));
@@ -770,6 +785,7 @@ static const char* acl_connection_str(connection_state_t state)
 static void process_connection_state_changed_evt(bt_address_t* addr, acl_state_param_t* acl_params)
 {
     bt_device_t* device;
+    adapter_service_t* adapter = &g_adapter_service;
 
     BT_ADDR_LOG("ACL connection state changed, addr:%s, link:%d, state:%s, status:%d, reason:%" PRIu32 "", addr,
         acl_params->transport, acl_connection_str(acl_params->connection_state),
@@ -824,6 +840,13 @@ static void process_connection_state_changed_evt(bt_address_t* addr, acl_state_p
     /* send connection changed notification */
     CALLBACK_FOREACH(CBLIST, adapter_callbacks_t, on_connection_state_changed, addr,
         acl_params->transport, acl_params->connection_state);
+
+    /* check acls connection is all disconnected in safe disable mode */
+    if (acl_params->connection_state == CONNECTION_STATE_DISCONNECTED) {
+        if (adapter_check_acl_all_disconnected()) {
+            send_to_state_machine((state_machine_t*)adapter->stm, BREDR_ACL_ALL_DISCONNECTED, NULL);
+        }
+    }
 }
 
 static void handle_connection_event(void* data)
@@ -1727,8 +1750,15 @@ bt_status_t adapter_disable(uint8_t opt)
         return BT_STATUS_DONE;
     }
 
+    return adapter_disable_safe(opt);
+}
+
+bt_status_t adapter_disable_safe(uint8_t opt)
+{
+    adapter_service_t* adapter = &g_adapter_service;
+
     if (opt == SYS_SET_BT_ALL)
-        send_to_state_machine((state_machine_t*)adapter->stm, SYS_TURN_OFF, NULL);
+        send_to_state_machine((state_machine_t*)adapter->stm, SYS_TURN_OFF_SAFE, NULL);
     else
         send_to_state_machine((state_machine_t*)adapter->stm, TURN_OFF_BLE, NULL);
 
@@ -2516,6 +2546,25 @@ bt_status_t adapter_disconnect(bt_address_t* addr)
 
     device_set_connection_state(device, CONNECTION_STATE_DISCONNECTING);
     adapter_unlock();
+    return BT_STATUS_SUCCESS;
+}
+
+bt_status_t adapter_disconnect_safe(void)
+{
+    bt_device_t* device;
+    bt_list_node_t* node;
+    adapter_service_t* adapter = &g_adapter_service;
+
+    /* check acls connection is all disconnected in safe disable mode */
+    if (adapter_check_acl_all_disconnected()) {
+        send_to_state_machine((state_machine_t*)adapter->stm, BREDR_ACL_ALL_DISCONNECTED, NULL);
+    }
+
+    for (node = bt_list_head(g_adapter_service.devices); node != NULL; node = bt_list_next(g_adapter_service.devices, node)) {
+        device = (bt_device_t*)bt_list_node(node);
+        adapter_disconnect(device_get_address(device));
+    }
+
     return BT_STATUS_SUCCESS;
 }
 

--- a/service/src/adapter_state.c
+++ b/service/src/adapter_state.c
@@ -33,6 +33,8 @@
 #include "bt_utils.h"
 #include "utils/log.h"
 
+#define DISABLE_SAFE_TIMEOUT (2000)
+
 static void off_enter(state_machine_t* sm);
 static void off_exit(state_machine_t* sm);
 static void ble_turning_on_enter(state_machine_t* sm);
@@ -55,6 +57,8 @@ static bool turning_on_process_event(state_machine_t* sm, uint32_t event, void* 
 static bool on_state_process_event(state_machine_t* sm, uint32_t event, void* p_data);
 static bool turning_off_process_event(state_machine_t* sm, uint32_t event, void* p_data);
 static bool ble_turning_off_process_event(state_machine_t* sm, uint32_t event, void* p_data);
+
+static void turning_off_safe_timeout_callback(service_timer_t* timer, void* data);
 
 static const state_t off_state = {
     .state_name = "Off",
@@ -119,6 +123,8 @@ typedef struct adapter_state_machine {
     bool a2dp_offloading;
     bool hfp_offloading;
     bool lea_offloading;
+    bool turning_off_safe;
+    service_timer_t* disable_safe_timer;
 } adapter_state_machine_t;
 
 #define ADPATER_STM_DEBUG 1
@@ -129,6 +135,8 @@ static const char* event_to_string(uint16_t event)
     switch (event) {
         CASE_RETURN_STR(SYS_TURN_ON)
         CASE_RETURN_STR(SYS_TURN_OFF)
+        CASE_RETURN_STR(SYS_TURN_OFF_SAFE)
+        CASE_RETURN_STR(SYS_TURN_OFF_SAFE_TIMEOUT)
         CASE_RETURN_STR(TURN_ON_BLE)
         CASE_RETURN_STR(TURN_OFF_BLE)
         CASE_RETURN_STR(BREDR_ENABLED)
@@ -139,6 +147,7 @@ static const char* event_to_string(uint16_t event)
         CASE_RETURN_STR(BREDR_DISABLE_TIMEOUT)
         CASE_RETURN_STR(BREDR_ENABLE_PROFILE_TIMEOUT)
         CASE_RETURN_STR(BREDR_DISABLE_PROFILE_TIMEOUT)
+        CASE_RETURN_STR(BREDR_ACL_ALL_DISCONNECTED)
         CASE_RETURN_STR(BLE_ENABLED)
         CASE_RETURN_STR(BLE_DISABLED)
         CASE_RETURN_STR(BLE_PROFILE_ENABLED)
@@ -392,11 +401,25 @@ static void on_state_exit(state_machine_t* sm)
 
 static bool on_state_process_event(state_machine_t* sm, uint32_t event, void* p_data)
 {
+    adapter_state_machine_t* stm = (adapter_state_machine_t*)sm;
     ADAPTER_DBG_EVENT(sm, event);
 
     switch (event) {
     case SYS_TURN_OFF:
         hsm_transition_to(sm, &turning_off_state);
+        break;
+    case SYS_TURN_OFF_SAFE:
+        stm->turning_off_safe = true;
+
+        adapter_disconnect_safe();
+
+        stm->disable_safe_timer = service_loop_timer(DISABLE_SAFE_TIMEOUT, 0,
+            turning_off_safe_timeout_callback, (void*)sm);
+        break;
+    case BREDR_ACL_ALL_DISCONNECTED:
+    case SYS_TURN_OFF_SAFE_TIMEOUT:
+        if (stm->turning_off_safe)
+            hsm_transition_to(sm, &turning_off_state);
         break;
     default:
         return false;
@@ -407,7 +430,15 @@ static bool on_state_process_event(state_machine_t* sm, uint32_t event, void* p_
 
 static void turning_off_enter(state_machine_t* sm)
 {
+    adapter_state_machine_t* stm = (adapter_state_machine_t*)sm;
     ADAPTER_DBG_ENTER(sm);
+
+    stm->turning_off_safe = false;
+
+    /* Cancel the timer in safe disable mode */
+    service_loop_cancel_timer(stm->disable_safe_timer);
+    stm->disable_safe_timer = NULL;
+
     /* profile service shotdown */
     service_manager_shutdown(BT_TRANSPORT_BREDR);
     adapter_notify_state_change(BT_ADAPTER_STATE_ON, BT_ADAPTER_STATE_TURNING_OFF);
@@ -488,6 +519,11 @@ static bool ble_turning_off_process_event(state_machine_t* sm, uint32_t event, v
     }
 
     return true;
+}
+
+static void turning_off_safe_timeout_callback(service_timer_t* timer, void* data)
+{
+    send_to_state_machine((state_machine_t*)data, SYS_TURN_OFF_SAFE_TIMEOUT, NULL);
 }
 
 adapter_state_machine_t* adapter_state_machine_new(void* context)


### PR DESCRIPTION
Originally, only the "adapter_disable" function was executed. An additional step was added before that, which disconnects all ACL connections. A timer was also started to wait for the "disconnect" event for 2 seconds, followed by cleaning up profile resources (by following the normal disable procedure).