### PR TITLE
fix return miss branch to run in adapter_le_add_whitelist.

### DIFF
--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -2653,10 +2653,11 @@ bt_status_t adapter_le_add_whitelist(bt_address_t* addr)
     }
 
     adapter_unlock();
-    return bt_sal_le_add_white_list(PRIMARY_ADAPTER, addr, device_get_address_type(device));
 
     bt_addr_ba2str(addr, addr_str);
     BT_LOGD("%s, %s", __func__, addr_str);
+
+    return bt_sal_le_add_white_list(PRIMARY_ADAPTER, addr, device_get_address_type(device));
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif


### PR DESCRIPTION
fix return miss branch to run in adapter_le_add_whitelist.

bug: v/52011

Signed-off-by: zhongzhijie1 <zhongzhijie1@xiaomi.com>