### PR TITLE
Fix stability issues and improve LE connection/GATT event reporting

### DIFF
--- a/service/stacks/include/sal_adapter_le_interface.h
+++ b/service/stacks/include/sal_adapter_le_interface.h
@@ -25,6 +25,9 @@
 #include "power_manager.h"
 #include "vhal/bt_vhal.h"
 
+#define GATT_ROLE_SERVER (1UL << 0)
+#define GATT_ROLE_CLIENT (1UL << 1)
+
 bt_status_t bt_sal_le_init(const bt_vhal_interface* vhal);
 void bt_sal_le_cleanup(void);
 bt_status_t bt_sal_le_enable(bt_controller_id_t id);
@@ -54,6 +57,8 @@ bt_status_t bt_sal_get_identity_addr(bt_address_t* addr, bt_address_t* id_addr);
 
 struct bt_conn* get_le_conn_from_addr(bt_address_t* addr);
 bt_status_t get_le_addr_from_conn(struct bt_conn* conn, bt_address_t* addr);
+bt_status_t le_conn_set_role(bt_address_t* addr, uint8_t flag);
+bt_status_t le_conn_remove(bt_address_t* addr);
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 ble_phy_type_t le_phy_convert_from_stack(uint8_t mode);

--- a/service/stacks/include/sal_gatt_client_interface.h
+++ b/service/stacks/include/sal_gatt_client_interface.h
@@ -44,5 +44,6 @@ bt_status_t bt_sal_gatt_client_read_phy(bt_controller_id_t id, bt_address_t* add
 bt_status_t bt_sal_gatt_client_set_phy(bt_controller_id_t id, bt_address_t* addr, ble_phy_type_t tx_phy, ble_phy_type_t rx_phy);
 void bt_sal_gatt_client_connection_updated_callback(bt_controller_id_t id, bt_address_t* addr, uint16_t connection_interval, uint16_t peripheral_latency,
     uint16_t supervision_timeout, bt_status_t status);
+void bt_sal_gatt_client_connection_state_changed_callback(bt_controller_id_t id, bt_address_t* addr, profile_connection_state_t state);
 
 #endif /* __SAL_GATT_CLIENT_INTERFACE_H__ */

--- a/service/stacks/include/sal_gatt_server_interface.h
+++ b/service/stacks/include/sal_gatt_server_interface.h
@@ -48,5 +48,6 @@ bt_status_t bt_sal_gatt_server_read_phy(bt_controller_id_t id, bt_address_t* add
 bt_status_t bt_sal_gatt_server_set_phy(bt_controller_id_t id, bt_address_t* addr, ble_phy_type_t tx_phy, ble_phy_type_t rx_phy);
 void bt_sal_gatt_server_connection_changed_callback(bt_address_t* addr, uint16_t connection_interval, uint16_t peripheral_latency,
     uint16_t supervision_timeout);
+void bt_sal_gatt_server_connection_state_changed_callback(bt_controller_id_t id, bt_address_t* addr, profile_connection_state_t state);
 
 #endif

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -19,6 +19,8 @@
 #include "adapter_internel.h"
 #include "gattc_service.h"
 #include "gatts_service.h"
+#include "sal_gatt_client_interface.h"
+#include "sal_gatt_server_interface.h"
 #include "sal_interface.h"
 #include "service_loop.h"
 
@@ -207,11 +209,11 @@ static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
     adapter_on_connection_state_changed(&state);
 #ifdef CONFIG_BLUETOOTH_GATT
     if (role & GATT_ROLE_SERVER) {
-        if_gatts_on_connection_state_changed(&state.addr, profile_state);
+        bt_sal_gatt_server_connection_state_changed_callback(PRIMARY_ADAPTER, &state.addr, profile_state);
     }
 
     if (role & GATT_ROLE_CLIENT) {
-        if_gattc_on_connection_state_changed(&state.addr, profile_state);
+        bt_sal_gatt_client_connection_state_changed_callback(PRIMARY_ADAPTER, &state.addr, profile_state);
     }
 #endif
 }
@@ -286,11 +288,11 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
     adapter_on_connection_state_changed(&state);
 #ifdef CONFIG_BLUETOOTH_GATT
     if (role & GATT_ROLE_SERVER) {
-        if_gatts_on_connection_state_changed(&state.addr, PROFILE_STATE_DISCONNECTED);
+        bt_sal_gatt_server_connection_state_changed_callback(PRIMARY_ADAPTER, &state.addr, PROFILE_STATE_DISCONNECTED);
     }
 
     if (role & GATT_ROLE_CLIENT) {
-        if_gattc_on_connection_state_changed(&state.addr, PROFILE_STATE_DISCONNECTED);
+        bt_sal_gatt_client_connection_state_changed_callback(PRIMARY_ADAPTER, &state.addr, PROFILE_STATE_DISCONNECTED);
     }
 #endif
 }
