### PR TITLE
Android-Vela:add cnum interface for android

### DIFF
--- a/framework/api/bt_hfp_hf.c
+++ b/framework/api/bt_hfp_hf.c
@@ -198,3 +198,9 @@ bt_status_t BTSYMBOLS(bt_hfp_hf_send_dtmf)(bt_instance_t* ins, bt_address_t* add
     hfp_hf_interface_t* profile = get_profile_service();
     return profile->send_dtmf(addr, dtmf);
 }
+
+bt_status_t BTSYMBOLS(bt_hfp_hf_get_subscriber_number)(bt_instance_t* ins, bt_address_t* addr)
+{
+    hfp_hf_interface_t* profile = get_profile_service();
+    return profile->get_subscriber_number(addr);
+}

--- a/framework/include/bt_hfp_hf.h
+++ b/framework/include/bt_hfp_hf.h
@@ -70,6 +70,15 @@ typedef struct {
 } hfp_current_call_t;
 
 /**
+ * @brief HFP subscriber number service
+ */
+typedef enum {
+    HFP_HF_SERVICE_UNKNOWN = 0,
+    HFP_HF_SERVICE_VOICE,
+    HFP_HF_SERVICE_FAX,
+} hfp_subscriber_number_service_t;
+
+/**
  * @endcond
  */
 
@@ -389,6 +398,16 @@ void hfp_hf_callheld_cb(void* cookie, bt_address_t* addr, hfp_callheld_t callhel
 typedef void (*hfp_hf_callheld_callback)(void* cookie, bt_address_t* addr, hfp_callheld_t callheld);
 
 /**
+ * @brief HFP HF get subscriber number callback.
+ *
+ * @param cookie - callback cookie.
+ * @param addr - address of peer AG device.
+ * @param number - phone number.
+ * @param service - indicates which service this phone number relates to.
+ */
+typedef void (*hfp_hf_subscriber_number_callback)(void* cookie, bt_address_t* addr, const char* number, hfp_subscriber_number_service_t service);
+
+/**
  * @brief HFP HF +clip callback.
  *
  * @param cookie - callback cookie.
@@ -420,6 +439,7 @@ typedef struct
     hfp_hf_callsetup_callback callsetup_cb;
     hfp_hf_callheld_callback callheld_cb;
     hfp_hf_clip_callback clip_cb;
+    hfp_hf_subscriber_number_callback subscriber_number_cb;
 } hfp_hf_callbacks_t;
 
 /**
@@ -1157,6 +1177,15 @@ int app_send_dtmf(bt_instance_t* ins, bt_address_t* addr, char dtmf);
  * @endcode
  */
 bt_status_t BTSYMBOLS(bt_hfp_hf_send_dtmf)(bt_instance_t* ins, bt_address_t* addr, char dtmf);
+
+/**
+ * @brief Get Subscriber Number
+ *
+ * @param ins - bluetooth client instance.
+ * @param addr - address of peer AG device.
+ * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ */
+bt_status_t BTSYMBOLS(bt_hfp_hf_get_subscriber_number)(bt_instance_t* ins, bt_address_t* addr);
 
 #ifdef __cplusplus
 }

--- a/framework/socket/bt_hfp_hf.c
+++ b/framework/socket/bt_hfp_hf.c
@@ -454,3 +454,18 @@ bt_status_t bt_hfp_hf_send_dtmf(bt_instance_t* ins, bt_address_t* addr, char dtm
 
     return packet.hfp_hf_r.status;
 }
+
+bt_status_t bt_hfp_hf_get_subscriber_number(bt_instance_t* ins, bt_address_t* addr)
+{
+    bt_message_packet_t packet;
+    bt_status_t status;
+
+    BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
+
+    memcpy(&packet.hfp_hf_pl._bt_hfp_hf_get_subscriber_number.addr, addr, sizeof(bt_address_t));
+    status = bt_socket_client_sendrecv(ins, &packet, BT_HFP_HF_GET_SUBSCRIBER_NUMBER);
+    if (status != BT_STATUS_SUCCESS)
+        return status;
+
+    return packet.hfp_hf_r.status;
+}

--- a/service/ipc/socket/include/bt_message_hfp_hf.h
+++ b/service/ipc/socket/include/bt_message_hfp_hf.h
@@ -72,12 +72,16 @@ BT_HFP_HF_MESSAGE_START,
 
 #define BT_IPC_CODE_COMMAND_HFP_HF_BEGIN BT_IPC_CODE(BT_IPC_CODE_TYPE_COMMAND, BT_IPC_CODE_GROUP_HFP_HF, 0)
 // TODO: Add new BT IPC Code sequentially
