### PR TITLE
bluetooth: fix not update remote name

### DIFF
--- a/service/stacks/zephyr/sal_adapter_classic_interface.c
+++ b/service/stacks/zephyr/sal_adapter_classic_interface.c
@@ -227,6 +227,7 @@ static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
     };
 
     zblue_conn_get_addr(conn, &state.addr);
+    bt_sal_get_remote_name(BT_TRANSPORT_BREDR, &state.addr);
     adapter_on_connection_state_changed(&state);
 }
 


### PR DESCRIPTION
bug: v/59741

rootcause: it would not request remote when local has bonded info, then add remote name request when acl connected.


## Summary

fix not update remote name

## Impact
remote name  request 

## Testing
local createbond and remote createbond test pass

