### PR TITLE
Update GATT client and server command with address type parameter

### DIFF
--- a/tools/gatt_client.c
+++ b/tools/gatt_client.c
@@ -108,7 +108,7 @@ static gattc_device_t* find_gattc_device(void* handle)
 static int connect_cmd(void* handle, int argc, char* argv[])
 {
     ble_addr_type_t addr_type = BT_LE_ADDR_TYPE_RANDOM;
-    if (argc < 2)
+    if (argc < 3)
         return CMD_PARAM_NOT_ENOUGH;
 
     int conn_id = atoi(argv[0]);

--- a/tools/gatt_server.c
+++ b/tools/gatt_server.c
@@ -186,7 +186,7 @@ static bt_command_t g_gatts_tables[] = {
     { "unregister", unregister_cmd, 0, "\"unregister gatt service :<id>\"" },
     { "start", start_cmd, 0, "\"start gatt service :<id>\"" },
     { "stop", stop_cmd, 0, "\"stop gatt service :<id>\"" },
-    { "connect", connect_cmd, 0, "\"connect remote device :<id><address>\"" },
+    { "connect", connect_cmd, 0, "\"connect remote device :<id><address><addr type>\"" },
     { "disconnect", disconnect_cmd, 0, "\"disconnect remote device :<id><address>\"" },
     { "notify_battery", notify_bas_cmd, 0, "\"send battery notification :<address><level>(0-100)\"" },
     { "notify_custom", notify_cus_cmd, 0, "\"send custom notification :<address><playload>\"" },
@@ -243,7 +243,8 @@ static void remove_gatts_device(gatts_device_t* device)
 
 static int connect_cmd(void* handle, int argc, char* argv[])
 {
-    if (argc < 2)
+    ble_addr_type_t addr_type = BT_LE_ADDR_TYPE_RANDOM;
+    if (argc < 3)
         return CMD_PARAM_NOT_ENOUGH;
 
     bt_address_t addr;
@@ -254,7 +255,12 @@ static int connect_cmd(void* handle, int argc, char* argv[])
     int service_id = atoi(argv[0]);
     GET_SERVICE_HANDLE(service_id, service_handle)
 
-    if (bt_gatts_connect(service_handle, &addr, BT_LE_ADDR_TYPE_UNKNOWN) != BT_STATUS_SUCCESS)
+    addr_type = atoi(argv[2]);
+    if (addr_type > BT_LE_ADDR_TYPE_ANONYMOUS || addr_type < BT_LE_ADDR_TYPE_PUBLIC) {
+        return CMD_INVALID_OPT;
+    }
+
+    if (bt_gatts_connect(service_handle, &addr, addr_type) != BT_STATUS_SUCCESS)
         return CMD_ERROR;
 
     return CMD_OK;


### PR DESCRIPTION
This PR updates `gattc` and `gatts` commands in both `gatt_client.c` and `gatt_server.c` to include the last parameter as the address type.
