### PR TITLE
pm: fix SPP always holding ACTIVE and blocking other profiles from entering SNIFF.

### DIFF
--- a/service/src/power_manager.c
+++ b/service/src/power_manager.c
@@ -247,7 +247,7 @@ static const bt_pm_spec_table_t g_pm_spec[] = {
     { (BT_PM_SNIFF), /* allow sniff */
         (0), /* the SSR entry */
         {
-            { BT_PM_ACTIVE, 0 }, /* conn open */
+            { BT_PM_NO_ACTION, 0 }, /* conn open */
             { BT_PM_NO_PREF, 0 }, /* conn close */
             { BT_PM_ACTIVE, 0 }, /* app open */
             { BT_PM_NO_ACTION, 0 }, /* app close */


### PR DESCRIPTION
pm: fix SPP always holding ACTIVE and blocking other profiles from entering SNIFF.

bug: v/65520

Fix an issue where SPP connections that are never used remain in ACTIVE state,
causing the power manager to always select ACTIVE mode due to SPP's higher
priority over other BR profiles like GATT-over-BR/EDR.

Now idle or unused SPP won't block other profiles from falling back to SNIFF.

Signed-off-by: zhongzhijie1 <zhongzhijie1@xiaomi.com>