+#define HFP_HF_SUBCODE_GET_SUBSCRIBER_NUMBER 1
+#define BT_HFP_HF_GET_SUBSCRIBER_NUMBER BT_IPC_CODE(BT_IPC_CODE_TYPE_COMMAND, BT_IPC_CODE_GROUP_HFP_HF, HFP_HF_SUBCODE_GET_SUBSCRIBER_NUMBER)
 #define BT_IPC_CODE_COMMAND_HFP_HF_END BT_IPC_CODE(BT_IPC_CODE_TYPE_COMMAND, BT_IPC_CODE_GROUP_HFP_HF, BT_IPC_CODE_SUBCODE_MAX_NUM)
 
 #define BT_IPC_CODE_CALLBACK_HFP_HF_BEGIN BT_IPC_CODE(BT_IPC_CODE_TYPE_CALLBACK, BT_IPC_CODE_GROUP_HFP_HF, 0)
 // TODO: Add new BT IPC Code sequentially
 #define HFP_HF_SUBCODE_ON_CLIP_RECEIVED 1
 #define BT_HFP_HF_ON_CLIP_RECEIVED BT_IPC_CODE(BT_IPC_CODE_TYPE_CALLBACK, BT_IPC_CODE_GROUP_HFP_HF, HFP_HF_SUBCODE_ON_CLIP_RECEIVED)
+#define HFP_HF_SUBCODE_ON_SUBSCRIBER_NUMBER_RECEIVED 2
+#define BT_HFP_HF_ON_SUBSCRIBER_NUMBER_RECEIVED BT_IPC_CODE(BT_IPC_CODE_TYPE_CALLBACK, BT_IPC_CODE_GROUP_HFP_HF, HFP_HF_SUBCODE_ON_SUBSCRIBER_NUMBER_RECEIVED)
 #define BT_IPC_CODE_CALLBACK_HFP_HF_END BT_IPC_CODE(BT_IPC_CODE_TYPE_CALLBACK, BT_IPC_CODE_GROUP_HFP_HF, BT_IPC_CODE_SUBCODE_MAX_NUM)
 
     typedef union {
@@ -101,7 +105,8 @@ BT_HFP_HF_MESSAGE_START,
             _bt_hfp_hf_redial,
             _bt_hfp_hf_reject_call,
             _bt_hfp_hf_hold_call,
-            _bt_hfp_hf_terminate_call;
+            _bt_hfp_hf_terminate_call,
+            _bt_hfp_hf_get_subscriber_number;
 
         struct {
             bt_address_t addr;
@@ -211,6 +216,13 @@ BT_HFP_HF_MESSAGE_START,
             char number[HFP_PHONENUM_DIGITS_MAX];
             char name[HFP_NAME_DIGITS_MAX];
         } _on_clip_cb;
+
+        struct {
+            bt_address_t addr;
+            uint8_t pad[2];
+            char number[HFP_PHONENUM_DIGITS_MAX + 1];
+            uint8_t service; /* hfp_subscriber_number_service_t */
+        } _on_subscriber_number_cb;
     } bt_message_hfp_hf_callbacks_t;
 
 #ifdef __cplusplus

--- a/service/ipc/socket/src/bt_socket_hfp_hf.c
+++ b/service/ipc/socket/src/bt_socket_hfp_hf.c
@@ -188,6 +188,22 @@ static void on_clip_cb(void* cookie, bt_address_t* addr, const char* number, con
     bt_socket_server_send(ins, &packet, BT_HFP_HF_ON_CLIP_RECEIVED);
 }
 
