### PR TITLE
bluetooth: Fix compilation errors when calling Bluetooth in C++ files.

### DIFF
--- a/framework/api/bt_adapter.c
+++ b/framework/api/bt_adapter.c
@@ -169,9 +169,9 @@ bt_status_t BTSYMBOLS(bt_adapter_set_le_address)(bt_instance_t* ins, bt_address_
     return adapter_set_le_address(addr);
 }
 
-bt_status_t BTSYMBOLS(bt_adapter_set_le_identity_address)(bt_instance_t* ins, bt_address_t* addr, bool public)
+bt_status_t BTSYMBOLS(bt_adapter_set_le_identity_address)(bt_instance_t* ins, bt_address_t* addr, bool is_public)
 {
-    return adapter_set_le_identity_address(addr, public);
+    return adapter_set_le_identity_address(addr, is_public);
 }
 
 bt_status_t BTSYMBOLS(bt_adapter_set_le_appearance)(bt_instance_t* ins, uint16_t appearance)

--- a/framework/binder/bt_adapter.c
+++ b/framework/binder/bt_adapter.c
@@ -186,9 +186,9 @@ bt_status_t bt_adapter_set_le_address(bt_instance_t* ins, bt_address_t* addr)
     return BpBtAdapter_setLeAddress((BpBtAdapter*)ins->adapter_proxy, addr);
 }
 
-bt_status_t bt_adapter_set_le_identity_address(bt_instance_t* ins, bt_address_t* addr, bool public)
+bt_status_t bt_adapter_set_le_identity_address(bt_instance_t* ins, bt_address_t* addr, bool is_public)
 {
-    return BpBtAdapter_setLeIdentityAddress((BpBtAdapter*)ins->adapter_proxy, addr, public);
+    return BpBtAdapter_setLeIdentityAddress((BpBtAdapter*)ins->adapter_proxy, addr, is_public);
 }
 
 bt_status_t bt_adapter_set_le_appearance(bt_instance_t* ins, uint16_t appearance)