@@ -632,9 +634,9 @@ bt_status_t le_conn_set_role(bt_address_t* addr, uint8_t flag)
 
         if (info->conn) {
             if ((info->role & GATT_ROLE_CLIENT) && flag == GATT_ROLE_SERVER) {
-                if_gatts_on_connection_state_changed(&info->addr, PROFILE_STATE_CONNECTED);
+                bt_sal_gatt_server_connection_state_changed_callback(PRIMARY_ADAPTER, &info->addr, PROFILE_STATE_CONNECTED);
             } else if ((info->role & GATT_ROLE_SERVER) && flag == GATT_ROLE_CLIENT) {
-                if_gattc_on_connection_state_changed(&info->addr, PROFILE_STATE_CONNECTED);
+                bt_sal_gatt_client_connection_state_changed_callback(PRIMARY_ADAPTER, &info->addr, PROFILE_STATE_CONNECTED);
             }
             return BT_STATUS_DONE;
         }

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -48,6 +48,12 @@ typedef union {
 } sal_adapter_args_t;
 
 typedef struct {
+    struct bt_conn* conn;
+    bt_address_t addr;
+    uint8_t role; // e.g., GATT_ROLE_SERVER
+} le_conn_info_t;
+
+typedef struct {
     bt_controller_id_t id;
     bt_address_t addr;
     ble_addr_type_t addr_type;
@@ -84,6 +90,9 @@ static enum bt_security_err zblue_on_pairing_accept(struct bt_conn* conn, const 
 static void zblue_register_callback(void);
 static void zblue_unregister_callback(void);
 
+static le_conn_info_t* le_conn_add(const bt_address_t* addr);
+static le_conn_info_t* le_conn_find(const bt_address_t* addr);
+
 static struct bt_conn_cb g_conn_cbs = {
     .connected = zblue_on_connected,
     .disconnected = zblue_on_disconnected,
@@ -101,7 +110,7 @@ static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
 };
 
 static struct bt_conn_auth_cb g_conn_auth_cbs;
-static struct bt_conn* g_acl_conns[CONFIG_BT_MAX_CONN];
+static le_conn_info_t g_le_conn_info[CONFIG_BT_MAX_CONN];
 
 static uint8_t zblue_convert_addr_type(ble_addr_type_t addr_type)
 {
@@ -136,8 +145,9 @@ static uint8_t zblue_convert_addr_type(ble_addr_type_t addr_type)
 
 static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
 {
+    uint8_t role;
     struct bt_conn_info info;
-    int i;
+    le_conn_info_t* slot;
     profile_connection_state_t profile_state = PROFILE_STATE_CONNECTED;
 
     bt_address_t le_addr;
@@ -172,23 +182,35 @@ static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
         if (info.role == BT_HCI_ROLE_CENTRAL) {
             bt_conn_unref(conn);
         }
-
-        goto report;
     }
 
-    for (i = 0; i < ARRAY_SIZE(g_acl_conns); i++) {
-        if (!g_acl_conns[i]) {
-            g_acl_conns[i] = conn;
-            break;
+    slot = le_conn_add(&state.addr);
+
+    if (!slot) {
+        return;
+    }
+
+    if (!err) {
+        slot->conn = conn;
+        if (!slot->role) {
+            slot->role |= GATT_ROLE_SERVER;
         }
     }
 
-report:
+    role = slot->role;
+
+    if (err || (slot->conn == NULL)) {
+        le_conn_remove(&state.addr);
+        slot = NULL;
+    }
+
     adapter_on_connection_state_changed(&state);
 #ifdef CONFIG_BLUETOOTH_GATT
-    if (info.role == BT_HCI_ROLE_PERIPHERAL) {
+    if (role & GATT_ROLE_SERVER) {
         if_gatts_on_connection_state_changed(&state.addr, profile_state);
-    } else if (info.role == BT_HCI_ROLE_CENTRAL) {
+    }
+
+    if (role & GATT_ROLE_CLIENT) {
         if_gattc_on_connection_state_changed(&state.addr, profile_state);
     }
 #endif
@@ -220,7 +242,8 @@ bt_status_t bt_sal_get_identity_addr(bt_address_t* addr, bt_address_t* id_addr)
 static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
 {
     struct bt_conn_info info;
-    int i;
+    le_conn_info_t* slot;
+    uint8_t role;
     bt_address_t le_addr;
     bt_address_t* remote_addr;
     acl_state_param_t state = {
@@ -240,13 +263,6 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
         bt_conn_unref(conn);
     }
 
-    for (i = 0; i < ARRAY_SIZE(g_acl_conns); i++) {
-        if (g_acl_conns[i] == conn) {
-            g_acl_conns[i] = NULL;
-            break;
-        }
-    }
-
     memcpy(&le_addr, info.le.dst->a.val, sizeof(le_addr.addr));
     remote_addr = adapter_get_le_remote_address(&le_addr, info.le.dst->type);
     if (remote_addr) {
@@ -257,11 +273,23 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
         state.addr_type = info.le.dst->type;
     }
 
+    slot = le_conn_find(&state.addr);
+
+    if (!slot) {
+        return;
+    }
+
+    role = slot->role;
+    le_conn_remove(&state.addr);
+    slot = NULL;
+
     adapter_on_connection_state_changed(&state);
 #ifdef CONFIG_BLUETOOTH_GATT
-    if (info.role == BT_HCI_ROLE_PERIPHERAL) {
+    if (role & GATT_ROLE_SERVER) {
         if_gatts_on_connection_state_changed(&state.addr, PROFILE_STATE_DISCONNECTED);
-    } else if (info.role == BT_HCI_ROLE_CENTRAL) {
+    }
+
+    if (role & GATT_ROLE_CLIENT) {
         if_gattc_on_connection_state_changed(&state.addr, PROFILE_STATE_DISCONNECTED);
     }
 #endif
@@ -533,17 +561,11 @@ static bt_status_t sal_send_req(sal_adapter_req_t* req)
     return BT_STATUS_SUCCESS;
 }
 
-struct bt_conn* get_le_conn_from_addr(bt_address_t* addr)
+static le_conn_info_t* le_conn_find(const bt_address_t* addr)
 {
-    for (int i = 0; i < ARRAY_SIZE(g_acl_conns); i++) {
-        if (g_acl_conns[i]) {
-            struct bt_conn_info info;
-
-            bt_conn_get_info(g_acl_conns[i], &info);
-            if (!memcmp(info.le.dst->a.val, addr, sizeof(bt_address_t))
-                || !memcmp(info.le.remote->a.val, addr, sizeof(bt_address_t))) {
-                return g_acl_conns[i];
-            }
+    for (int i = 0; i < CONFIG_BT_MAX_CONN; i++) {
+        if (!bt_addr_compare(&g_le_conn_info[i].addr, addr)) {
+            return &g_le_conn_info[i];
         }
     }
 
@@ -551,17 +573,94 @@ struct bt_conn* get_le_conn_from_addr(bt_address_t* addr)
 }
 
 bt_status_t get_le_addr_from_conn(struct bt_conn* conn, bt_address_t* addr)
-
 {
-    struct bt_conn_info info;
+    for (int i = 0; i < CONFIG_BT_MAX_CONN; i++) {
+        if (g_le_conn_info[i].conn == conn) {
+            memcpy(addr, &g_le_conn_info[i].addr, sizeof(bt_address_t));
+            return BT_STATUS_SUCCESS;
+        }
+    }
 
-    if (bt_conn_get_info(conn, &info)) {
-        BT_LOGE("%s, get conn info fail", __func__);
+    BT_LOGD("%s, conn not found", __func__);
+    return BT_STATUS_FAIL;
+}
+
+struct bt_conn* get_le_conn_from_addr(bt_address_t* addr)
+{
+    le_conn_info_t* info;
+
+    info = le_conn_find(addr);
+
+    return info ? info->conn : NULL;
+}
+
+static le_conn_info_t* le_conn_add(const bt_address_t* addr)
+{
+    le_conn_info_t* info = le_conn_find(addr);
+    if (info) {
+        return info;
+    }
+
+    for (int i = 0; i < CONFIG_BT_MAX_CONN; i++) {
+        if (!g_le_conn_info[i].conn && bt_addr_is_empty(&g_le_conn_info[i].addr)) {
+            memcpy(g_le_conn_info[i].addr.addr, addr->addr, BT_ADDR_LENGTH);
+            return &g_le_conn_info[i];
+        }
+    }
+
+    BT_LOGE("%s, no free entry", __func__);
+    return NULL;
+}
+
+bt_status_t le_conn_set_role(bt_address_t* addr, uint8_t flag)
+{
+    le_conn_info_t* info;
+
+    if (bt_addr_is_empty(addr) || !flag) {
+        BT_LOGE("%s, invalid addr or flag", __func__);
         return BT_STATUS_FAIL;
     }
 
-    memcpy(addr, info.le.dst->a.val, sizeof(bt_address_t));
-    return BT_STATUS_SUCCESS;
+    info = le_conn_find(addr);
+    if (info) {
+        if (info->role & flag) {
+            BT_LOGD("conn flag already set, skip");
+            return BT_STATUS_DONE;
+        }
+
+        info->role |= flag;
+
+        if (info->conn) {
+            if ((info->role & GATT_ROLE_CLIENT) && flag == GATT_ROLE_SERVER) {
+                if_gatts_on_connection_state_changed(&info->addr, PROFILE_STATE_CONNECTED);
+            } else if ((info->role & GATT_ROLE_SERVER) && flag == GATT_ROLE_CLIENT) {
+                if_gattc_on_connection_state_changed(&info->addr, PROFILE_STATE_CONNECTED);
+            }
+            return BT_STATUS_DONE;
+        }
+
+        return BT_STATUS_SUCCESS;
+    }
+
+    info = le_conn_add(addr);
+    if (info) {
+        info->role = flag;
+        return BT_STATUS_SUCCESS;
+    }
+
+    return BT_STATUS_FAIL;
+}
+
+bt_status_t le_conn_remove(bt_address_t* addr)
+{
+    le_conn_info_t* info = le_conn_find(addr);
+    if (info) {
+        memset(info, 0, sizeof(*info));
+        return BT_STATUS_SUCCESS;
+    }
+
+    BT_LOGD("%s, addr not found", __func__);
+    return BT_STATUS_FAIL;
 }
 
 bt_status_t bt_sal_le_init(const bt_vhal_interface* vhal)

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -472,7 +472,7 @@ static void zblue_register_callback(void)
 
 static void zblue_unregister_callback(void)
 {
-    bt_conn_cb_register(NULL);
+    bt_conn_cb_unregister(&g_conn_cbs);
     bt_conn_le_auth_cb_register(NULL);
     bt_conn_auth_info_cb_unregister(&g_conn_auth_info_cbs);
 }

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -576,6 +576,10 @@ static le_conn_info_t* le_conn_find(const bt_address_t* addr)
 
 bt_status_t get_le_addr_from_conn(struct bt_conn* conn, bt_address_t* addr)
 {
+    struct bt_conn_info info;
+    bt_address_t* resolved_addr;
+
+    /* Check local connection info table first */
     for (int i = 0; i < CONFIG_BT_MAX_CONN; i++) {
         if (g_le_conn_info[i].conn == conn) {
             memcpy(addr, &g_le_conn_info[i].addr, sizeof(bt_address_t));
@@ -583,8 +587,32 @@ bt_status_t get_le_addr_from_conn(struct bt_conn* conn, bt_address_t* addr)
         }
     }
 
-    BT_LOGD("%s, conn not found", __func__);
-    return BT_STATUS_FAIL;
+    /*
+     * Fallback: g_le_conn_info may not be initialized yet if certain events
+     * (e.g. MTU exchange) occur before the connected callback.
+     * Use Zephyr's internal connection info as a fallback source.
+     */
+    if (bt_conn_get_info(conn, &info)) {
+        BT_LOGE("%s: failed to get conn info", __func__);
+        return BT_STATUS_FAIL;
+    }
+
+    if (info.type != BT_CONN_TYPE_LE || !info.le.dst) {
+        BT_LOGE("%s: invalid LE connection or dst is null", __func__);
+        return BT_STATUS_FAIL;
+    }
+
+    /* Attempt to resolve RPA to identity address */
+    resolved_addr = adapter_get_le_remote_address((bt_address_t*)info.le.dst->a.val,
+        info.le.dst->type);
+    if (resolved_addr) {
+        memcpy(addr, resolved_addr, sizeof(bt_address_t));
+        BT_LOGD("%s: fallback to bt_conn_info and resolved RPA to identity address", __func__);
+    } else {
+        memcpy(addr, info.le.dst->a.val, sizeof(bt_address_t));
+    }
+
+    return BT_STATUS_SUCCESS;
 }
 
 struct bt_conn* get_le_conn_from_addr(bt_address_t* addr)

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -1163,10 +1163,11 @@ bt_status_t bt_sal_gatt_client_register_notifications(bt_controller_id_t id, bt_
 static void zblue_gattc_mtu_updated_callback(struct bt_conn* conn, uint16_t tx, uint16_t rx)
 {
     bt_address_t addr;
+    uint16_t att_mtu = MIN(tx, rx);
+    uint16_t att_payload = (att_mtu >= 23) ? (att_mtu - 3) : 20;
 
-    BT_LOGD("Updated MTU: TX: %d RX: %d bytes, MIN: %d", tx, rx, MIN(tx, rx));
     get_le_addr_from_conn(conn, &addr);
-    if_gattc_on_mtu_changed(&addr, rx - 3, BT_STATUS_SUCCESS);
+    if_gattc_on_mtu_changed(&addr, att_payload, BT_STATUS_SUCCESS);
 }
 
 static void gatt_exchange_mtu_func(struct bt_conn* conn, uint8_t err,

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -403,8 +403,6 @@ static void STACK_CALL(conn_disconnect)(void* args)
     struct bt_conn* conn;
     int err;
 
-    gatt_free_instance(&req->addr);
-
     conn = get_le_conn_from_addr(&req->addr);
     if (!conn) {
         BT_LOGE("%s, conn null", __func__);
@@ -1329,4 +1327,13 @@ void bt_sal_gatt_client_connection_updated_callback(bt_controller_id_t id, bt_ad
 {
     /* Notthing to do, implement within zblue_on_param_updated*/
 }
+
+void bt_sal_gatt_client_connection_state_changed_callback(bt_controller_id_t id, bt_address_t* addr, profile_connection_state_t state)
+{
+    if (state == PROFILE_STATE_DISCONNECTED) {
+        gatt_free_instance(addr);
+    }
+    if_gattc_on_connection_state_changed(addr, state);
+}
+
 #endif /* CONFIG_BLUETOOTH_GATT */

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -341,11 +341,16 @@ static void STACK_CALL(conn_connect)(void* args)
     struct bt_conn* conn = NULL;
     int err;
 
+    if (le_conn_set_role(&req->addr, GATT_ROLE_CLIENT) != BT_STATUS_SUCCESS) {
+        return;
+    }
+
     address.type = req->addr_type;
     memcpy(&address.a, &req->addr, sizeof(address.a));
 
     err = bt_conn_le_create(&address, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT, &conn);
     if (err) {
+        le_conn_remove(&req->addr);
         BT_LOGE("%s, failed to create connection (%d)", __func__, err);
         return;
     }

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -1051,4 +1051,9 @@ bt_status_t bt_sal_gatt_server_set_phy(bt_controller_id_t id, bt_address_t* addr
     return bt_sal_le_set_phy(id, addr, tx_phy, rx_phy);
 }
 
+void bt_sal_gatt_server_connection_state_changed_callback(bt_controller_id_t id, bt_address_t* addr, profile_connection_state_t state)
+{
+    if_gatts_on_connection_state_changed(addr, state);
+}
+
 #endif /* CONFIG_BLUETOOTH_GATT*/

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -22,8 +22,6 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/uuid.h>
 
-#include "sal_gatt_server_interface.h"
-
 #include "bluetooth.h"
 #include "bt_list.h"
 #include "bt_status.h"
@@ -151,14 +149,6 @@ static uint8_t svc_count;
 static struct bt_gatt_service server_svcs[CONFIG_GATT_SERVER_MAX_SERVICES];
 static struct bt_gatt_attr server_db[CONFIG_GATT_SERVER_MAX_ATTRIBUTES];
 
-static void zblue_conn_get_addr(struct bt_conn* conn, bt_address_t* addr)
-{
-    struct bt_conn_info info;
-
-    bt_conn_get_info(conn, &info);
-    bt_addr_set(addr, info.le.dst->a.val);
-}
-
 static ssize_t read_value(struct bt_conn* conn, const struct bt_gatt_attr* attr,
     void* buf, uint16_t len, uint16_t offset)
 {
@@ -189,7 +179,7 @@ static ssize_t write_value(struct bt_conn* conn, const struct bt_gatt_attr* attr
     memcpy(user_data->data + offset, buf, len);
     user_data->len = offset + len;
 
-    zblue_conn_get_addr(conn, &addr);
+    get_le_addr_from_conn(conn, &addr);
 
     if_gatts_on_received_element_write_request(&addr, GATT_OPS_WRITE_REQUEST, element->handle, (uint8_t*)buf, offset, len);
 
@@ -397,7 +387,7 @@ static ssize_t bt_sal_on_ccc_written(struct bt_conn* conn, const struct bt_gatt_
 
     value = ccc->cfg[index].value;
 
-    zblue_conn_get_addr(conn, &addr);
+    get_le_addr_from_conn(conn, &addr);
 
     if_gatts_on_received_element_write_request(&addr, GATT_OPS_WRITE_REQUEST,
         element->handle, (uint8_t*)&value, 0, sizeof(value));
@@ -517,7 +507,7 @@ static void zblue_gatts_mtu_updated_callback(struct bt_conn* conn, uint16_t tx, 
     bt_address_t addr;
 
     BT_LOGD("Updated MTU: TX: %d RX: %d bytes, MIN: %d", tx, rx, MIN(tx, rx));
-    zblue_conn_get_addr(conn, &addr);
+    get_le_addr_from_conn(conn, &addr);
     if_gatts_on_mtu_changed(&addr, tx - 3);
 }
 
@@ -871,7 +861,7 @@ static void send_notification_result(struct bt_conn* conn, void* user_data)
         return;
     }
 
-    zblue_conn_get_addr(conn, &addr);
+    get_le_addr_from_conn(conn, &addr);
 
     if_gatts_on_notification_sent(&addr, element->handle, GATT_STATUS_SUCCESS);
 }
@@ -958,7 +948,7 @@ static void send_indication_result(struct bt_conn* conn, struct bt_gatt_indicate
         return;
     }
 
-    zblue_conn_get_addr(conn, &addr);
+    get_le_addr_from_conn(conn, &addr);
 
     if (err) {
         BT_LOGE("%s, send indication failed for handle:0x%04x", __func__, element->handle);

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -685,11 +685,16 @@ static void STACK_CALL(conn_connect)(void* args)
     struct bt_conn* conn = NULL;
     int err;
 
+    if (le_conn_set_role(&req->addr, GATT_ROLE_SERVER) != BT_STATUS_SUCCESS) {
+        return;
+    }
+
     address.type = req->addr_type;
     memcpy(&address.a, &req->addr, sizeof(address.a));
 
     err = bt_conn_le_create(&address, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT, &conn);
     if (err) {
+        le_conn_remove(&req->addr);
         BT_LOGE("%s, failed to create connection (%d)", __func__, err);
         return;
     }

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -505,10 +505,11 @@ static void set_value(uint16_t attr_id, uint8_t* val, uint16_t len)
 static void zblue_gatts_mtu_updated_callback(struct bt_conn* conn, uint16_t tx, uint16_t rx)
 {
     bt_address_t addr;
+    uint16_t att_mtu = MIN(tx, rx);
+    uint16_t att_payload = (att_mtu >= 23) ? (att_mtu - 3) : 20;
 
-    BT_LOGD("Updated MTU: TX: %d RX: %d bytes, MIN: %d", tx, rx, MIN(tx, rx));
     get_le_addr_from_conn(conn, &addr);
-    if_gatts_on_mtu_changed(&addr, tx - 3);
+    if_gatts_on_mtu_changed(&addr, att_payload);
 }
 
 static struct bt_gatt_cb zblue_gatt_callbacks = {

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -79,6 +79,7 @@ struct add_descriptor {
     uint8_t permissions;
     uint8_t properties;
     const struct bt_uuid* uuid;
+    gatt_element_t* element;
 };
 
 struct add_characteristic {
@@ -94,6 +95,19 @@ struct add_characteristic {
 struct gatt_value {
     void* context;
     uint8_t flags[1];
+    uint16_t len;
+    uint8_t data[0];
+};
+
+struct gatt_ccc_wrapper {
+    /**
+     * NOTE: `ccc` must be the first member!
+     * This ensures `&wrapper->ccc == (void *)wrapper`,
+     * so that we can safely cast between `_bt_gatt_ccc*` and `gatt_ccc_wrapper*`
+     * or free it through `user_data` pointer.
+     */
+    struct _bt_gatt_ccc ccc;
+    gatt_element_t* element;
     uint16_t len;
     uint8_t data[0];
 };
@@ -203,14 +217,18 @@ static struct bt_gatt_attr* gatt_db_add(const struct bt_gatt_attr* pattern, size
     }
     memcpy((void*)attr->uuid, &u->uuid, uuid_size);
 
-    attr->user_data = malloc(user_data_len);
-    if (!attr->user_data) {
-        BT_LOGE("%s, user_data malloc failed", __func__);
-        free((void*)attr->uuid);
-        attr->uuid = NULL;
-        return NULL;
+    if (user_data_len == 0) {
+        attr->user_data = pattern->user_data;
+    } else {
+        attr->user_data = malloc(user_data_len);
+        if (!attr->user_data) {
+            BT_LOGE("%s, user_data malloc failed", __func__);
+            free((void*)attr->uuid);
+            attr->uuid = NULL;
+            return NULL;
+        }
+        memcpy(attr->user_data, pattern->user_data, user_data_len);
     }
-    memcpy(attr->user_data, pattern->user_data, user_data_len);
 
     BT_LOGD("user_data 0x%p, user_data_len: %zu", attr->user_data, user_data_len);
 
@@ -350,15 +368,49 @@ static void add_characteristic(gatt_element_t* element)
     }
 }
 
-static void ccc_cfg_changed(const struct bt_gatt_attr* attr, uint16_t value)
+static ssize_t bt_sal_on_ccc_written(struct bt_conn* conn, const struct bt_gatt_attr* attr,
+    const void* buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
-    BT_LOGD("%s, value:%d", __func__, value);
+    bt_address_t addr;
+    struct gatt_ccc_wrapper* wrapper;
+    struct _bt_gatt_ccc* ccc;
+    gatt_element_t* element;
+    uint16_t value;
+    ssize_t ret;
+    uint8_t index;
+
+    ret = bt_gatt_attr_write_ccc(conn, attr, buf, len, offset, flags);
+
+    if (ret < 0)
+        return ret;
+
+    ccc = (struct _bt_gatt_ccc*)attr->user_data;
+
+    wrapper = CONTAINER_OF(ccc, struct gatt_ccc_wrapper, ccc);
+    element = wrapper->element;
+
+    index = bt_conn_index(conn);
+    if (index >= CONFIG_BT_MAX_CONN) {
+        BT_LOGE("%s, invalid conn index = %u", __func__, index);
+        return -EINVAL;
+    }
+
+    value = ccc->cfg[index].value;
+
+    zblue_conn_get_addr(conn, &addr);
+
+    if_gatts_on_received_element_write_request(&addr, GATT_OPS_WRITE_REQUEST,
+        element->handle, (uint8_t*)&value, 0, sizeof(value));
+
+    return ret;
 }
 
 static int alloc_descriptor(const struct bt_gatt_attr* attr, struct add_descriptor* desc)
 {
     struct bt_gatt_attr* attr_desc;
+    struct gatt_ccc_wrapper* ccc_wrapper;
     struct bt_gatt_chrc* chrc = attr->user_data;
+    struct _bt_gatt_ccc* ccc;
 
     if (bt_uuid_cmp(desc->uuid, BT_UUID_GATT_CCC)) {
         BT_LOGE("%s uuid not match", __func__);
@@ -370,8 +422,27 @@ static int alloc_descriptor(const struct bt_gatt_attr* attr, struct add_descript
         return -EINVAL;
     }
 
-    attr_desc = gatt_db_add(&(struct bt_gatt_attr)BT_GATT_CCC(ccc_cfg_changed, desc->permissions & GATT_PERM_MASK), sizeof(struct _bt_gatt_ccc));
+    /* This memory is freed in remove_service() via attr->user_data */
+    ccc_wrapper = zalloc(sizeof(struct gatt_ccc_wrapper));
+    if (!ccc_wrapper) {
+        BT_LOGE("%s, wrapper alloc failed", __func__);
+        return -ENOMEM;
+    }
+
+    ccc = &ccc_wrapper->ccc;
+    ccc_wrapper->element = desc->element;
+
+    attr_desc = gatt_db_add(
+        &(struct bt_gatt_attr) {
+            .uuid = BT_UUID_GATT_CCC,
+            .perm = desc->permissions & GATT_PERM_MASK,
+            .read = bt_gatt_attr_read_ccc,
+            .write = bt_sal_on_ccc_written,
+            .user_data = ccc },
+        0);
+
     if (!attr_desc) {
+        free(ccc_wrapper);
         BT_LOGE("%s attr_desc null", __func__);
         return -EINVAL;
     }
@@ -411,6 +482,7 @@ static void add_descriptor(gatt_element_t* element)
     desc.permissions = element->permissions;
     desc.properties = element->properties;
     desc.uuid = &u.uuid;
+    desc.element = element;
 
     chrc = get_base_chrc(LAST_DB_ATTR);
     if (!chrc) {


### PR DESCRIPTION
**PR Title:**
`Bluetooth: Fix stability issues and improve LE connection/GATT event reporting`

---

**Summary:**
This PR addresses multiple stability and correctness issues in the LE connection and GATT layers, and improves profile-level event reporting.

---

**Changes:**

1. **Fix crash when unregistering connection callbacks**

   * Replaced `bt_conn_cb_register(NULL)` with `bt_conn_cb_unregister()` to avoid NULL pointer dereference when accessing `cb->node`.
   * **Bug:** v/66402

2. **Improve LE connection event reporting with profile tracking**

   * Extended `g_acl` to `g_le_conn_info` with connection role flags.
   * Added slot matching based on address to associate events with the correct profile (e.g., GATTC, GATTS).
   * Introduced helper APIs:

     * `le_conn_find()` – find connection info by address
     * `le_conn_add()` – allocate a new entry
     * `le_conn_remove()` – free an entry
     * `le_conn_set_role()` – set role flags and trigger profile callbacks
   * **Bug:** v/64642

3. **Add client address reporting in CCC written callback**

   * Modified `bt_sal_on_ccc_written()` to retrieve and pass the client address to upper layers.
   * Enables application-level tracking of CCC configuration changes per client.
   * **Bug:** v/66330

4. **Remove redundant `zblue_conn_get_addr`**

   * Cleaned up unused helper function.
   * **Bug:** v/66768

5. **Fix CCC callback crash on disconnect**

   * Deferred instance cleanup until `zblue_on_disconnected()` is called.
   * Prevents CCC callbacks from accessing freed memory during Zephyr’s internal disconnect process.
   * **Bug:** v/66753

6. **Fix incorrect MTU reporting**

   * Always report the effective MTU as `min(tx, rx)` to the upper layer.
   * Prevents tools (e.g., bttool) from sending oversized packets that exceed local MTU capability.
   * **Bug:** v/66910

7. **Fix connection address resolution in early MTU callback**

   * Added fallback to `bt_conn_get_info()` if `g_le_conn_info` is uninitialized.
   * Resolved RPA addresses to identity addresses using `adapter_get_le_remote_address()`.
   * **Bug:** v/67775

---

**Impact:**

* Eliminates multiple crash scenarios during callback execution.
* Ensures accurate MTU and address reporting.
* Improves profile-specific LE connection event handling.
* Adds per-client CCC change tracking for better application behavior.
