### PR TITLE
TestSuit: Bluetooth address input optimization.

### DIFF
--- a/tools/test_suite/android/app/src/main/java/com/openvela/bluetoothtest/ble/BleL2capActivity.java
+++ b/tools/test_suite/android/app/src/main/java/com/openvela/bluetoothtest/ble/BleL2capActivity.java
@@ -28,6 +28,7 @@ import android.widget.EditText;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.openvela.bluetooth.BtHelper;
 import com.openvela.bluetooth.BtSock;
 import com.openvela.bluetoothtest.MainActivity;
 import com.openvela.bluetoothtest.R;
@@ -114,7 +115,13 @@ public class BleL2capActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 String uuid = textServiceUUID_1.getText().toString();
-                String addr = textBdAddr_1.getText().toString();
+                String addr = BtHelper.formatMacAddress(textBdAddr_1.getText().toString());
+                if (addr == null) {
+                    textBdAddr_1.setText("Invalid");
+                    return;
+                }
+
+                textBdAddr_1.setText(addr);
 
                 Log.d(TAG, "onClick: Connect by Client#1, to BD_ADDR =  " + addr);
                 btSock_1.connect(addr, uuid);
@@ -140,7 +147,14 @@ public class BleL2capActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 String uuid = textServiceUUID_2.getText().toString();
-                String addr = textBdAddr_2.getText().toString();
+                String addr = BtHelper.formatMacAddress(textBdAddr_2.getText().toString());
+                if(addr == null)
+                {
+                    textBdAddr_2.setText("Invalid");
+                    return;
+                }
+
+                textBdAddr_2.setText(addr);
 
                 Log.d(TAG, "onClick: Connect by Client#2, to BD_ADDR =  " + addr);
                 btSock_2.connect(addr, uuid);
@@ -168,7 +182,7 @@ public class BleL2capActivity extends AppCompatActivity {
                 String str = textDataToSend_1.getText().toString();
 
                 Log.d(TAG, "onClick: Send by Client/Server#1, data =  " + str);
-                btSock_1.send(str, 0);
+                btSock_1.send(str, 1);
             }
         });
 
@@ -183,7 +197,7 @@ public class BleL2capActivity extends AppCompatActivity {
                 String str = textDataToSend_2.getText().toString();
 
                 Log.d(TAG, "onClick: Send by Client/Server#2, data =  " + str);
-                btSock_2.send(str, 0);
+                btSock_2.send(str, 1);
             }
         });
 

--- a/tools/test_suite/android/app/src/main/java/com/openvela/bluetoothtest/bredr/SppActivity.java
+++ b/tools/test_suite/android/app/src/main/java/com/openvela/bluetoothtest/bredr/SppActivity.java
@@ -28,6 +28,7 @@ import android.widget.EditText;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.openvela.bluetooth.BtHelper;
 import com.openvela.bluetooth.BtSock;
 import com.openvela.bluetoothtest.MainActivity;
 import com.openvela.bluetoothtest.R;
@@ -116,8 +117,13 @@ public class SppActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 String uuid = textServiceUUID_1.getText().toString();
-                String addr = textBdAddr_1.getText().toString();
+                String addr = BtHelper.formatMacAddress(textBdAddr_1.getText().toString());
+                if (addr == null) {
+                    textBdAddr_1.setText("Invalid");
+                    return;
+                }
 
+                textBdAddr_1.setText(addr);
                 Log.d(TAG, "onClick: Connect by Client#1, to BD_ADDR =  " + addr);
                 btSpp_1.connect(addr, uuid);
             }
@@ -142,8 +148,13 @@ public class SppActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 String uuid = textServiceUUID_2.getText().toString();
-                String addr = textBdAddr_2.getText().toString();
+                String addr = BtHelper.formatMacAddress(textBdAddr_2.getText().toString());
+                if (addr == null) {
+                    textBdAddr_2.setText("Invalid");
+                    return;
+                }
 
+                textBdAddr_2.setText(addr);
                 Log.d(TAG, "onClick: Connect by Client#2, to BD_ADDR =  " + addr);
                 btSpp_2.connect(addr, uuid);
             }

--- a/tools/test_suite/android/core/src/main/java/com/openvela/bluetooth/BtHelper.java
+++ b/tools/test_suite/android/core/src/main/java/com/openvela/bluetooth/BtHelper.java
@@ -1,0 +1,44 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+package com.openvela.bluetooth;
+
+import android.bluetooth.BluetoothAdapter;
+import android.util.Log;
+
+public class BtHelper {
+    private static final String TAG = "BtHelper";
+    public static String formatMacAddress(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            Log.e(TAG, "Invalid input");
+            return null;
+        }
+
+        String cleaned = input.replaceAll("[^0-9A-Fa-f]", "").toUpperCase();
+        if (cleaned.length() != 12) {
+            Log.e(TAG, "Invalid Bluetooth MAC address");
+            return null;
+        }
+
+        String addr = cleaned.replaceAll("(..)(..)(..)(..)(..)(..)", "$1:$2:$3:$4:$5:$6");
+        if (!BluetoothAdapter.checkBluetoothAddress(addr)) {
+            Log.e(TAG, "Bluetooth Address detection failed");
+            return null;
+        }
+
+        return addr;
+    }
+}


### PR DESCRIPTION
bug: v/62197

Rootcause: Due to the fact that the Android Bluetooth interface supports Bluetooth addresses with uppercase characters, it is necessary to standardize user address input. Add BtHelper to implement address standardization functionality.