+static void on_subscriber_number_cb(void* cookie, bt_address_t* addr, const char* number, hfp_subscriber_number_service_t service)
+{
+    bt_message_packet_t packet = { 0 };
+    bt_instance_t* ins = cookie;
+
+    memcpy(&packet.hfp_hf_cb._on_subscriber_number_cb.addr, addr, sizeof(bt_address_t));
+
+    if (number) {
+        strlcpy(packet.hfp_hf_cb._on_subscriber_number_cb.number, number, sizeof(packet.hfp_hf_cb._on_subscriber_number_cb.number));
+    }
+
+    packet.hfp_hf_cb._on_subscriber_number_cb.service = service;
+
+    bt_socket_server_send(ins, &packet, BT_HFP_HF_ON_SUBSCRIBER_NUMBER_RECEIVED);
+}
+
 const static hfp_hf_callbacks_t g_hfp_hf_socket_cbs = {
     .connection_state_cb = on_connection_state_changed_cb,
     .audio_state_cb = on_audio_state_changed_cb,
@@ -200,6 +216,7 @@ const static hfp_hf_callbacks_t g_hfp_hf_socket_cbs = {
     .callsetup_cb = on_callsetup_cb,
     .callheld_cb = on_callheld_cb,
     .clip_cb = on_clip_cb,
+    .subscriber_number_cb = on_subscriber_number_cb,
 };
 
 static bool bt_socket_allocator(void** data, uint32_t size)
@@ -355,7 +372,14 @@ void bt_socket_server_hfp_hf_process(service_poll_t* poll, int fd,
             packet->hfp_hf_pl._bt_hfp_hf_send_dtmf.dtmf);
         break;
     default:
-        break;
+        switch (BT_IPC_GET_SUBCODE(packet->code)) {
+        case HFP_HF_SUBCODE_GET_SUBSCRIBER_NUMBER:
+            packet->hfp_hf_r.status = BTSYMBOLS(bt_hfp_hf_get_subscriber_number)(ins,
+                &packet->hfp_hf_pl._bt_hfp_hf_get_subscriber_number.addr);
+            break;
+        default:
+            break;
+        }
     }
 }
 #endif
@@ -438,6 +462,13 @@ int bt_socket_client_hfp_hf_callback(service_poll_t* poll,
                 &packet->hfp_hf_cb._on_clip_cb.addr,
                 packet->hfp_hf_cb._on_clip_cb.number,
                 packet->hfp_hf_cb._on_clip_cb.name);
+            break;
+        case HFP_HF_SUBCODE_ON_SUBSCRIBER_NUMBER_RECEIVED:
+            CALLBACK_FOREACH(CBLIST, hfp_hf_callbacks_t,
+                subscriber_number_cb,
+                &packet->hfp_hf_cb._on_at_cmd_complete_cb.addr,
+                packet->hfp_hf_cb._on_subscriber_number_cb.number,
+                packet->hfp_hf_cb._on_subscriber_number_cb.service);
             break;
         default:
             return BT_STATUS_PARM_INVALID;

--- a/service/profiles/hfp_hf/hfp_hf_service.c
+++ b/service/profiles/hfp_hf/hfp_hf_service.c
@@ -756,6 +756,17 @@ static bt_status_t hfp_hf_send_dtmf(bt_address_t* addr, char dtmf)
     return hfp_hf_send_message(msg);
 }
 
