### PR TITLE
HFP HF:Modify compilation warning.

### DIFF
--- a/service/profiles/hfp_hf/hfp_hf_state_machine.c
+++ b/service/profiles/hfp_hf/hfp_hf_state_machine.c
@@ -40,10 +40,12 @@
 
 #define HFP_HF_RETRY_MAX 1
 
+#ifdef CONFIG_HFP_HF_WEBCHAT_BLOCKER
 const static char voip_call_number[][HFP_PHONENUM_DIGITS_MAX] = {
     "10000000",
     "10000001"
 };
+#endif
 
 #define HFP_HF_REPORT_CIEV_AND_CACHE(_hfsm, _ciev)                                                  \
     do {                                                                                            \


### PR DESCRIPTION
bug: v/46476

rootcause:voip_call_number is used only when HFP_HF_WEBCHAT_BLOCKER is enabled.