### PR TITLE
bluetooth:  Rename the macro for modifying A2DP SBC parameters.

### DIFF
--- a/service/profiles/a2dp/codec/a2dp_codec_sbc.c
+++ b/service/profiles/a2dp/codec/a2dp_codec_sbc.c
@@ -58,12 +58,12 @@ static int a2dp_parse_sbc_info(a2dp_sbc_info_t* info, uint8_t* codec_info)
         return -1;
     }
 
-    info->samp_freq = *codec_info & A2DP_SBC_SAMP_FREQ_MSK;
-    info->ch_mode = *codec_info & A2DP_SBC_CH_MD_MSK;
+    info->samp_freq = *codec_info & BT_A2DP_SBC_SAMP_FREQ_MSK;
+    info->ch_mode = *codec_info & BT_A2DP_SBC_CH_MD_MSK;
     codec_info++;
-    info->block_len = *codec_info & A2DP_SBC_BLOCKS_MSK;
-    info->num_subbands = *codec_info & A2DP_SBC_SUBBAND_MSK;
-    info->alloc_method = *codec_info & A2DP_SBC_ALLOC_MD_MSK;
+    info->block_len = *codec_info & BT_A2DP_SBC_BLOCKS_MSK;
+    info->num_subbands = *codec_info & BT_A2DP_SBC_SUBBAND_MSK;
+    info->alloc_method = *codec_info & BT_A2DP_SBC_ALLOC_MD_MSK;
     codec_info++;
     info->min_bitpool = *codec_info++;
     info->max_bitpool = *codec_info++;
