### PR TITLE
A2DP: add sample codes for A2DP Sink.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,9 @@ CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/service/st
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/service/vendor
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/dfx
 
+CSRCS += sample_code/a2dpsnk/*.c
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/sample_code/a2dpsnk
+
 ifeq ($(CONFIG_BLUETOOTH_SERVICE), y)
 ifneq ($(CONFIG_BLUETOOTH_STACK_BREDR_BLUELET)$(CONFIG_BLUETOOTH_STACK_LE_BLUELET),)
 	CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/service/stacks/bluelet/include
@@ -433,6 +436,8 @@ ifeq ($(CONFIG_BLUETOOTH_TOOLS), y)
 	MAINSRC  += tools/bt_tools.c
 	PROGNAME += adapter_test
 	MAINSRC  += tests/adapter_test.c
+	PROGNAME += z
+	MAINSRC  += sample_code/a2dpsnk/a2dpsnk.c
 endif
 
 ifeq ($(CONFIG_BLUETOOTH_UPGRADE), y)

--- a/sample_code/a2dpsnk/a2dpsnk.c
+++ b/sample_code/a2dpsnk/a2dpsnk.c
@@ -1,0 +1,348 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "a2dpsnk.h"
+#include "bt_a2dp_sink.h"
+
+static app_demo_t app_demo = { 0 };
+
+/**
+ * @brief peer device address.
+ *
+ * @note The address is in reverse order. If the address of the peer device
+ *       is 11:22:33:44:55:66, it should be written as 66:55:44:33:22:11 here.
+ */
+static const bt_address_t test_remote_addr = {
+    { 0x66, 0x55, 0x44, 0x33, 0x22, 0x11 }
+};
+
+/**
+ * @brief Block the current thread and wait to be woken up.
+ */
+static void wait_awakened(void)
+{
+    sem_wait(&app_demo.sem);
+}
+
+/**
+ * @brief Wake up the main thread of the app.
+ */
+static void wakeup_thread(void)
+{
+    sem_post(&app_demo.sem);
+}
+
+bool app_demo_a2dpsnk_get_acl_active(void)
+{
+    return app_demo.is_acl_active;
+}
+
+void app_demo_a2dpsnk_set_acl_active(bool active)
+{
+    app_demo.is_acl_active = active;
+}
+
+/**
+ * @brief Add a node to the message queue.
+ */
+static void app_list_add_tail(struct list_node* node)
+{
+    pthread_mutex_lock(&app_demo.mutex);
+    list_add_tail(&app_demo.message_queue, node);
+    pthread_mutex_unlock(&app_demo.mutex);
+    wakeup_thread();
+}
+
+/**
+ * @brief Remove the head node of the message queue.
+ */
+static node_t* app_list_remove_head(void)
+{
+    node_t* node_data;
+
+    wait_awakened();
+
+    pthread_mutex_lock(&app_demo.mutex);
+    struct list_node* node = list_remove_head(&app_demo.message_queue);
+    pthread_mutex_unlock(&app_demo.mutex);
+    if (node == NULL) {
+        return NULL;
+    }
+
+    node_data = list_entry(node, node_t, node);
+    return node_data;
+}
+
+/**
+ * @brief Set io capability to NOINPUTNOOUTPUT.
+ */
+static void app_bt_set_io_capability(bt_io_capability_t capability)
+{
+    node_t* node = (node_t*)malloc(sizeof(node_t));
+    if (node == NULL) {
+        LOGE("malloc failed.");
+        return;
+    }
+
+    node->data.msg_type = APP_BT_GAP_SET_IO_CAPABILITY;
+    node->data.message._bt_adapter_set_io_capability.cap = capability;
+    app_list_add_tail(&node->node);
+}
+
+static void bt_gap_init(void)
+{
+    app_bt_set_io_capability(BT_IO_CAPABILITY_NOINPUTNOOUTPUT);
+}
+
+/**
+ * @brief Discover nearby Bluetooth devices.
+ */
+static void app_create_conn(void)
+{
+    app_demo.is_acl_active = false; 
+    // check if another connection is pending
+    if (app_demo.is_acl_active) {
+        LOGI("Repeated attempt for %02X:%02X:%02X:%02X:%02X:%02X", 
+             test_remote_addr.addr[5], test_remote_addr.addr[4],
+             test_remote_addr.addr[3], test_remote_addr.addr[2],
+             test_remote_addr.addr[1], test_remote_addr.addr[0]);
+        return;
+    } 
+    node_t* node = (node_t*)malloc(sizeof(node_t));
+    if (node == NULL) {
+        LOGE("malloc failed.");
+        return;
+    }
+
+    node->data.msg_type = APP_BT_GAP_CREATE_CONN;
+    app_demo.is_acl_active = true;
+    LOGI("%s[%d]: addr: %02x:%02x:%02x:%02x:%02x:%02x\n",__func__,__LINE__,
+        test_remote_addr.addr[5],test_remote_addr.addr[4],test_remote_addr.addr[3],
+        test_remote_addr.addr[2],test_remote_addr.addr[1],test_remote_addr.addr[0]);
+    memcpy(&node->data.message._bt_device_create_conn.addr, &test_remote_addr, sizeof(bt_address_t));
+    
+    app_list_add_tail(&node->node);
+}
+
+/**
+ * @brief  Adapter state change callback.
+ *
+ * This function is executed in the bt_client thread, the app needs to handle the callback
+ * in another thread.
+ */
+static void gap_adapter_state_changed_callback(void* cookie, bt_adapter_state_t state)
+{
+    if (state != BT_ADAPTER_STATE_ON && state != BT_ADAPTER_STATE_OFF)
+        return;
+
+    if (state == BT_ADAPTER_STATE_ON) {
+        bt_gap_init();
+        app_create_conn();
+    } else if (state == BT_ADAPTER_STATE_OFF) {
+        app_demo.running = 0;
+    }
+}
+
+/**
+ * @brief  Connection state change callback.
+ *
+ * This function is executed in the bt_client thread, the app needs to handle the callback
+ * in another thread.
+ */
+// 
+static void gap_connection_state_changed_callback(void* cookie, bt_address_t* addr, bt_transport_t transport, connection_state_t state)
+{
+
+    node_t* node = (node_t*)malloc(sizeof(node_t));
+    if (node == NULL) {
+        LOGE("malloc failed.");
+        return;
+    }
+
+    node->data.msg_type = APP_BT_A2DP_CREATE_CONN;
+    node->data.message._on_connection_state_changed.state = state;
+    memcpy(&node->data.message._on_connection_state_changed.addr, addr, sizeof(bt_address_t));
+    app_list_add_tail(&node->node);
+}
+
+// gap callback
+const static adapter_callbacks_t app_gap_cbs = {
+    .on_adapter_state_changed = gap_adapter_state_changed_callback,
+    .on_connection_state_changed = gap_connection_state_changed_callback,
+};
+
+static void app_a2dp_connection_state_callback(void* cookie, bt_address_t* addr,
+    profile_connection_state_t state)
+{
+    LOGI("A2DP connection state: %d", state);
+}
+
+static void app_a2dp_audio_state_callback(void* cookie, bt_address_t* addr,
+    a2dp_audio_state_t state)
+{
+    LOGI("A2DP audio state: %d", state);
+}
+
+// a2dp callback
+const static a2dp_sink_callbacks_t app_a2dp_cbs = {
+    .connection_state_cb = app_a2dp_connection_state_callback,
+    .audio_state_cb = app_a2dp_audio_state_callback,
+};
+
+/**
+ * @brief  Initialize semaphore, mutex, message queue.
+ *
+ * @note   Semaphores are used to control the number of concurrently executing threads.
+ *         A semaphore has a counter, and threads need to acquire the semaphore before
+ *         accessing a resource. When the semaphore counter is greater than 0, the thread
+ *         can continue executing. When the semaphore counter is equal to 0, the thread
+ *         needs to wait for other threads to release resources so that the semaphore
+ *         counter can increase before it can continue executing.
+ *
+ * @note   Mutex locks are used to protect shared resources, ensuring that only one thread
+ *         can access the shared resource at a time, while other threads must wait until
+ *         the lock is released by that thread before they can access it.
+ *
+ * @note   Message queues is used to store events to be processed. When calling the Bluetooth
+ *         synchronization interface, receiving and sending Bluetooth messages from the Bluetooth
+ *         module should be done in different threads.
+ */
+static void app_demo_init(void)
+{
+    memset(&app_demo, 0x00, sizeof(app_demo_t));
+
+    app_demo.running = 1;
+    sem_init(&app_demo.sem, 0, 1);
+    pthread_mutex_init(&app_demo.mutex, NULL);
+    list_initialize(&app_demo.message_queue);
+}
+
+/**
+ * @brief Destroy semaphore, mutex, clear up message queue.
+ */
+static void app_demo_deinit(void)
+{
+    sem_destroy(&app_demo.sem);
+    pthread_mutex_destroy(&app_demo.mutex);
+
+    node_t* entry = NULL;
+    node_t* temp_entry = NULL;
+    list_for_every_entry_safe(&app_demo.message_queue, entry, temp_entry, node_t, node)
+    {
+        list_delete(&app_demo.message_queue);
+        free(entry);
+    }
+}
+
+/**
+ * @brief The main thread processes events.
+ */
+static void app_handle_message(node_t* node)
+{
+    if (node == NULL) {
+        return;
+    }
+
+    if (node->data.msg_type > APP_BT_GAP_MESSAGE_START && node->data.msg_type < APP_BT_GAP_MESSAGE_END)
+        app_bt_handle_message(app_demo.bt_ins, node);
+}
+
+/**
+ * @brief Check the exit condition of the while loop in the main function.
+ *
+ * The condition for exiting the while loop can be multiple, but in this demo,
+ * only one scenario is provided: Bluetooth is turned off.
+ */
+static bool app_if_running(void)
+{
+    // Developers can add additional exit condition checks.
+
+    return app_demo.running;
+}
+
+int main(int argc, char* argv[])
+{
+    node_t* node = NULL;
+
+    // 1. Initialize semaphore;
+    // 2. Initialize mutex;
+    // 3. Initialize message queue.
+    app_demo_init();
+
+    // Create bluetooth client instance.
+    app_demo.bt_ins = bluetooth_create_instance();
+    if (app_demo.bt_ins == NULL) {
+        LOGE("create instance error");
+        goto error;
+    }
+
+    // Register gap callback.
+    app_demo.adapter_callback = bt_adapter_register_callback(app_demo.bt_ins, &app_gap_cbs);
+    if (app_demo.adapter_callback == NULL) {
+        LOGE("register callback error.");
+        goto error;
+    }
+
+    app_demo.a2dp_callback = bt_a2dp_sink_register_callbacks(app_demo.bt_ins, &app_a2dp_cbs);
+    if (app_demo.a2dp_callback == NULL) {
+        LOGE("register callback error.");
+        goto error;
+    }
+
+    // Enable bluetooth.
+    if (bt_adapter_enable(app_demo.bt_ins) != BT_STATUS_SUCCESS) {
+        LOGE("enable adapter error.");
+        goto error;
+    }
+
+    // The app main thread，is used to handle bluetooth events.
+    while (app_if_running()) {
+        // Obtain the msg to be processed.
+        node = app_list_remove_head();
+
+        // The main thread processes events.
+        app_handle_message(node);
+    }
+
+error:
+    // Unregister gap callback;
+    if (app_demo.adapter_callback) {
+        bt_adapter_unregister_callback(app_demo.bt_ins, app_demo.adapter_callback);
+        app_demo.adapter_callback = NULL;
+    }
+
+    if (app_demo.a2dp_callback) {
+        bt_a2dp_sink_unregister_callbacks(app_demo.bt_ins, app_demo.a2dp_callback);
+        app_demo.a2dp_callback = NULL;
+    }
+
+    if (app_demo.bt_ins) {
+        // Delete bluetooth client instance;
+        bluetooth_delete_instance(app_demo.bt_ins);
+        app_demo.bt_ins = NULL;
+    }
+
+    // 1. Destroy semaphore;
+    // 2. Destroy mutex;
+    // 3. clean up message queue.
+    app_demo_deinit();
+
+    LOGI("Bluetooth closed.");
+
+    return 0;
+}

