### PR TITLE
Fix crash and ARRAY_SIZE redefine issues in bt_tools and related headers

### DIFF
--- a/framework/include/bt_utils.h
+++ b/framework/include/bt_utils.h
@@ -25,6 +25,11 @@ extern "C" {
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #endif
 
+#ifdef CONFIG_BLUETOOTH_STACK_LE_ZBLUE
+#undef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#endif
+
 #define CASE_RETURN_STR(const) \
     case const:                \
         return #const;

--- a/tools/bt_tools.c
+++ b/tools/bt_tools.c
@@ -368,10 +368,6 @@ static void bt_tool_uninit(void* handle)
 #ifdef CONFIG_BLUETOOTH_PAN
     pan_command_uninit(handle);
 #endif
-#ifdef CONFIG_BLUETOOTH_GATT
-    gattc_command_uninit(handle);
-    gatts_command_uninit(handle);
-#endif
 #ifdef CONFIG_BLUETOOTH_LEAUDIO_SERVER
     leas_command_uninit(handle);
 #endif
@@ -414,6 +410,10 @@ static int enable_cmd(void* handle, int argc, char** argv)
 
 static int disable_cmd(void* handle, int argc, char** argv)
 {
+#ifdef CONFIG_BLUETOOTH_GATT
+    gattc_command_uninit(handle);
+    gatts_command_uninit(handle);
+#endif
     bt_adapter_disable(handle);
     return CMD_OK;
 }

--- a/tools/bt_tools.h
+++ b/tools/bt_tools.h
@@ -39,7 +39,15 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#endif
+
+#ifdef CONFIG_BLUETOOTH_STACK_LE_ZBLUE
+#undef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#endif
+
 #define CMD_OK (0)
 #define CMD_INVALID_PARAM (-1)
 #define CMD_INVALID_OPT (-4)


### PR DESCRIPTION
This PR addresses two issues in `bt_tools.c` and related header files:
- Fixes the crash issue when releasing resources after GATT server/client (gatts/gattc) is disabled.
- Resolves the ARRAY_SIZE redefine issue in `bttool` and `zblue` terminal.
