### PR TITLE
bluetooth: When removing the bond, first disconnect the profile and t…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ ifneq ($(CONFIG_BLUETOOTH_STACK_BREDR_ZBLUE)$(CONFIG_BLUETOOTH_STACK_LE_ZBLUE),)
 	CSRCS += service/stacks/zephyr/sal_debug_interface.c
 	CSRCS += service/stacks/zephyr/sal_zblue.c
 	CSRCS += service/stacks/zephyr/sal_adapter_interface.c
+	CSRCS += service/stacks/zephyr/sal_connection_manager.c
 ifeq ($(CONFIG_BLUETOOTH_A2DP), y)
 	CSRCS += service/stacks/zephyr/sal_a2dp_interface.c
 endif #CONFIG_BLUETOOTH_A2DP

--- a/service/stacks/zephyr/include/sal_connection_manager.h
+++ b/service/stacks/zephyr/include/sal_connection_manager.h
@@ -1,0 +1,35 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#include "bluetooth.h"
+#include "bt_addr.h"
+#include "bt_profile.h"
+
+typedef struct {
+    bt_address_t addr;
+    uint8_t profile_id;
+} cm_data_t;
+
+cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id);
+void bt_sal_cm_profile_disconnected_callback(cm_data_t* data);
+void bt_sal_cm_acl_disconnected_callback(cm_data_t* data);
+
+void bt_sal_cm_conn_init(void);
+bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair);
+void bt_sal_cm_conn_cleanup(void);
+
+bool bt_sal_a2dp_try_disconnect_a2dp_sink(bt_controller_id_t id, bt_address_t* addr);
+bool bt_sal_a2dp_try_disconnect_a2dp_srouce(bt_controller_id_t id, bt_address_t* addr);
+bool bt_sal_avrcp_try_disconnect_avrcp_control(bt_controller_id_t id, bt_address_t* addr);

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -27,6 +27,7 @@
 #include "bt_utils.h"
 #include "sal_a2dp_sink_interface.h"
 #include "sal_a2dp_source_interface.h"
+#include "sal_connection_manager.h"
 #include "sal_interface.h"
 #include "sal_zblue.h"
 #include "utils/log.h"
@@ -833,6 +834,19 @@ static void zblue_on_stream_established(struct bt_a2dp_stream* stream)
     }
 }
 
+static void bt_sal_a2dp_notify_disconnected(struct zblue_a2dp_info_t* a2dp_info)
+{
+    if (a2dp_info->role == SEP_SRC) {
+#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP));
+#endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
+    } else { /* SEP_SNK */
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK));
+#endif /* CONFIG_BLUETOOTH_A2DP_SINK */
+    }
+}
+
 static void bt_a2dp_stream_released(struct bt_a2dp_stream* stream)
 {
     struct zblue_a2dp_info_t* a2dp_info;
@@ -866,6 +880,7 @@ static void bt_a2dp_stream_released(struct bt_a2dp_stream* stream)
 
     if (flag_is_conn_none(a2dp_info)) {
         BT_LOGI("%s, Both channel disconnected", __func__);
+        bt_sal_a2dp_notify_disconnected(a2dp_info);
         bt_list_remove_a2dp_info(a2dp_info);
     }
 }
@@ -1190,8 +1205,10 @@ static void zblue_on_disconnected(struct bt_a2dp* a2dp)
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
     }
 
-    if (flag_is_conn_none(a2dp_info))
+    if (flag_is_conn_none(a2dp_info)) {
+        bt_sal_a2dp_notify_disconnected(a2dp_info);
         bt_list_remove_a2dp_info(a2dp_info);
+    }
 }
 
 static uint8_t bt_avdtp_codec_sanity_check(uint8_t local, uint8_t config, uint8_t offset, uint8_t len, uint8_t err)
