### PR TITLE
bluetooth-media: fix problem that a2dp can not be stopped

### DIFF
--- a/service/profiles/a2dp/a2dp_source_audio.h
+++ b/service/profiles/a2dp/a2dp_source_audio.h
@@ -52,6 +52,7 @@ typedef struct {
     void (*cleanup)(void);
     void (*send_frames)(uint16_t header_reserve, uint64_t timestamp);
     int (*get_interval_ms)(void);
+    int (*get_min_frame_size)(void);
 } a2dp_source_stream_interface_t;
 
 void a2dp_source_audio_init(bool offloading);

--- a/service/profiles/a2dp/source/a2dp_source_aac_stream.c
+++ b/service/profiles/a2dp/source/a2dp_source_aac_stream.c
@@ -221,12 +221,18 @@ int a2dp_source_aac_interval_ms(void)
     return a2dp_aac_encoder_interval_ms;
 }
 
+int a2dp_source_aac_get_min_frame_size(void)
+{
+    return 1; // AAC does not have a minimum frame size.
+}
+
 static const a2dp_source_stream_interface_t a2dp_source_stream_aac = {
     a2dp_source_aac_stream_init,
     a2dp_source_aac_stream_reset,
     NULL,
     a2dp_source_aac_send_frames,
     a2dp_source_aac_interval_ms,
+    a2dp_source_aac_get_min_frame_size,
 };
 
 const a2dp_source_stream_interface_t* get_a2dp_source_aac_stream_interface(void)

--- a/service/profiles/a2dp/source/a2dp_source_audio.c
+++ b/service/profiles/a2dp/source/a2dp_source_audio.c
@@ -249,7 +249,7 @@ static void a2dp_source_audio_handle_timer(service_timer_t* timer, void* arg)
         return;
 
     /* Handle stream underflow */
-    if (circbuf_used(&stream->stream_pool) == 0) {
+    if (circbuf_used(&stream->stream_pool) < stream->stream_interface->get_min_frame_size()) {
         if (!stream->underflow.ticks)
             BT_LOGD("a2dp src send frame, underflowed");
 

--- a/service/profiles/a2dp/source/a2dp_source_sbc_stream.c
+++ b/service/profiles/a2dp/source/a2dp_source_sbc_stream.c
@@ -243,12 +243,18 @@ static int a2dp_source_sbc_interval_ms(void)
     return A2DP_SBC_ENCODER_INTERVAL_MS;
 }
 
+static int a2dp_source_sbc_get_min_frame_size(void)
+{
+    return sbc_stream.frames_len;
+}
+
 static const a2dp_source_stream_interface_t a2dp_source_stream_sbc = {
     a2dp_source_sbc_stream_init,
     a2dp_source_sbc_stream_reset,
     NULL,
     a2dp_source_sbc_send_frames,
     a2dp_source_sbc_interval_ms,
+    a2dp_source_sbc_get_min_frame_size,
 };
 
 const a2dp_source_stream_interface_t* get_a2dp_source_sbc_stream_interface(void)


### PR DESCRIPTION
Rootcause: After media sending A2DP_CTRL_CMD_STOP, still remain some bytes in circlebuf and too short to send, result in a2dp can not go to stop.