### PR TITLE
manager: Fix missing unlocks to avoid potential deadlocks.

### DIFF
--- a/service/src/manager_service.c
+++ b/service/src/manager_service.c
@@ -64,16 +64,21 @@ static bt_instance_impl_t* manager_find_instance(const char* name, pid_t pid)
 
         size_t name_len = strlen(name);
         name_len = name_len > BT_INST_HOST_NAME_LEN ? BT_INST_HOST_NAME_LEN : name_len;
-        if (strncmp((char*)ins->host_name, name, name_len) == 0 && ins->pid == pid)
+        if (strncmp((char*)ins->host_name, name, name_len) == 0 && ins->pid == pid) {
+            uv_mutex_unlock(&g_mutex);
             return ins;
+        }
     }
 
+    uv_mutex_unlock(&g_mutex);
     return NULL;
 }
 
 static bt_instance_impl_t* manager_find_async_instance(const char* name, pid_t pid)
 {
     struct list_node* node;
+
+    uv_mutex_lock(&g_mutex);
 
     list_for_every(&g_instances, node)
     {
@@ -169,18 +174,23 @@ bt_status_t manager_create_async_instance(uint64_t handle, uint32_t type,
     if (ins)
         return BT_STATUS_FAIL;
 
+    uv_mutex_lock(&g_mutex);
+
     if (g_instance_id == NULL)
         g_instance_id = index_allocator_create(10);
 
     ins = malloc(sizeof(bt_instance_impl_t));
-    if (!ins)
+    if (!ins) {
+        uv_mutex_unlock(&g_mutex);
         return BT_STATUS_NOMEM;
+    }
 
     ins->pid = pid;
     ins->uid = uid;
     int idx = index_alloc(g_instance_id);
     if (idx < 0) {
         free(ins);
+        uv_mutex_unlock(&g_mutex);
         return BT_STATUS_NO_RESOURCES;
     }
     *app_id = idx;
@@ -190,6 +200,8 @@ bt_status_t manager_create_async_instance(uint64_t handle, uint32_t type,
     snprintf((char*)ins->host_name, BT_INST_HOST_NAME_LEN, "%s", name);
 
     list_add_tail(&g_instances, &ins->node);
+
+    uv_mutex_unlock(&g_mutex);
 
     return BT_STATUS_SUCCESS;
 }


### PR DESCRIPTION
bug: v/66226

Fix missing uv_mutex_unlock calls in functions like manager_find_async_instance, etc.. the global mutex g_mutex was not properly unlocked before returning, leading to potential deadlocks or thread stalls.

