### PR TITLE
Bluetooth: Fix problem that remote uuids error when reboot bluetooth

### DIFF
--- a/service/src/device.c
+++ b/service/src/device.c
@@ -430,6 +430,7 @@ static void device_get_remote_uuids(bt_device_t* device, remote_device_propertie
             0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
     };
 
+    memset(prop->uuids, 0, sizeof(prop->uuids));
     if (device->remote.uuids.uuid_cnt == 0) {
         BT_LOGD("%s, No uuids found", __func__);
         return;


### PR DESCRIPTION
bug: v/58506

Root Cause: when device has no 128 uuid, When saving the remote UUID, if the remote device does not have a 128-byte UUID, it will cause storage errors.

Change-Id: Ibcfaa116ba02659fb7419077238bb94507d25692

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