+static bt_status_t hfp_hf_get_subscriber_number(bt_address_t* addr)
+{
+    CHECK_ENABLED();
+
+    hfp_hf_msg_t* msg = hfp_hf_msg_new(HF_GET_SUBSCRIBER_NUMBER, addr);
+    if (!msg)
+        return BT_STATUS_NOMEM;
+
+    return hfp_hf_send_message(msg);
+}
+
 static const hfp_hf_interface_t HfInterface = {
     sizeof(HfInterface),
     .register_callbacks = hfp_hf_register_callbacks,
@@ -783,6 +794,7 @@ static const hfp_hf_interface_t HfInterface = {
     .update_battery_level = hfp_hf_update_battery_level,
     .volume_control = hfp_hf_volume_control,
     .send_dtmf = hfp_hf_send_dtmf,
+    .get_subscriber_number = hfp_hf_get_subscriber_number,
 };
 
 static const void* get_hf_profile_interface(void)
@@ -864,6 +876,12 @@ void hf_service_notify_clip_received(bt_address_t* addr, const char* number, con
 {
     BT_LOGD("%s", __func__);
     HF_CALLBACK_FOREACH(g_hfp_service.callbacks, clip_cb, addr, number, name);
+}
+
+void hf_service_notify_subscriber_number(bt_address_t* addr, const char* number, hfp_subscriber_number_service_t service)
+{
+    BT_LOGD("%s", __func__);
+    HF_CALLBACK_FOREACH(g_hfp_service.callbacks, subscriber_number_cb, addr, number, service);
 }
 
 void hfp_hf_on_connection_state_changed(bt_address_t* addr, profile_connection_state_t state,
@@ -1036,6 +1054,18 @@ void hfp_hf_on_at_command_result_response(bt_address_t* addr, uint32_t at_cmd_co
 
     msg->data.valueint1 = at_cmd_code;
     msg->data.valueint2 = result;
+    hfp_hf_send_message(msg);
+}
+
+void hfp_hf_on_subscriber_number_response(bt_address_t* addr, const char* number, hfp_subscriber_number_service_t service)
+{
+    hfp_hf_msg_t* msg = hfp_hf_msg_new(HF_STACK_EVENT_CNUM, addr);
+    if (!msg)
+        return;
+
+    HF_MSG_ADD_STR(msg, 1, number, strlen(number));
+    msg->data.valueint2 = service;
+
     hfp_hf_send_message(msg);
 }
 

--- a/service/profiles/hfp_hf/hfp_hf_state_machine.c
+++ b/service/profiles/hfp_hf/hfp_hf_state_machine.c
@@ -198,6 +198,7 @@ static const char* stack_event_to_string(hfp_hf_event_t event)
         CASE_RETURN_STR(HF_SEND_AT_COMMAND)
         CASE_RETURN_STR(HF_UPDATE_BATTERY_LEVEL)
         CASE_RETURN_STR(HF_SEND_DTMF)
+        CASE_RETURN_STR(HF_GET_SUBSCRIBER_NUMBER)
         CASE_RETURN_STR(HF_TIMEOUT)
         CASE_RETURN_STR(HF_OFFLOAD_START_REQ)
         CASE_RETURN_STR(HF_OFFLOAD_STOP_REQ)
@@ -220,6 +221,7 @@ static const char* stack_event_to_string(hfp_hf_event_t event)
         CASE_RETURN_STR(HF_STACK_EVENT_CMD_RESULT)
         CASE_RETURN_STR(HF_STACK_EVENT_RING_INDICATION)
         CASE_RETURN_STR(HF_STACK_EVENT_CODEC_CHANGED)
+        CASE_RETURN_STR(HF_STACK_EVENT_CNUM)
     default:
         return "UNKNOWN_HF_EVENT";
     }
@@ -1014,6 +1016,11 @@ static bool default_process_event(state_machine_t* sm, uint32_t event, hfp_hf_da
         if (status != BT_STATUS_SUCCESS)
             BT_LOGE("Send dtmf failed");
         break;
+    case HF_GET_SUBSCRIBER_NUMBER:
+        status = bt_sal_hfp_hf_get_subscriber_number(&hfsm->addr);
+        if (status != BT_STATUS_SUCCESS)
+            BT_LOGE("Get subscriber number failed");
+        break;
     case HF_STACK_EVENT_VR_STATE_CHANGED: {
         hfp_hf_vr_state_t state = data->valueint1;
 
@@ -1104,6 +1111,14 @@ static bool default_process_event(state_machine_t* sm, uint32_t event, hfp_hf_da
     case HF_STACK_EVENT_CODEC_CHANGED:
         hfsm->codec = data->valueint1 == HFP_CODEC_MSBC ? HFP_CODEC_MSBC : HFP_CODEC_CVSD;
         break;
+    case HF_STACK_EVENT_CNUM: {
+        char* number = data->string1;
+        uint32_t service = data->valueint2;
+
+        BT_LOGD("CNUM:number: %s, service: %" PRIu32, number == NULL ? "NULL" : number, service);
+        hf_service_notify_subscriber_number(&hfsm->addr, data->string1, (hfp_subscriber_number_service_t)data->valueint2);
+        break;
+    }
     default:
         BT_LOGW("Unexpected event:%" PRIu32 "", event);
         break;

--- a/service/profiles/include/hfp_hf_event.h
+++ b/service/profiles/include/hfp_hf_event.h
@@ -53,6 +53,7 @@ typedef enum {
     HF_SEND_AT_COMMAND = 19,
     HF_UPDATE_BATTERY_LEVEL = 20,
     HF_SEND_DTMF = 21,
+    HF_GET_SUBSCRIBER_NUMBER = 22,
     HF_STARTUP = 28,
     HF_SHUTDOWN = 29,
     HF_TIMEOUT = 30,
@@ -77,6 +78,7 @@ typedef enum {
     HF_STACK_EVENT_CMD_RESULT,
     HF_STACK_EVENT_RING_INDICATION,
     HF_STACK_EVENT_CODEC_CHANGED,
+    HF_STACK_EVENT_CNUM,
 } hfp_hf_event_t;
 
 typedef struct

--- a/service/profiles/include/hfp_hf_service.h
+++ b/service/profiles/include/hfp_hf_service.h
@@ -77,6 +77,7 @@ void hfp_hf_on_current_call_response(bt_address_t* addr, uint32_t idx,
     hfp_call_mpty_type_t mpty,
     const char* number, uint32_t type);
 void hfp_hf_on_at_command_result_response(bt_address_t* addr, uint32_t at_cmd_code, uint32_t result);
+void hfp_hf_on_subscriber_number_response(bt_address_t* addr, const char* number, hfp_subscriber_number_service_t service);
 
 /*
  *  statemachine callbacks
@@ -93,7 +94,7 @@ void hf_service_notify_call(bt_address_t* addr, hfp_call_t call);
 void hf_service_notify_callsetup(bt_address_t* addr, hfp_callsetup_t callsetup);
 void hf_service_notify_callheld(bt_address_t* addr, hfp_callheld_t callheld);
 void hf_service_notify_clip_received(bt_address_t* addr, const char* number, const char* name);
-
+void hf_service_notify_subscriber_number(bt_address_t* addr, const char* number, hfp_subscriber_number_service_t service);
 /*
  * service api
  */
@@ -129,6 +130,7 @@ typedef struct hf_interface {
     bt_status_t (*update_battery_level)(bt_address_t* addr, uint8_t level);
     bt_status_t (*volume_control)(bt_address_t* addr, hfp_volume_type_t type, uint8_t volume);
     bt_status_t (*send_dtmf)(bt_address_t* addr, char dtmf);
+    bt_status_t (*get_subscriber_number)(bt_address_t* addr);
 } hfp_hf_interface_t;
 
 /*

--- a/tools/hfp_hf.c
+++ b/tools/hfp_hf.c
@@ -43,6 +43,7 @@ static int query_current_calls_cmd(void* handle, int argc, char* argv[]);
 static int send_at_cmd_cmd(void* handle, int argc, char* argv[]);
 static int update_battery_level_cmd(void* handle, int argc, char* argv[]);
 static int send_dtmf_cmd(void* handle, int argc, char* argv[]);
+static int get_subscriber_number(void* handle, int argc, char* argv[]);
 
 #define CHLD_0_DESC "0: Releases all held calls or sets User Determined User Busy (UDUB) for a waiting call"
 #define CHLD_1_DESC "1: Releases all active calls (if any exist) and accepts the other (held or waiting) call"
@@ -96,6 +97,7 @@ static bt_command_t g_hfp_tables[] = {
     { "sendat", send_at_cmd_cmd, 0, "Send customize AT command to peer    params: <address> <atcmd>" },
     { "battery", update_battery_level_cmd, 0, "Update battery level within [0, 100] params: <address> <level>\"" },
     { "dtmf", send_dtmf_cmd, 0, SEND_DTMF_USAGE },
+    { "cnum", get_subscriber_number, 0, "Get subscriber number                  params: <address> " },
     { "state", get_hfp_connection_state_cmd, 0, "get hfp profile state" },
 };
 
@@ -466,6 +468,22 @@ static int send_dtmf_cmd(void* handle, int argc, char* argv[])
     return CMD_OK;
 }
 
+static int get_subscriber_number(void* handle, int argc, char* argv[])
+{
+    if (argc < 1)
+        return CMD_PARAM_NOT_ENOUGH;
+
+    bt_address_t addr;
+
+    if (bt_addr_str2ba(argv[0], &addr) < 0)
+        return CMD_INVALID_ADDR;
+
+    if (bt_hfp_hf_get_subscriber_number(handle, &addr) != BT_STATUS_SUCCESS)
+        return CMD_ERROR;
+
+    return CMD_OK;
+}
+
 static void hf_connection_state_callback(void* context, bt_address_t* addr, profile_connection_state_t state)
 {
     PRINT_ADDR("hf_connection_state_callback, addr:%s, state:%d", addr, state);
@@ -507,6 +525,11 @@ static void hf_clip_cb(void* context, bt_address_t* addr, const char* number, co
     PRINT_ADDR("hf_clip_cb, addr:%s, number:%s, name:%s", addr, number, name);
 }
 
+static void hf_subscriber_number_cb(void* context, bt_address_t* addr, const char* number, hfp_subscriber_number_service_t service)
+{
+    PRINT_ADDR("hf_subscriber_number_cb, addr:%s, number:%s, service:%d", addr, number, service);
+}
+
 static const hfp_hf_callbacks_t hfp_hf_cbs = {
     sizeof(hfp_hf_cbs),
     hf_connection_state_callback,
@@ -520,6 +543,7 @@ static const hfp_hf_callbacks_t hfp_hf_cbs = {
     NULL,
     NULL,
     hf_clip_cb,
+    hf_subscriber_number_cb,
 };
 
 int hfp_hf_commond_init(void* handle)


### PR DESCRIPTION
bug: v/67447

Rootcause: Adapt the cnum interface to obtain the virtual call mobile phone number.