@@ -1669,6 +1686,46 @@ bt_status_t bt_sal_a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* add
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
+}
+
+bool bt_sal_a2dp_try_disconnect_a2dp_sink(bt_controller_id_t id, bt_address_t* addr)
+{
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+    struct zblue_a2dp_info_t* a2dp_info;
+
+    a2dp_info = (struct zblue_a2dp_info_t*)bt_list_find(bt_a2dp_conn, bt_a2dp_info_find_addr, addr);
+    if (!a2dp_info) {
+        BT_LOGW("%s, a2dp_info is NULL", __func__);
+        return false;
+    }
+
+    if (bt_sal_a2dp_disconnect(a2dp_info))
+        return false;
+
+    return true;
+#else
+    return false;
+#endif /* CONFIG_BLUETOOTH_A2DP_SINK */
+}
+
+bool bt_sal_a2dp_try_disconnect_a2dp_srouce(bt_controller_id_t id, bt_address_t* addr)
+{
+#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+    struct zblue_a2dp_info_t* a2dp_info;
+
+    a2dp_info = (struct zblue_a2dp_info_t*)bt_list_find(bt_a2dp_conn, bt_a2dp_info_find_addr, addr);
+    if (!a2dp_info) {
+        BT_LOGW("%s, a2dp_info is NULL", __func__);
+        return false;
+    }
+
+    if (bt_sal_a2dp_disconnect(a2dp_info))
+        return false;
+
+    return true;
+#else
+    return false;
+#endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
 }
 
 bt_status_t bt_sal_a2dp_source_start_stream(bt_controller_id_t id, bt_address_t* addr)

--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -37,6 +37,7 @@
 #include <zephyr/settings/settings.h>
 
 #include "sal_adapter_le_interface.h"
+#include "sal_connection_manager.h"
 #include "sal_interface.h"
 
 #include "utils/log.h"
@@ -241,6 +242,7 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
 
     zblue_conn_get_addr(conn, &state.addr);
     adapter_on_connection_state_changed(&state);
+    bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN));
 }
 
 static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,
@@ -494,6 +496,7 @@ bt_status_t bt_sal_init(const bt_vhal_interface* vhal)
     extern void z_sys_init(void);
     static struct bt_hfp_hf_cb hf_cb;
     z_sys_init();
+    bt_sal_cm_conn_init();
 
     bt_br_discovery_cb_register(&g_br_discovery_cb);
     bt_conn_cb_register(&g_conn_cbs);
@@ -514,6 +517,7 @@ void bt_sal_cleanup(void)
     bt_br_discovery_cb_unregister(&g_br_discovery_cb);
     bt_conn_auth_cb_register(NULL);
     bt_conn_auth_info_cb_unregister(&g_conn_auth_info_cbs);
+    bt_sal_cm_conn_cleanup();
 #endif
 }
 
