### PR TITLE
SAL: Remove unused HFP HF callback registration in zblue_register_cal…

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -502,14 +502,10 @@ static struct bt_br_discovery_cb g_br_discovery_cb = {
 
 static void zblue_register_callback(void)
 {
-    static struct bt_hfp_hf_cb hf_cb;
-
     bt_br_discovery_cb_register(&g_br_discovery_cb);
     bt_conn_cb_register(&g_conn_cbs);
     bt_conn_auth_cb_register(&g_conn_auth_cbs);
     bt_conn_auth_info_cb_register(&g_conn_auth_info_cbs);
-    /* HFP HF for test */
-    bt_hfp_hf_register(&hf_cb);
 }
 
 static void zblue_unregister_callback(void)


### PR DESCRIPTION
…lback.

bug: v/67405

Rootcause: The registration of HF here is only limited to maintaining the ACL connection during the connection debugging process with the phone, and HF services should not actually be registered here.