--- a/sample_code/a2dpsnk/a2dpsnk.h
+++ b/sample_code/a2dpsnk/a2dpsnk.h
@@ -1,0 +1,78 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#include <nuttx/list.h>
+#include <semaphore.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <syslog.h>
+
+#include "app_bt_message.h"
+#include "bluetooth.h"
+#include "bt_adapter.h"
+
+typedef enum {
+#define __APP_BT_MESSAGE_CODE__
+#include "app_bt_message.h"
+#undef __APP_BT_MESSAGE_CODE__
+} app_bt_message_type_t;
+
+#define APP_LOG_TAG "app_demo"
+
+#define LOG_EMERG 0 /* system is unusable */
+#define LOG_ALERT 1 /* action must be taken immediately */
+#define LOG_CRIT 2 /* critical conditions */
+#define LOG_ERR 3 /* error conditions */
+#define LOG_WARNING 4 /* warning conditions */
+#define LOG_NOTICE 5 /* normal but significant condition */
+#define LOG_INFO 6 /* informational */
+#define LOG_DEBUG 7 /* debug-level messages */
+
+#define LOGE(fmt, ...) syslog(LOG_ERR, "[" APP_LOG_TAG "]" \
+                                       ": " fmt "\n",      \
+    ##__VA_ARGS__);
+#define LOGW(fmt, ...) syslog(LOG_WARNING, "[" APP_LOG_TAG "]" \
+                                           ": " fmt "\n",      \
+    ##__VA_ARGS__);
+#define LOGI(fmt, ...) syslog(LOG_INFO, "[" APP_LOG_TAG "]" \
+                                        ": " fmt "\n",      \
+    ##__VA_ARGS__);
+
+typedef struct {
+    uint32_t msg_type;
+    union {
+        app_bt_message_t message;
+    };
+} app_demo_message_t;
+
+typedef struct {
+    struct list_node node;
+    app_demo_message_t data;
+} node_t;
+
+typedef struct {
+    uint8_t running;
+    sem_t sem;
+    pthread_mutex_t mutex;
+    struct list_node message_queue;
+    bt_instance_t* bt_ins;
+    void* adapter_callback;
+    void* a2dp_callback;
+    bool is_acl_active;
+} app_demo_t;
+
+void app_bt_handle_message(bt_instance_t* bt_ins, node_t* node);
+bool app_demo_a2dpsnk_get_acl_active(void);
+void app_demo_a2dpsnk_set_acl_active(bool active);