@@ -1301,7 +1305,12 @@ bt_status_t bt_sal_cancel_bond(bt_controller_id_t id, bt_address_t* addr, bt_tra
 #ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
 static void STACK_CALL(remove_bond)(void* args)
 {
+    bt_status_t status;
     sal_adapter_req_t* req = args;
+
+    status = bt_sal_cm_try_disconnect_profiles(&req->addr, true);
+    if (status == BT_STATUS_SUCCESS)
+        return;
 
     SAL_CHECK(bt_br_unpair((bt_addr_t*)&req->addr), 0);
 }

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -25,6 +25,7 @@
 #include "sal_a2dp_source_interface.h"
 #include "sal_avrcp_control_interface.h"
 #include "sal_avrcp_target_interface.h"
+#include "sal_connection_manager.h"
 #include "sal_interface.h"
 #include "sal_zblue.h"
 
@@ -156,6 +157,8 @@ static void zblue_on_disconnected(struct bt_conn* conn)
     msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
+
+    bt_sal_cm_profile_disconnected_callback(cm_data_new(&bd_addr, PROFILE_AVRCP_CT));
 #endif /* CONFIG_BLUETOOTH_AVRCP_CONTROL */
 #ifdef CONFIG_BLUETOOTH_AVRCP_TARGET
     msg = avrcp_msg_new(AVRC_CONNECTION_STATE_CHANGED, &bd_addr);
@@ -399,6 +402,14 @@ bt_status_t bt_sal_avrcp_control_disconnect(bt_controller_id_t id, bt_address_t*
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif
+}
+
+bool bt_sal_avrcp_try_disconnect_avrcp_control(bt_controller_id_t id, bt_address_t* addr)
+{
+    if (bt_sal_avrcp_control_disconnect(id, addr) == BT_STATUS_SUCCESS)
+        return true;
+
+    return false;
 }
 
 bt_status_t bt_sal_avrcp_control_send_pass_through_cmd(bt_controller_id_t id,

--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -1,0 +1,249 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#include "sal_connection_manager.h"
+#include "bt_list.h"
+#include "sal_interface.h"
+#include "service_loop.h"
+
+#include <zephyr/bluetooth/conn.h>
+
+#include "utils/log.h"
+
+#define FLAG_NONE (0)
+#define FLAG_A2DP_SINK (1UL << (PROFILE_A2DP_SINK))
+#define FLAG_A2DP_SOURCE (1UL << (PROFILE_A2DP))
+#define FLAG_AVRCP_TARGET (1UL << (PROFILE_AVRCP_TG))
+#define FLAG_AVRCP_CONTROL (1UL << (PROFILE_AVRCP_CT))
+
+typedef struct {
+    bt_address_t device_addr;
+    uint32_t profile_flags;
+    bool is_unpair;
+} bt_profile_connection_manager_t;
+
+static bt_list_t* bt_sal_disconnecting_list = NULL;
+
+static void flags_set(uint32_t* profile_flags, uint32_t flags)
+{
+    *profile_flags |= flags;
+}
+
+static void flags_clear(uint32_t* profile_flags, uint32_t flags)
+{
+    *profile_flags &= ~flags;
+}
+
+static void flags_reset(uint32_t* profile_flags)
+{
+    *profile_flags = FLAG_NONE;
+}
+
+static void bt_connection_manager_destory(void* data)
+{
+    free(data);
+}
+
+static bool bt_cm_disconnect_find(void* data, void* context)
+{
+    bt_profile_connection_manager_t* manager = (bt_profile_connection_manager_t*)data;
+    if (!manager)
+        return false;
+
+    return memcmp(&manager->device_addr, context, sizeof(bt_address_t)) == 0;
+}
+
+cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id)
+{
+    cm_data_t* data = (cm_data_t*)zalloc(sizeof(cm_data_t));
+    if (!data)
+        return NULL;
+
+    if (addr != NULL)
+        memcpy(&data->addr, addr, sizeof(bt_address_t));
+
+    data->profile_id = profile_id;
+    return data;
+}
+
+void bt_sal_cm_conn_init(void)
+{
+    bt_sal_disconnecting_list = bt_list_new(bt_connection_manager_destory);
+}
+
+void cm_data_destory(cm_data_t* data)
+{
+    free(data);
+}
+
+static bt_status_t bt_try_disconnect_acl(bt_profile_connection_manager_t* manager)
+{
+    struct bt_conn* conn;
+    int ret;
+
+    if (manager->profile_flags != FLAG_NONE) {
+        BT_LOGI("%s, Disconnecting profile.", __func__);
+        return BT_STATUS_BUSY;
+    }
+
+    if (manager->is_unpair) {
+        return bt_br_unpair((bt_addr_t*)&manager->device_addr);
+    }
+
+    conn = bt_conn_lookup_addr_br((bt_addr_t*)&manager->device_addr);
+    if (conn == NULL) {
+        BT_LOGE("%s, conn not found.", __func__);
+        return BT_STATUS_FAIL;
+    }
+
+    ret = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+    bt_conn_unref(conn);
+
+    if (ret) {
+        BT_LOGE("%s, bt_conn_disconnect failed.", __func__);
+        return BT_STATUS_FAIL;
+    }
+    return BT_STATUS_SUCCESS;
+}
+
+static void bt_sal_cm_profile_disconnected(void* data)
+{
+    if (data == NULL)
+        return;
+
+    cm_data_t* cm_data = data;
+    bt_profile_connection_manager_t* manager;
+
+    if (bt_sal_disconnecting_list == NULL)
+        return;
+
+    manager = bt_list_find(bt_sal_disconnecting_list, bt_cm_disconnect_find, &cm_data->addr);
+    if (manager == NULL) {
+        BT_LOGW("%s, manager not found.", __func__);
+        return;
+    }
+
+    switch (cm_data->profile_id) {
+    case PROFILE_A2DP_SINK: {
+        flags_clear(&manager->profile_flags, FLAG_A2DP_SINK);
+        break;
+    }
+    case PROFILE_A2DP: {
+        flags_clear(&manager->profile_flags, FLAG_A2DP_SOURCE);
+        break;
+    }
+    case PROFILE_AVRCP_TG: {
+        flags_clear(&manager->profile_flags, FLAG_AVRCP_TARGET);
+        break;
+    }
+    case PROFILE_AVRCP_CT: {
+        flags_clear(&manager->profile_flags, FLAG_AVRCP_CONTROL);
+        break;
+    }
+    default:
+        break;
+    }
+
+    bt_try_disconnect_acl(manager);
+
+    cm_data_destory(cm_data);
+}
+
+static void bt_sal_cm_acl_disconnected(void* data)
+{
+    if (data == NULL)
+        return;
+
+    cm_data_t* cm_data = data;
+    bt_profile_connection_manager_t* manager;
+
+    if (bt_sal_disconnecting_list == NULL)
+        return;
+
+    manager = bt_list_find(bt_sal_disconnecting_list, bt_cm_disconnect_find, &cm_data->addr);
+    if (manager == NULL) {
+        BT_LOGW("%s, manager not found.", __func__);
+        return;
+    }
+
+    bt_list_remove(bt_sal_disconnecting_list, manager);
+
+    cm_data_destory(cm_data);
+}
+
+void bt_sal_cm_profile_disconnected_callback(cm_data_t* data)
+{
+    if (data == NULL)
+        return;
+
+    do_in_service_loop(bt_sal_cm_profile_disconnected, data);
+}
+
+void bt_sal_cm_acl_disconnected_callback(cm_data_t* data)
+{
+    if (data == NULL)
+        return;
+
+    do_in_service_loop(bt_sal_cm_acl_disconnected, data);
+}
+
+bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair)
+{
+    bt_profile_connection_manager_t* manager;
+    uint32_t flag = FLAG_NONE;
+
+    if (bt_sal_disconnecting_list == NULL)
+        return BT_STATUS_FAIL;
+
+    manager = bt_list_find(bt_sal_disconnecting_list, bt_cm_disconnect_find, addr);
+    if (manager) {
+        BT_LOGW("%s, Disconnecting.", __func__);
+        return BT_STATUS_BUSY;
+    }
+
+    manager = (bt_profile_connection_manager_t*)zalloc(sizeof(bt_profile_connection_manager_t));
+    if (!manager) {
+        BT_LOGE("%s, malloc failed", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&manager->device_addr, addr, sizeof(bt_address_t));
+    flags_reset(&manager->profile_flags);
+    manager->is_unpair = is_unpair;
+    bt_list_add_tail(bt_sal_disconnecting_list, manager);
+
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+    if (bt_sal_a2dp_try_disconnect_a2dp_sink(PRIMARY_ADAPTER, addr))
+        flag |= FLAG_A2DP_SINK;
+#endif
+#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+    if (bt_sal_a2dp_try_disconnect_a2dp_srouce(PRIMARY_ADAPTER, addr))
+        flag |= FLAG_A2DP_SOURCE;
+#endif
+#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+    if (bt_sal_avrcp_try_disconnect_avrcp_control(PRIMARY_ADAPTER, addr))
+        flag |= FLAG_AVRCP_CONTROL;
+#endif
+
+    flags_set(&manager->profile_flags, flag);
+
+    return bt_try_disconnect_acl(manager);
+}
+
+void bt_sal_cm_conn_cleanup(void)
+{
+    bt_list_free(bt_sal_disconnecting_list);
+    bt_sal_disconnecting_list = NULL;
+}


### PR DESCRIPTION
…hen disconnect the ACL.

bug: v/59903

Root cause: When removing the bond, zblue only disconnects the ACL, not the profile. As a result, the A2DP connection fails when reconnecting next time.

