### PR TITLE
bluetooth: Fix Kconfig so that Framework and zblue correspond.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -435,6 +435,7 @@ choice
 		select LIB_BLUELET
 	config BLUETOOTH_STACK_LE_ZBLUE
 		bool "ble stack use zblue"
+		select BT
 	config BLUETOOTH_STACK_NOT_SUPPORT_LE
 		bool "not support ble stack"
 endchoice


### PR DESCRIPTION
bug: v/60321

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

