### PR TITLE
bluetooth: add bt memory debug tool.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,10 @@ if(CONFIG_BLUETOOTH)
     list(APPEND INCDIR ${BLUETOOTH_DIR}/service/vhal)
   endif()
 
+  if(CONFIG_BLUETOOTH_DEBUG_MEMORY)
+    list(APPEND CSRCS ${BLUETOOTH_DIR}/debug/bt_memory.c)
+  endif()
+
   if(CONFIG_BLUETOOTH_TOOLS)
     list(APPEND CSRCS ${BLUETOOTH_DIR}/tools/utils.c)
     list(APPEND CSRCS ${BLUETOOTH_DIR}/tools/log.c)

--- a/Kconfig
+++ b/Kconfig
@@ -47,6 +47,14 @@ config BLUETOOTH_DEBUG_TIME_UNIT_US
         Enable this option to use microseconds (us) for Bluetooth debug time.
         If disabled, milliseconds (ms) will be used by default.
 
+config BLUETOOTH_DEBUG_MEMORY
+    bool "Enable Bluetooth Debug Memory"
+    default n
+    help
+        Enable this option to override standard memory allocation functions
+        (malloc, calloc, free) with Bluetooth-specific versions (bt_malloc, etc).
+        Useful for tracking memory usage and debugging in Bluetooth modules.
+
 config BLUETOOTH_BREDR_SUPPORT
 	bool "BREDR support"
 	default y

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ else
 CSRCS += service/common/storage.c
 endif
 
+ifeq ($(CONFIG_BLUETOOTH_DEBUG_MEMORY),y)
+CSRCS += debug/bt_memory.c
+endif
+
 ifeq ($(CONFIG_BLUETOOTH_SERVICE), y)
 	CSRCS += service/common/bt_time.c
 	CSRCS += service/common/service_loop.c

--- a/debug/bt_memory.c
+++ b/debug/bt_memory.c
@@ -1,0 +1,166 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#include "bt_memory.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+
+#define GUARD_SIZE 16
+#define GUARD_HEAD 0xAA
+#define GUARD_TAIL 0xBB
+
+typedef struct bt_mem_node {
+    void* addr;
+    size_t size;
+    const char* file;
+    int line;
+    unsigned char guard[GUARD_SIZE];
+    struct bt_mem_node* next;
+} bt_mem_node_t;
+
+typedef struct bt_mem_manager {
+    bt_mem_node_t* mem_list;
+    pthread_mutex_t list_lock;
+    size_t current_mem;
+    size_t peak_mem;
+} bt_mem_manager_t;
+
+static bt_mem_manager_t g_mem_manager = {
+    .mem_list = NULL,
+    .list_lock = PTHREAD_MUTEX_INITIALIZER,
+    .current_mem = 0,
+    .peak_mem = 0,
+};
+
+void* bt_malloc_hook(size_t size, const char* file, int line)
+{
+    bt_mem_manager_t* mem_manager = &g_mem_manager;
+    void* raw;
+    bt_mem_node_t* head;
+
+    raw = malloc(size + sizeof(bt_mem_node_t) + GUARD_SIZE);
+    if (!raw) {
+        syslog(LOG_ALERT, "[bt_memory] malloc failed, size: %zu, file: %s, line: %d", size, file, line);
+        return NULL;
+    }
+
+    head = (bt_mem_node_t*)raw;
+    *head = (bt_mem_node_t) {
+        .addr = (char*)raw + sizeof(bt_mem_node_t),
+        .size = size,
+        .file = file,
+        .line = line,
+        .next = NULL
+    };
+
+    memset(head->guard, GUARD_HEAD, sizeof(head->guard));
+    memset((char*)head->addr + size, GUARD_TAIL, GUARD_SIZE);
+
+    pthread_mutex_lock(&mem_manager->list_lock);
+    mem_manager->current_mem += size;
+    if (mem_manager->current_mem > mem_manager->peak_mem) {
+        mem_manager->peak_mem = mem_manager->current_mem;
+    }
+
+    head->next = mem_manager->mem_list;
+    mem_manager->mem_list = head;
+    pthread_mutex_unlock(&mem_manager->list_lock);
+
+    return head->addr;
+}
+
+void* bt_calloc_hook(size_t num, size_t size, const char* file, int line)
+{
+    size_t total;
+    void* ptr;
+
+    total = num * size;
+    ptr = bt_malloc_hook(total, file, line);
+    if (!ptr) {
+        syslog(LOG_ALERT, "[bt_memory] calloc failed, num: %zu, size: %zu, file: %s, line: %d", num, size, file, line);
+        return NULL;
+    }
+
+    memset(ptr, 0, total);
+    return ptr;
+}
+
+void bt_free_hook(void* ptr)
+{
+    bt_mem_manager_t* mem_manager = &g_mem_manager;
+    bt_mem_node_t** pp;
+    bool found = false;
+
+    if (!ptr) {
+        return;
+    }
+
+    pthread_mutex_lock(&mem_manager->list_lock);
+
+    pp = &mem_manager->mem_list;
+    while (*pp) {
+        if ((*pp)->addr == ptr) {
+            bt_mem_node_t* node = *pp;
+
+            for (int i = 0; i < GUARD_SIZE; i++) {
+                if (((uint8_t)node->guard[i] != GUARD_HEAD) || ((uint8_t)((char*)ptr + node->size)[i] != GUARD_TAIL)) {
+                    syslog(LOG_ALERT, "[bt_memory] Buffer overflow at %s:%d", node->file, node->line);
+                    assert(0);
+                }
+            }
+
+            mem_manager->current_mem -= node->size;
+            *pp = node->next;
+            found = true;
+            free(node);
+            break;
+        }
+        pp = &(*pp)->next;
+    }
+
+    pthread_mutex_unlock(&mem_manager->list_lock);
+
+    if (!found) {
+        syslog(LOG_ALERT, "[bt_memory] Freeing unallocated memory %p", ptr);
+        assert(0);
+    }
+}
+
+void bt_report_leak(void)
+{
+    bt_mem_manager_t* mem_manager = &g_mem_manager;
+    bt_mem_node_t* node;
+
+    pthread_mutex_lock(&mem_manager->list_lock);
+
+    syslog(LOG_ALERT, "[bt_memory] ===== Memory Leak Report =====");
+    syslog(LOG_ALERT, "[bt_memory] Peak memory: %zu bytes", mem_manager->peak_mem);
+
+    node = mem_manager->mem_list;
+    while (node) {
+        syslog(LOG_ALERT, "[bt_memory] Leak %p (%zu bytes) at %s:%d",
+            node->addr, node->size, node->file, node->line);
+        node = node->next;
+    }
+    syslog(LOG_ALERT, "[bt_memory] ===== End of Report =====");
+
+    pthread_mutex_unlock(&mem_manager->list_lock);
+}

