### PR TITLE
Patch for gattc discover res alloc fail due to static arrow size limts, and cleanup when discover completed.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -439,6 +439,23 @@ choice
 		bool "not support ble stack"
 endchoice
 
+config GATT_CLIENT_SERVICE_MAX
+    int "Maximum number of discovered services per connection"
+    default 20
+    depends on BLUETOOTH_GATT && BLUETOOTH_STACK_LE_ZBLUE && BT_GATT_CLIENT
+    help
+		The maximum number of GATT services that can be stored per BLE connection
+		when using the ZBLUE stack.
+
+config GATT_CLIENT_ELEMENT_MAX
+    int "Maximum number of discovered GATT attributes per connection"
+    default 200
+    depends on BLUETOOTH_GATT && BLUETOOTH_STACK_LE_ZBLUE && BT_GATT_CLIENT
+    help
+		The maximum number of GATT attribute elements (e.g., characteristics
+		and descriptors) that can be stored per BLE connection
+		when using the ZBLUE stack.
+
 config BLUETOOTH_LE_SCANNER_MAX_NUM
 	int "LE scanner max register number"
 	default 2

--- a/service/profiles/gatt/gattc_service.c
+++ b/service/profiles/gatt/gattc_service.c
@@ -217,7 +217,9 @@ static void gattc_service_delete(gattc_service_t* service)
         return;
 
     if (service->elements)
+#ifndef CONFIG_BLUETOOTH_STACK_LE_ZBLUE
         free(service->elements);
+#endif
     free(service);
 }
 

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -28,9 +28,6 @@
 #include "service_loop.h"
 #include "utils/log.h"
 
-#define CONFIG_GATT_CLIENT_SERVICE_MAX 10
-#define CONFIG_GATT_CLIENT_ELEMENT_MAX 20
-
 #ifdef CONFIG_BLUETOOTH_GATT
 #define STACK_CALL(func) zblue_##func
 
@@ -349,6 +346,9 @@ static uint8_t zblue_gatt_client_disc_chrc_callback(struct bt_conn* conn, const 
             BT_LOGD("%s, discover service finished", __func__);
             if_gattc_on_service_discovered(&instance->addr, instance->element, instance->element_size);
             if_gattc_on_discover_completed(&addr, GATT_STATUS_SUCCESS);
+            instance->element_size = 0;
+            instance->service_idx = 0;
+            instance->service_size = 0;
         }
         return BT_GATT_ITER_STOP;
     }


### PR DESCRIPTION
Patch for gattc discover res alloc fail due to static arrow size limts, and cleanup when discover completed.

bug: v/60649