### PR TITLE
fix bt_sal_gatt_server_disable call null pointer access.

### DIFF
--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -425,7 +425,7 @@ bt_status_t bt_sal_gatt_server_enable(void)
 
 bt_status_t bt_sal_gatt_server_disable(void)
 {
-    bt_gatt_cb_register(NULL);
+    bt_gatt_cb_unregister(&zblue_gatt_callbacks);
 
     return BT_STATUS_SUCCESS;
 }


### PR DESCRIPTION
fix bt_sal_gatt_server_disable call null pointer access.

bug: v/59087

**Attention:** this PR rely on 

> 'https://github.com/open-vela/external_zblue/pull/32/commits

'.