--- a/sample_code/a2dpsnk/app_bt.c
+++ b/sample_code/a2dpsnk/app_bt.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "a2dpsnk.h"
+#include "bt_a2dp_sink.h"
+
+void app_bt_handle_message(bt_instance_t* bt_ins, node_t* node)
+{
+    bt_status_t ret;
+    app_demo_message_t* msg = &node->data;
+    switch (msg->msg_type) {
+    case APP_BT_GAP_SET_IO_CAPABILITY:
+        bt_adapter_set_io_capability(bt_ins, msg->message._bt_adapter_set_io_capability.cap);
+        break;
+    case APP_BT_GAP_CREATE_CONN:
+        ret = bt_device_connect(bt_ins, &msg->message._bt_device_create_conn.addr);
+        if (ret != BT_STATUS_SUCCESS) {
+            LOGE("create conn failed, ret = %d\n", ret);
+        }
+        break;
+    case APP_BT_A2DP_CREATE_CONN:
+        LOGI("Connection state changed: %d", msg->message._on_connection_state_changed.state);
+        if (msg->message._on_connection_state_changed.state == CONNECTION_STATE_CONNECTED) {
+            LOGI("Connect A2DP now\r\n");
+            bt_a2dp_sink_connect(bt_ins, &msg->message._on_connection_state_changed.addr);
+        }
+        if (msg->message._on_connection_state_changed.state == CONNECTION_STATE_DISCONNECTED) {
+            LOGI("ACL is disconnect\r\n");
+            app_demo_a2dpsnk_set_acl_active(false);
+        }
+        break;       
+    default:
+        break;
+    }
+}

