### PR TITLE
[bluetooth][profile][a2dp]: Fix the build error when LOCAL mode is enabled

### DIFF
--- a/feature/src/feature_bluetooth_callback.c
+++ b/feature/src/feature_bluetooth_callback.c
@@ -732,7 +732,7 @@ void feature_bluetooth_callback_init(bt_instance_t* bt_ins)
 
     bt_ins->adapter_cookie = bt_adapter_register_callback(bt_ins, &g_adapter_cbs);
 
-#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK && CONFIG_BLUETOOTH_FRAMEWORK_SOCKET_IPC
     features_callbacks->feature_a2dp_sink_callbacks = bt_list_new(free_feature_bluetooth_a2dp_sink_node);
     bt_ins->a2dp_sink_cookie = bt_a2dp_sink_register_callbacks(bt_ins, &a2dp_sink_cbs);
 #endif
@@ -760,7 +760,7 @@ void feature_bluetooth_callback_uninit(bt_instance_t* bt_ins)
     }
 
     bt_adapter_unregister_callback(bt_ins, bt_ins->adapter_cookie);
-#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK && CONFIG_BLUETOOTH_FRAMEWORK_SOCKET_IPC
     bt_a2dp_sink_unregister_callbacks(bt_ins, bt_ins->a2dp_sink_cookie);
 #endif
 

--- a/service/ipc/socket/src/bt_socket_a2dp_sink.c
+++ b/service/ipc/socket/src/bt_socket_a2dp_sink.c
@@ -138,6 +138,7 @@ void bt_socket_server_a2dp_sink_process(service_poll_t* poll,
         break;
     }
     case BT_A2DP_SINK_REGISTER_CALLBACKS: {
+#ifdef CONFIG_BLUETOOTH_FRAMEWORK_SOCKET_IPC
         if (ins->a2dp_sink_cookie == NULL) {
             a2dp_sink_interface_t* profile = get_profile_service();
             ins->a2dp_sink_cookie = profile->register_callbacks(ins, &g_a2dp_sink_cbs);
@@ -149,9 +150,11 @@ void bt_socket_server_a2dp_sink_process(service_poll_t* poll,
         } else {
             packet->a2dp_sink_r.status = BT_STATUS_SUCCESS;
         }
+#endif
         break;
     }
     case BT_A2DP_SINK_UNREGISTER_CALLBACKS: {
+#ifdef CONFIG_BLUETOOTH_FRAMEWORK_SOCKET_IPC
         if (ins->a2dp_sink_cookie) {
             a2dp_sink_interface_t* profile = get_profile_service();
             if (profile->unregister_callbacks(NULL, ins->a2dp_sink_cookie)) {
@@ -163,6 +166,7 @@ void bt_socket_server_a2dp_sink_process(service_poll_t* poll,
         } else {
             packet->a2dp_sink_r.status = BT_STATUS_NOT_FOUND;
         }
+#endif
         break;
     }
     default:

--- a/service/profiles/a2dp/sink/a2dp_sink_service.c
+++ b/service/profiles/a2dp/sink/a2dp_sink_service.c
@@ -304,12 +304,13 @@ static void a2dp_sink_process_msg(profile_msg_t* msg)
         break;
     case PROFILE_EVT_REMOTE_DETACH: {
         bt_instance_t* ins = msg->data.data;
-
+#ifdef CONFIG_BLUETOOTH_FRAMEWORK_SOCKET_IPC
         if (ins->a2dp_sink_cookie) {
             BT_LOGD("%s PROFILE_EVT_REMOTE_DETACH", __func__);
             a2dp_sink_unregister_callbacks(NULL, ins->a2dp_sink_cookie);
             ins->a2dp_sink_cookie = NULL;
         }
+#endif
         break;
     }
     default:


### PR DESCRIPTION
[bluetooth][profile][a2dp]: Fix the build error when LOCAL mode is enabled

rootcase : It uses definitions intended for IPC mode, which do not exist in LOCAL mode.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

