### PR TITLE
Add SPP Proxy connection states to handle different events

### DIFF
--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -219,7 +219,6 @@ int euv_pipe_read_stop(euv_pipe_t* handle)
     }
 
     if (handle->cli_pipe.data) {
-        BT_LOGD("%s, free cli_pipe's reader ", __func__);
         free(handle->cli_pipe.data);
         handle->cli_pipe.data = NULL;
     }

--- a/framework/include/bt_spp.h
+++ b/framework/include/bt_spp.h
@@ -53,6 +53,8 @@ extern "C" {
 typedef enum {
     SPP_PROXY_STATE_CONNECTED,
     SPP_PROXY_STATE_DISCONNECTED,
+    SPP_PROXY_STATE_CONNECTING,
+    SPP_PROXY_STATE_CLOSING,
 } spp_proxy_state_t;
 
 /**

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -624,6 +624,12 @@ static void spp_proxy_connection_callback(euv_pipe_t* handle, int status, void* 
         return;
     }
 
+    BT_LOGD("%s, connection port %" PRIu16 ", proxy state: %d", __func__, device->conn_id, device->proxy_state);
+    if (device->proxy_state == SPP_PROXY_STATE_CLOSING) {
+        spp_device_cleanup(device, false);
+        return;
+    }
+
     BT_LOGD("spp proxy connected, status: %d", status);
     device->proxy_state = SPP_PROXY_STATE_CONNECTED;
     spp_rx_buffer_send(device);
@@ -754,12 +760,19 @@ static void spp_on_connection_state_chaneged(bt_address_t* addr, uint16_t port,
             return;
         }
 
+        device->proxy_state = SPP_PROXY_STATE_CONNECTING; // waiting for proxy connection
         spp_notify_proxy_state(device, SPP_PROXY_STATE_CONNECTED);
         bt_pm_conn_open(PROFILE_SPP, &device->addr);
     } else if (state == PROFILE_STATE_DISCONNECTED) {
         bt_pm_conn_close(PROFILE_SPP, &device->addr);
         spp_notify_proxy_state(device, SPP_PROXY_STATE_DISCONNECTED);
-        spp_device_cleanup(device, false);
+        BT_LOGD("spp proxy state: %d", device->proxy_state);
+        if (device->proxy_state == SPP_PROXY_STATE_CONNECTING) {
+            BT_LOGI("spp proxy is waiting for connection, connection port: %" PRIu16 " release later", device->conn_id);
+            device->proxy_state = SPP_PROXY_STATE_CLOSING;
+        } else {
+            spp_device_cleanup(device, false);
+        }
     }
 }
 

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -387,7 +387,7 @@ static spp_device_t* spp_device_open(spp_device_t* device)
         goto error;
     }
 
-    BT_LOGD("spp proxy open success, name: %s", device->proxy_name);
+    BT_LOGD("spp proxy open success, name: %s, handle: %p", device->proxy_name, device->handle);
     return device;
 
 error:
@@ -1184,6 +1184,7 @@ static bt_status_t spp_connect(void* handle, bt_address_t* addr, int16_t scn, bt
     // todo: start connect timer, release device if timeout
     *port = device->conn_id;
     device->state = PROFILE_STATE_CONNECTING;
+    BT_LOGD("%s, return port: %" PRIu16, __func__, device->conn_id);
 
 unlock_exit:
     pthread_mutex_unlock(&g_spp_handle.spp_lock);

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -156,6 +156,7 @@ static int do_spp_write(spp_device_t* device, uint8_t* buffer, uint16_t length);
 static void spp_server_cleanup_devices(spp_server_t* server);
 static void spp_proxy_connection_callback(euv_pipe_t* handle, int status, void* user_data);
 static bt_status_t spp_unregister_app(void** remote, void* handle);
+static bool spp_rx_buffer_empty(spp_device_t* device);
 
 /****************************************************************************
  * Private Data
@@ -413,6 +414,19 @@ static void spp_device_close(spp_device_t* device)
         BT_LOGD("%s, free cache buf, length: %d", __func__, device->cache_buf.length);
         free(device->cache_buf.buffer_head);
         device->cache_buf.length = 0;
+    }
+
+    if (!spp_rx_buffer_empty(device)) {
+        BT_LOGD("%s, free rx cache list, list_length: %zu", __func__, list_length(&device->rx_list));
+        struct list_node *node, *tmp;
+
+        list_for_every_safe(&device->rx_list, node, tmp)
+        {
+            /* The memory pointed to by buf->buffer must be released prior to the protocol stack
+            reporting status. */
+            list_delete(node);
+            free(node);
+        }
     }
 
     device->app_handle = NULL;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

Since the SPP Proxy's state is closely tied to the SPP connection status, but socket-related operations make it impossible for the two to maintain full synchronization. When an SPP disconnection occurs, the server-side Proxy will be closed directly. If bt_client subsequently attempts to connect to the Proxy via Socket, there may be a thread blocking risk. Therefore, adding two states - SPP_PROXY_STATE_CONNECTING and SPP_PROXY_STATE_CLOSING - better describes the Proxy's status under different scenarios, enabling differentiated operations for handling disconnection events. In such risk scenarios, the SPP Proxy will enter the SPP_PROXY_STATE_CLOSING state to delay the closure of the Proxy, ensuring synchronization between the Proxy connection and SPP connection.

## Impact

SPP connection

## Testing
SPP connection