--- a/debug/bt_memory_sample.c
+++ b/debug/bt_memory_sample.c
@@ -1,0 +1,53 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#include <stdio.h>
+#include <string.h>
+
+#include "bt_memory.h"
+
+void test_leak()
+{
+    void* p1 = bt_malloc(128);
+    void* p2 = bt_malloc(256);
+}
+
+void test_overflow()
+{
+    char* buf = (char*)bt_malloc(16);
+    memset(buf, 0, 20);
+    bt_free(buf);
+}
+
+void test_double_free()
+{
+    void* p = bt_malloc(64);
+    bt_free(p);
+    bt_free(p);
+}
+
+int main()
+{
+    test_leak();
+
+    test_overflow();
+
+    test_double_free();
+
+    void* p2 = bt_malloc(500);
+
+    bt_report_leak();
+    return 0;
+}

--- a/framework/include/bt_memory.h
+++ b/framework/include/bt_memory.h
@@ -1,0 +1,48 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#ifndef _BT_MEMORY_H_
+#define _BT_MEMORY_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_BLUETOOTH_DEBUG_MEMORY)
+void* bt_malloc_hook(size_t size, const char* file, int line);
+void* bt_calloc_hook(size_t n, size_t size, const char* file, int line);
+void bt_free_hook(void* ptr);
+void bt_report_leak(void);
+
+#define bt_malloc(size) bt_malloc_hook(size, __FILE__, __LINE__)
+#define bt_calloc(n, size) bt_calloc_hook(n, size, __FILE__, __LINE__)
+#define bt_free(ptr) bt_free_hook(ptr)
+#define bt_zalloc(size) bt_calloc(1, size)
+#else
+#define bt_malloc(size) malloc(size)
+#define bt_calloc(n, size) calloc(n, size)
+#define bt_free(ptr) free(ptr)
+#define bt_zalloc(size) zalloc(size)
+#endif // CONFIG_BLUETOOTH_DEBUG_MEMORY
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _BT_MEMORY_H_


### PR DESCRIPTION
bug: v/59567

rootcause: add bt memory debug, support memory out-of-bounds check, peak memory printing, and memory leak check

## Summary
bluetooth: add bt memory debug tool.

## Impact
NO

## Testing
local function test pass

