### PR TITLE
gattc: allow discovery all characteristics by passing NULL UUID

### DIFF
--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -58,7 +58,6 @@ struct gatt_service {
     uint16_t start_handle;
     uint16_t end_handle;
     bt_uuid_t uuid;
-    const struct bt_uuid* uuid_ref;
 };
 
 struct gatt_instance {
@@ -497,7 +496,7 @@ static uint8_t zblue_gatt_client_disc_desc_callback(struct bt_conn* conn, const 
                     element->properties = 0;
                     element->permissions = 0;
                 }
-                zblue_gatt_client_discover_chrc(conn, service->uuid_ref, service->start_handle, service->end_handle);
+                zblue_gatt_client_discover_chrc(conn, NULL, service->start_handle, service->end_handle);
             } else {
 #ifdef CONFIG_GATT_CLIENT_LOG
                 BT_LOGD("%s, all services discovered", __func__);
@@ -558,7 +557,7 @@ static uint8_t zblue_gatt_client_disc_desc_callback(struct bt_conn* conn, const 
                     element->properties = 0;
                     element->permissions = 0;
                 }
-                zblue_gatt_client_discover_chrc(conn, service->uuid_ref, service->start_handle, service->end_handle);
+                zblue_gatt_client_discover_chrc(conn, NULL, service->start_handle, service->end_handle);
             } else {
 #ifdef CONFIG_GATT_CLIENT_LOG
                 BT_LOGD("%s, all services discovered", __func__);
@@ -666,7 +665,7 @@ static uint8_t zblue_gatt_client_disc_chrc_callback(struct bt_conn* conn, const 
                     element->type = BT_GATT_DISCOVER_PRIMARY;
                     element->properties = 0;
                     element->permissions = 0;
-                    zblue_gatt_client_discover_chrc(conn, service->uuid_ref, service->start_handle, service->end_handle);
+                    zblue_gatt_client_discover_chrc(conn, NULL, service->start_handle, service->end_handle);
                 }
             } else {
 #ifdef CONFIG_GATT_CLIENT_LOG
@@ -742,7 +741,7 @@ static uint8_t zblue_gatt_client_disc_service_callback(struct bt_conn* conn, con
             element->permissions = 0;
         }
 
-        zblue_gatt_client_discover_chrc(conn, service->uuid_ref, service->start_handle, service->end_handle);
+        zblue_gatt_client_discover_chrc(conn, NULL, service->start_handle, service->end_handle);
         return BT_GATT_ITER_STOP;
     }
 
@@ -760,7 +759,6 @@ static uint8_t zblue_gatt_client_disc_service_callback(struct bt_conn* conn, con
     data = attr->user_data;
     service->start_handle = attr->handle;
     service->end_handle = data->end_handle;
-    service->uuid_ref = data->uuid;
     zblue_uuid1_to_uuid2(data->uuid, &service->uuid);
 
     return BT_GATT_ITER_CONTINUE;


### PR DESCRIPTION
    gattc: allow discovery all characteristics by passing NULL UUID
    
    bug: v/64571
    
    When a UUID pointer is specified, discovery will only return characteristics within the start and end handle range that match the UUID.
    
    However, for "discover all characteristics" operations, we need to return all characteristics in the given range without filtering by UUID.
    This change allows passing a NULL UUID to disable UUID filtering.
    
    Signed-off-by: zhongzhijie1 <zhongzhijie1@xiaomi.com>