### PR TITLE
bluetooth: Fix the memory leak issue in GATTC.

### DIFF
--- a/framework/btwrap/async/bt_gatt_feature.c
+++ b/framework/btwrap/async/bt_gatt_feature.c
@@ -856,7 +856,7 @@ bt_status_t bt_gattc_feature_delete_client_async(bt_instance_t* ins, bt_address_
 {
     gatt_client_t* client;
 
-    if (!ins || !addr || !cb)
+    if (!ins || !addr)
         return BT_STATUS_PARM_INVALID;
 
     client = find_client_by_addr(addr);


### PR DESCRIPTION
bug: v/76459

When deleting GATTC, if the application does not provide a callback, the Bluetooth async API cannot be invoked, leading to the inability to release gattc_remote_list and causing a memory leak.