### PR TITLE
Fix service matching logic by adding UUID comparison

### DIFF
--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -582,14 +582,15 @@ static struct bt_gatt_service* get_primary_service_from_element(gatt_element_t* 
         return NULL;
     }
 
-    struct bt_gatt_attr attr = BT_GATT_PRIMARY_SERVICE(&u.uuid);
-
     for (srv = server_svcs; srv < server_svcs + CONFIG_GATT_SERVER_MAX_SERVICES; srv++) {
         if (!srv->attrs) {
             continue;
         }
-        if (!bt_uuid_cmp(srv->attrs[0].uuid, attr.uuid)) {
-            return srv;
+        if (!bt_uuid_cmp(srv->attrs[0].uuid, BT_UUID_GATT_PRIMARY)) {
+            const struct bt_uuid* svc_uuid = (const struct bt_uuid*)srv->attrs[0].user_data;
+            if (svc_uuid && !bt_uuid_cmp(svc_uuid, &u.uuid)) {
+                return srv;
+            }
         }
     }
 


### PR DESCRIPTION
bug: v/65358

Previously, the matching logic only checked if the attribute type was BT_UUID_GATT_PRIMARY, without verifying the actual service UUID. This could lead to incorrect matches when multiple services shared the same attribute type.

This commit updates the logic to also compare the service UUID stored in attrs.user_data to ensure accurate service identification.