@@ -74,9 +74,9 @@ static int a2dp_parse_sbc_info(a2dp_sbc_info_t* info, uint8_t* codec_info)
 static int a2dp_get_sbc_allocation_method(a2dp_sbc_info_t* info)
 {
     switch (info->alloc_method) {
-    case A2DP_SBC_ALLOC_MD_S:
+    case BT_A2DP_SBC_ALLOC_MD_S:
         return SBC_SNR;
-    case A2DP_SBC_ALLOC_MD_L:
+    case BT_A2DP_SBC_ALLOC_MD_L:
         return SBC_LOUDNESS;
     default:
         break;
@@ -88,13 +88,13 @@ static int a2dp_get_sbc_allocation_method(a2dp_sbc_info_t* info)
 static int a2dp_get_sbc_blocks(a2dp_sbc_info_t* info)
 {
     switch (info->block_len) {
-    case A2DP_SBC_BLOCKS_4:
+    case BT_A2DP_SBC_BLOCKS_4:
         return SBC_BLOCK_0;
-    case A2DP_SBC_BLOCKS_8:
+    case BT_A2DP_SBC_BLOCKS_8:
         return SBC_BLOCK_1;
-    case A2DP_SBC_BLOCKS_12:
+    case BT_A2DP_SBC_BLOCKS_12:
         return SBC_BLOCK_2;
-    case A2DP_SBC_BLOCKS_16:
+    case BT_A2DP_SBC_BLOCKS_16:
         return SBC_BLOCK_3;
     default:
         break;
@@ -120,13 +120,13 @@ static int a2dp_get_sbc_subbands(a2dp_sbc_info_t* info)
 static int a2dp_get_sbc_samp_frequency(a2dp_sbc_info_t* info)
 {
     switch (info->samp_freq) {
-    case A2DP_SBC_SAMP_FREQ_16:
+    case BT_A2DP_SBC_SAMP_FREQ_16:
         return SBC_SF_16000;
-    case A2DP_SBC_SAMP_FREQ_32:
+    case BT_A2DP_SBC_SAMP_FREQ_32:
         return SBC_SF_32000;
-    case A2DP_SBC_SAMP_FREQ_44:
+    case BT_A2DP_SBC_SAMP_FREQ_44:
         return SBC_SF_44100;
-    case A2DP_SBC_SAMP_FREQ_48:
+    case BT_A2DP_SBC_SAMP_FREQ_48:
         return SBC_SF_48000;
     default:
         break;
@@ -138,13 +138,13 @@ static int a2dp_get_sbc_samp_frequency(a2dp_sbc_info_t* info)
 static int a2dp_get_sbc_channel_mode(a2dp_sbc_info_t* info)
 {
     switch (info->ch_mode) {
-    case A2DP_SBC_CH_MD_MONO:
+    case BT_A2DP_SBC_CH_MD_MONO:
         return SBC_MONO;
-    case A2DP_SBC_CH_MD_DUAL:
+    case BT_A2DP_SBC_CH_MD_DUAL:
         return SBC_DUAL;
-    case A2DP_SBC_CH_MD_STEREO:
+    case BT_A2DP_SBC_CH_MD_STEREO:
         return SBC_STEREO;
-    case A2DP_SBC_CH_MD_JOINT:
+    case BT_A2DP_SBC_CH_MD_JOINT:
         return SBC_JOINT_STEREO;
     default:
         break;

--- a/service/profiles/a2dp/codec/a2dp_codec_sbc.h
+++ b/service/profiles/a2dp/codec/a2dp_codec_sbc.h
@@ -35,50 +35,50 @@
 
 #include "sbc_encoder.h"
 /* the length of the SBC Media Payload header. */
-#define A2DP_SBC_MPL_HDR_LEN 1
+#define BT_A2DP_SBC_MPL_HDR_LEN 1
 
 /* the sync word of the SBC Media Payload Header */
 #define A2DP_SBC_SYNCWORD 0x9C
 
 /* the LOSC of SBC media codec capabilitiy */
-#define A2DP_SBC_INFO_LEN 6
+#define BT_A2DP_SBC_INFO_LEN 6
 
 /* for Codec Specific Information Element */
-#define A2DP_SBC_SAMP_FREQ_MSK 0xF0 /* b7-b4 sampling frequency */
-#define A2DP_SBC_SAMP_FREQ_16 0x80 /* b7:16  kHz */
-#define A2DP_SBC_SAMP_FREQ_32 0x40 /* b6:32  kHz */
-#define A2DP_SBC_SAMP_FREQ_44 0x20 /* b5:44.1kHz */
-#define A2DP_SBC_SAMP_FREQ_48 0x10 /* b4:48  kHz */
+#define BT_A2DP_SBC_SAMP_FREQ_MSK 0xF0 /* b7-b4 sampling frequency */
+#define BT_A2DP_SBC_SAMP_FREQ_16 0x80 /* b7:16  kHz */
+#define BT_A2DP_SBC_SAMP_FREQ_32 0x40 /* b6:32  kHz */
+#define BT_A2DP_SBC_SAMP_FREQ_44 0x20 /* b5:44.1kHz */
+#define BT_A2DP_SBC_SAMP_FREQ_48 0x10 /* b4:48  kHz */
 
-#define A2DP_SBC_CH_MD_MSK 0x0F /* b3-b0 channel mode */
-#define A2DP_SBC_CH_MD_MONO 0x08 /* b3: mono */
-#define A2DP_SBC_CH_MD_DUAL 0x04 /* b2: dual */
-#define A2DP_SBC_CH_MD_STEREO 0x02 /* b1: stereo */
-#define A2DP_SBC_CH_MD_JOINT 0x01 /* b0: joint stereo */
+#define BT_A2DP_SBC_CH_MD_MSK 0x0F /* b3-b0 channel mode */
+#define BT_A2DP_SBC_CH_MD_MONO 0x08 /* b3: mono */
+#define BT_A2DP_SBC_CH_MD_DUAL 0x04 /* b2: dual */
+#define BT_A2DP_SBC_CH_MD_STEREO 0x02 /* b1: stereo */
+#define BT_A2DP_SBC_CH_MD_JOINT 0x01 /* b0: joint stereo */
 
-#define A2DP_SBC_BLOCKS_MSK 0xF0 /* b7-b4 number of blocks */
-#define A2DP_SBC_BLOCKS_4 0x80 /* 4 blocks */
-#define A2DP_SBC_BLOCKS_8 0x40 /* 8 blocks */
-#define A2DP_SBC_BLOCKS_12 0x20 /* 12blocks */
-#define A2DP_SBC_BLOCKS_16 0x10 /* 16blocks */
+#define BT_A2DP_SBC_BLOCKS_MSK 0xF0 /* b7-b4 number of blocks */
+#define BT_A2DP_SBC_BLOCKS_4 0x80 /* 4 blocks */
+#define BT_A2DP_SBC_BLOCKS_8 0x40 /* 8 blocks */
+#define BT_A2DP_SBC_BLOCKS_12 0x20 /* 12blocks */
+#define BT_A2DP_SBC_BLOCKS_16 0x10 /* 16blocks */
 
-#define A2DP_SBC_SUBBAND_MSK 0x0C /* b3-b2 number of subbands */
+#define BT_A2DP_SBC_SUBBAND_MSK 0x0C /* b3-b2 number of subbands */
 #define BT_A2DP_SBC_SUBBAND_4 0x08 /* b3: 4 */
 #define BT_A2DP_SBC_SUBBAND_8 0x04 /* b2: 8 */
 
-#define A2DP_SBC_ALLOC_MD_MSK 0x03 /* b1-b0 allocation mode */
-#define A2DP_SBC_ALLOC_MD_S 0x02 /* b1: SNR */
-#define A2DP_SBC_ALLOC_MD_L 0x01 /* b0: loundess */
+#define BT_A2DP_SBC_ALLOC_MD_MSK 0x03 /* b1-b0 allocation mode */
+#define BT_A2DP_SBC_ALLOC_MD_S 0x02 /* b1: SNR */
+#define BT_A2DP_SBC_ALLOC_MD_L 0x01 /* b0: loundess */
 
-#define A2DP_SBC_MIN_BITPOOL 2
-#define A2DP_SBC_MAX_BITPOOL 250
-#define A2DP_SBC_BITPOOL_MIDDLE_QUALITY 35
+#define BT_A2DP_SBC_MIN_BITPOOL 2
+#define BT_A2DP_SBC_MAX_BITPOOL 250
+#define BT_A2DP_SBC_BITPOOL_MIDDLE_QUALITY 35
 
 /* for media payload header */
-#define A2DP_SBC_HDR_F_MSK 0x80
-#define A2DP_SBC_HDR_S_MSK 0x40
-#define A2DP_SBC_HDR_L_MSK 0x20
-#define A2DP_SBC_HDR_NUM_MSK 0x0F
+#define BT_A2DP_SBC_HDR_F_MSK 0x80
+#define BT_A2DP_SBC_HDR_S_MSK 0x40
+#define BT_A2DP_SBC_HDR_L_MSK 0x20
+#define BT_A2DP_SBC_HDR_NUM_MSK 0x0F
 
 void a2dp_codec_parse_sbc_param(sbc_param_t* param, uint8_t* codec_info);
 uint16_t a2dp_sbc_sample_frequency(uint16_t sample_frequency);


### PR DESCRIPTION
bug: v/60871

Root cause: The macro names A2DP_SBC_SUBBAND_MSK and A2DP_SBC_SUBBAND_4 conflict with the macros defined in zblue, causing warnings to appear. The names of the macros in the framework were prefixed with BT to resolve the conflict, and the macro names for A2DP SBC defined in the framework were also uniformly prefixed with BT to maintain consistency in style.