### PR TITLE
Fix issues in sal_adapter_classic_interface.c for BR and BLE coexistence and disconnect reason reporting

### DIFF
--- a/service/stacks/zephyr/sal_adapter_classic_interface.c
+++ b/service/stacks/zephyr/sal_adapter_classic_interface.c
@@ -221,6 +221,10 @@ static void zblue_on_connect_req(struct bt_conn* conn, uint8_t link_type, uint8_
 
 static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
 {
+    if (!bt_conn_get_dst_br(conn)) {
+        return;
+    }
+
     acl_state_param_t state = {
         .transport = BT_TRANSPORT_BREDR,
         .connection_state = CONNECTION_STATE_CONNECTED
@@ -232,6 +236,10 @@ static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
 
 static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
 {
+    if (!bt_conn_get_dst_br(conn)) {
+        return;
+    }
+
     acl_state_param_t state = {
         .transport = BT_TRANSPORT_BREDR,
         .connection_state = CONNECTION_STATE_DISCONNECTED

--- a/service/stacks/zephyr/sal_adapter_classic_interface.c
+++ b/service/stacks/zephyr/sal_adapter_classic_interface.c
@@ -242,7 +242,8 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
 
     acl_state_param_t state = {
         .transport = BT_TRANSPORT_BREDR,
-        .connection_state = CONNECTION_STATE_DISCONNECTED
+        .connection_state = CONNECTION_STATE_DISCONNECTED,
+        .hci_reason_code = reason
     };
 
     zblue_conn_get_addr(conn, &state.addr);

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -135,7 +135,8 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
     int i;
     acl_state_param_t state = {
         .transport = BT_TRANSPORT_BLE,
-        .connection_state = CONNECTION_STATE_DISCONNECTED
+        .connection_state = CONNECTION_STATE_DISCONNECTED,
+        .hci_reason_code = reason
     };
 
     BT_LOGD("%s", __func__);


### PR DESCRIPTION
This PR addresses two issues in `sal_adapter_classic_interface.c`:
- Adds a disconnect reason report in `zblue_on_disconnected` callback.
- Fixes issues that occur when BR and BLE coexist, ensuring that the BREDR framework correctly monitors and responds to BLE connection success.