--- a/sample_code/a2dpsnk/app_bt_message.h
+++ b/sample_code/a2dpsnk/app_bt_message.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#ifdef __APP_BT_MESSAGE_CODE__
+APP_BT_GAP_MESSAGE_START,
+    APP_BT_GAP_ON_GAP_STATE_CHANGED,
+    APP_BT_GAP_SET_IO_CAPABILITY,
+    APP_BT_GAP_CREATE_CONN,
+    APP_BT_A2DP_CREATE_CONN,
+    APP_BT_GAP_MESSAGE_END,
+#endif
+
+#ifndef _BT_MESSAGE_ADAPTER_H__
+#define _BT_MESSAGE_ADAPTER_H__
+
+#define BT_NAME_LENGTH 64
+
+#ifdef __cplusplus
+    extern "C"
+{
+#endif
+
+#include "bt_adapter.h"
+
+    typedef union {
+        struct {
+            uint8_t cap; /* bt_io_capability_t */
+        } _bt_adapter_set_io_capability;
+
+        struct {
+            bt_address_t addr;
+        } _bt_device_create_conn;
+
+        struct {
+            uint8_t state; /* bt_adapter_state_t */
+        } _on_adapter_state_changed;
+
+        struct {
+            bt_address_t addr;
+            uint8_t state; /* connection_state_t */
+        } _on_connection_state_changed;
+
+        struct {
+            bt_address_t addr;
+            uint8_t state; /* profile_connection_state_t */
+        } _on_a2dp_state_changed;
+    } app_bt_message_t;
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BT_MESSAGE_ADAPTER_H__ */


### PR DESCRIPTION
bug: v/65644

Create a new sample app that allows to connect a remote device as A2DP Sink.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

