### PR TITLE
bluetooth: fix visibility not disabled before bt_disable

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -564,6 +564,7 @@ static void STACK_CALL(brder_disable)(void* args)
 
     zblue_unregister_callback();
 #ifndef CONFIG_BLUETOOTH_BLE_SUPPORT
+    bt_br_set_visibility(false, false);
     bt_disable();
 #endif
 }


### PR DESCRIPTION
bug: v/64223

rootcause: device remained visible after bt_disable