### PR TITLE
Optimization of power consumption in re-connect when disconnected(0x08).

### DIFF
--- a/service/src/connection_manager.c
+++ b/service/src/connection_manager.c
@@ -35,7 +35,7 @@
 
 #include "utils/log.h"
 
-#define CM_RECONNECT_INTERVAL (8000) /* reconnect Interval */
+#define CM_RECONNECT_INTERVAL (12000) /* reconnect Interval */
 #define PROFILE_CONNECT_INTERVAL (500) /* Interval between HFP and A2DP */
 #define CM_RECONNECT_TIMES ((60 * 30) / 8) /* Continuous 30-mins reconnect */
 


### PR DESCRIPTION
bug: v/62139

Increase in re-connect interval from 8s to 12s. In the current power consumption test, the power consumption is 4.67% per half hour when the pullback interval is 8s, and 3.72% when it is increased to 12s. Moreover, the reconnection interval is too long, resulting in poor user experience. Considering the power consumption and user experience, 12s is finally chosen as the reconnection interval.