--- a/framework/include/bt_adapter.h
+++ b/framework/include/bt_adapter.h
@@ -1201,7 +1201,7 @@ bt_status_t bt_adapter_set_le_io_capability_async(bt_instance_t* ins, uint32_t l
 bt_status_t bt_adapter_get_le_io_capability_async(bt_instance_t* ins, bt_u32_cb_t get_le_ioc_cb, void* userdata);
 bt_status_t bt_adapter_get_le_address_async(bt_instance_t* ins, bt_adapter_get_le_address_cb_t cb, void* userdata);
 bt_status_t bt_adapter_set_le_address_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
-bt_status_t bt_adapter_set_le_identity_address_async(bt_instance_t* ins, bt_address_t* addr, bool public, bt_status_cb_t cb, void* userdata);
+bt_status_t bt_adapter_set_le_identity_address_async(bt_instance_t* ins, bt_address_t* addr, bool is_public, bt_status_cb_t cb, void* userdata);
 bt_status_t bt_adapter_set_le_appearance_async(bt_instance_t* ins, uint16_t appearance, bt_status_cb_t cb, void* userdata);
 bt_status_t bt_adapter_get_le_appearance_async(bt_instance_t* ins, bt_u16_cb_t cb, void* userdata);
 bt_status_t bt_adapter_le_enable_key_derivation_async(bt_instance_t* ins,

--- a/framework/socket/async/bt_adapter_async.c
+++ b/framework/socket/async/bt_adapter_async.c
@@ -494,14 +494,14 @@ bt_status_t bt_adapter_set_le_address_async(bt_instance_t* ins, bt_address_t* ad
     return bt_socket_client_send_with_reply(ins, &packet, BT_ADAPTER_SET_LE_ADDRESS, adapter_status_reply, (void*)cb, userdata);
 }
 
-bt_status_t bt_adapter_set_le_identity_address_async(bt_instance_t* ins, bt_address_t* addr, bool public, bt_status_cb_t cb, void* userdata)
+bt_status_t bt_adapter_set_le_identity_address_async(bt_instance_t* ins, bt_address_t* addr, bool is_public, bt_status_cb_t cb, void* userdata)
 {
     bt_message_packet_t packet;
 
     BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
 
     memcpy(&packet.adpt_pl._bt_adapter_set_le_identity_address.addr, addr, sizeof(*addr));
-    packet.adpt_pl._bt_adapter_set_le_identity_address.pub = public;
+    packet.adpt_pl._bt_adapter_set_le_identity_address.pub = is_public;
 
     return bt_socket_client_send_with_reply(ins, &packet, BT_ADAPTER_SET_LE_IDENTITY_ADDRESS, adapter_status_reply, (void*)cb, userdata);
 }

--- a/framework/socket/bt_adapter.c
+++ b/framework/socket/bt_adapter.c
@@ -527,7 +527,7 @@ bt_status_t bt_adapter_set_le_address(bt_instance_t* ins, bt_address_t* addr)
     return packet.adpt_r.status;
 }
 
-bt_status_t bt_adapter_set_le_identity_address(bt_instance_t* ins, bt_address_t* addr, bool public)
+bt_status_t bt_adapter_set_le_identity_address(bt_instance_t* ins, bt_address_t* addr, bool is_public)
 {
     bt_message_packet_t packet;
     bt_status_t status;
@@ -535,7 +535,7 @@ bt_status_t bt_adapter_set_le_identity_address(bt_instance_t* ins, bt_address_t*
     BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
 
     memcpy(&packet.adpt_pl._bt_adapter_set_le_identity_address.addr, addr, sizeof(*addr));
-    packet.adpt_pl._bt_adapter_set_le_identity_address.pub = public;
+    packet.adpt_pl._bt_adapter_set_le_identity_address.pub = is_public;
     status = bt_socket_client_sendrecv(ins, &packet, BT_ADAPTER_SET_LE_IDENTITY_ADDRESS);
     if (status != BT_STATUS_SUCCESS) {
         return status;

--- a/service/ipc/binder/include/adapter_proxy.h
+++ b/service/ipc/binder/include/adapter_proxy.h
@@ -60,7 +60,7 @@ bt_status_t BpBtAdapter_SetLeIOCapability(BpBtAdapter* bpBinder, uint32_t le_io_
 uint32_t BpBtAdapter_getLeIOCapability(BpBtAdapter* bpBinder);
 bt_status_t BpBtAdapter_getLeAddress(BpBtAdapter* bpBinder, bt_address_t* addr, ble_addr_type_t* type);
 bt_status_t BpBtAdapter_setLeAddress(BpBtAdapter* bpBinder, bt_address_t* addr);
-bt_status_t BpBtAdapter_setLeIdentityAddress(BpBtAdapter* bpBinder, bt_address_t* addr, bool public);
+bt_status_t BpBtAdapter_setLeIdentityAddress(BpBtAdapter* bpBinder, bt_address_t* addr, bool is_public);
 bt_status_t BpBtAdapter_setLeAppearance(BpBtAdapter* bpBinder, uint16_t appearance);
 uint16_t BpBtAdapter_getLeAppearance(BpBtAdapter* bpBinder);
 bt_status_t BpBtAdapter_getBondedDevices(BpBtAdapter* bpBinder, bt_address_t** addr, int* num, bt_allocator_t allocator);

--- a/service/ipc/binder/src/adapter_proxy.c
+++ b/service/ipc/binder/src/adapter_proxy.c
@@ -658,7 +658,7 @@ bt_status_t BpBtAdapter_setLeAddress(BpBtAdapter* bpBinder, bt_address_t* addr)
     return status;
 }
 
-bt_status_t BpBtAdapter_setLeIdentityAddress(BpBtAdapter* bpBinder, bt_address_t* addr, bool public)
+bt_status_t BpBtAdapter_setLeIdentityAddress(BpBtAdapter* bpBinder, bt_address_t* addr, bool is_public)
 {
     binder_status_t stat = STATUS_OK;
     AParcel *parcelIn, *parcelOut;
@@ -673,7 +673,7 @@ bt_status_t BpBtAdapter_setLeIdentityAddress(BpBtAdapter* bpBinder, bt_address_t
     if (stat != STATUS_OK)
         return BT_STATUS_IPC_ERROR;
 
-    stat = AParcel_writeBool(parcelIn, public);
+    stat = AParcel_writeBool(parcelIn, is_public);
     if (stat != STATUS_OK)
         return BT_STATUS_IPC_ERROR;
 

--- a/service/src/adapter_internel.h
+++ b/service/src/adapter_internel.h
@@ -291,7 +291,7 @@ bt_status_t adapter_set_le_io_capability(uint32_t le_io_cap);
 uint32_t adapter_get_le_io_capability(void);
 bt_status_t adapter_get_le_address(bt_address_t* addr, ble_addr_type_t* type);
 bt_status_t adapter_set_le_address(bt_address_t* addr);
-bt_status_t adapter_set_le_identity_address(bt_address_t* addr, bool public);
+bt_status_t adapter_set_le_identity_address(bt_address_t* addr, bool is_public);
 bt_status_t adapter_set_le_appearance(uint16_t appearance);
 uint16_t adapter_get_le_appearance(void);
 bt_status_t adapter_get_bonded_devices(bt_transport_t transport, bt_address_t** addr, int* size, bt_allocator_t allocator);

--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -2154,11 +2154,11 @@ bt_status_t adapter_set_le_address(bt_address_t* addr)
 #endif
 }
 
-bt_status_t adapter_set_le_identity_address(bt_address_t* addr, bool public)
+bt_status_t adapter_set_le_identity_address(bt_address_t* addr, bool is_public)
 {
 #ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
     // adapter_service_t *adapter = &g_adapter_service;
-    if (public)
+    if (is_public)
         bt_sal_le_set_public_identity(PRIMARY_ADAPTER, addr);
     else
         bt_sal_le_set_static_identity(PRIMARY_ADAPTER, addr);


### PR DESCRIPTION
VELAPLATFO-67883

Root Cause: When a C++ file references a Bluetooth file, compilation errors occur due to the Bluetooth file using C++ keywords.

Change-Id: Ic05bdca488d6a0dc64175314c64f3995d8dd1b96

