### PR TITLE
hci: add missing poll remove when close fd.

### DIFF
--- a/service/stacks/zephyr/hci_h4.c
+++ b/service/stacks/zephyr/hci_h4.c
@@ -72,6 +72,8 @@ struct h4_data {
 static const struct device* bt_dev;
 static service_poll_t* hci_handle;
 
+static void hci_remove_recv(void* data);
+
 static void h4_data_dump(const char* tag, uint8_t type, uint8_t* data, uint32_t len)
 {
 #ifdef CONFIG_BT_HCI_H4_DEBUG
@@ -230,6 +232,7 @@ static void bt_sal_hci_transport_recv(void)
     len = read(h4->fd, frame + frame_size, sizeof(frame) - frame_size);
     if (len < 0) {
         BT_LOGE("Reading hci failed, errno %d", errno);
+        hci_remove_recv(NULL);
         close(h4->fd);
         h4->fd = -1;
         return;
@@ -296,10 +299,7 @@ int bt_sal_hci_transport_init(const bt_vhal_interface* vhal)
 
 void bt_sal_hci_transport_cleanup(void)
 {
-    struct h4_data* h4 = bt_dev->data;
-
-    close(h4->fd);
-    h4->fd = -1;
+    return;
 }
 
 static void hci_remove_recv(void* data)
@@ -364,6 +364,18 @@ static int h4_open(const struct device* dev, bt_hci_recv_t recv, void* hci_data)
     return 0;
 }
 
+static int h4_close(const struct device* dev)
+{
+    struct h4_data* h4 = dev->data;
+
+    do_in_service_loop_sync(hci_remove_recv, NULL);
+
+    close(h4->fd);
+    h4->fd = -1;
+
+    return 0;
+}
+
 static int h4_send(const struct device* dev, struct net_buf* buf)
 {
     int len;
@@ -403,6 +415,7 @@ static int h4_send(const struct device* dev, struct net_buf* buf)
 
 const struct bt_hci_driver_api h4_drv_api = {
     .open = h4_open,
+    .close = h4_close,
     .send = h4_send,
 };
 


### PR DESCRIPTION
hci: add missing poll remove when close

bug: v/76968

Before only open was handled, poll fd was added in h4_open() but never removed when close device. When Bluetooth reopen many times, old poll fd still stay inside service loop, cause invalid fd crash in uv__io_poll assert.

Add missing h4_close() to remove poll fd before close fd, avoid invalid fd access during reopen.

![img_v3_02rj_43c51cca-7639-4e95-8ee5-fe8c8a2ae48g](https://github.com/user-attachments/assets/188d4e4f-4254-4510-a874-b4ff22ba3d30)



NuttShell (NSH)
openvela-ap> [    0.110000] [12] [  INFO] [ap] bluetoothd main 34
[    0.115900] [12] [  INFO] [ap] /data/misc/bt folder create: 0
[    0.127500] [11] [  INFO] [ap] pfw domain:SpeakerDomain switch to conf:music
[    0.128200] [11] [  INFO] [ap] process adevsink@pcm0p set_parameter set_scenario=music
[    0.128900] [11] [  INFO] [ap] process amix@MixSpeaker weights 1 1 1 1 1 1 1 0
[    0.129700] [11] [  INFO] [ap] pfw domain:SCOrxDomain switch to conf:disable
[    0.130100] [11] [  INFO] [ap] process astreamselect@SelSCO map -1
[    0.130700] [11] [  INFO] [ap] pfw domain:PlayDomain switch to conf:speaker
[    0.131000] [11] [  INFO] [ap] process astreamselect@SelPlay0 map 0 -1
[    0.131300] [11] [  INFO] [ap] astreamselect@SelPlay0 set graph reconfig
[    0.135500] [11] [  INFO] [ap] process astreamselect@SelPlay1 map 0 -1
[    0.135900] [11] [  INFO] [ap] astreamselect@SelPlay1 set graph reconfig
[    0.138700] [11] [  INFO] [ap] process astreamselect@SelPlay2 map 0 -1
[    0.139100] [11] [  INFO] [ap] astreamselect@SelPlay2 set graph reconfig
[    0.141700] [11] [  INFO] [ap] process astreamselect@SelPlay3 map 0 -1
[    0.142000] [11] [  INFO] [ap] astreamselect@SelPlay3 set graph reconfig
[    0.144600] [11] [  INFO] [ap] pfw domain:AlarmDomain switch to conf:speaker
[    0.144800] [11] [  INFO] [ap] process astreamselect@SelAlarm0 map 0 -1
[    0.145200] [11] [  INFO] [ap] astreamselect@SelAlarm0 set graph reconfig
[    0.148400] [11] [  INFO] [ap] pfw domain:SCOtxDomain switch to conf:default
[    0.148600] [11] [  INFO] [ap] process amoviesink_async@SCOtx stop _
[    0.149000] [11] [  INFO] [ap] moviesink_process_command filter amoviesink_async@SCOtx stop. pos 0
[    0.149500] [11] [  INFO] [ap] pfw domain:MicDomain switch to conf:capture
[    0.149900] [11] [  INFO] [ap] process adevsrc@pcm0c start _
[    0.150100] [11] [  INFO] [ap] adevsrc@pcm0c set graph reconfig
[    0.153100] [11] [  INFO] [ap] process astreamselect@SelCap map 0 0 -1
[    0.153400] [11] [  INFO] [ap] astreamselect@SelCap set graph reconfig
[    0.156800] [11] [  INFO] [ap] pfw domain:IncallVolumeDomain switch to conf:X
[    0.157100] [11] [  INFO] [ap] pfw domain:TTSVolumeDomain switch to conf:index-5
[    0.157400] [11] [  INFO] [ap] process volume@VolSCO volume 10^(-4*(10-5)/20)
[    0.158600] [11] [  INFO] [ap] pfw domain:RingVolumeDomain switch to conf:index-5
[    0.159000] [11] [  INFO] [ap] process volume@VolRing0 volume 10^(-4*(10-5)/20)
[    0.159600] [11] [  INFO] [ap] pfw domain:MediaVolumeDomain switch to conf:index-5
[    0.159800] [11] [  INFO] [ap] process volume@VolMedia0 volume 10^(-4*(10-5)/20)
[    0.160000] [11] [  INFO] [ap] process volume@VolMedia1 volume 10^(-4*(10-5)/20)
[    0.160400] [11] [  INFO] [ap] process volume@VolMedia2 volume 10^(-4*(10-5)/20)
[    0.160600] [11] [  INFO] [ap] process volume@VolMedia2 volume 10^(-4*(10-5)/20)
[    0.161000] [11] [  INFO] [ap] pfw domain:AlarmVolumeDomain switch to conf:index-5
[    0.161200] [11] [  INFO] [ap] process volume@VolAlarm0 volume 10^(-4*(10-5)/20)
[    0.168700] [12] [ ALERT] [ap] Framework log level: 7, Stack:0, mask:00000000, Snoop: 0
[    0.169800] [12] [ DEBUG] [ap] [195][storage]: bt_storage_init successed
[    0.170200] [12] [ DEBUG] [ap] [129][service_manager]: A2DP-Sink service register success
[    0.170400] [12] [ DEBUG] [ap] [129][service_manager]: AVRCP-CT service register success
[    0.170600] [12] [ DEBUG] [ap] [129][service_manager]: GATTC service register success
[    0.171000] [12] [ DEBUG] [ap] [129][service_manager]: GATTS service register success
[    0.171600] [12] [ DEBUG] [ap] [211][adapter-stm]: Enter, PrevState=(null) ---> NewState=Off
[    0.173800] [12] [  INFO] [ap] [32][stack_manager]: Stack Info: Zblue Ver:5.4 Sal:2
[    0.175100] [12] [ DEBUG] [ap] [411][h4]: Bluetooth H4 driver
[    0.175400] [12] [ DEBUG] [ap] [411][h4]: Bluetooth H4 driver
[    0.175700] [12] [ DEBUG] [ap] [45][stack_manager]: stack_manager_init done
[    0.176000] [12] [ DEBUG] [ap] [263][bt_service]: bt_service_init done
[    0.176500] [12] [ DEBUG] [ap] [263][service_loop]: service loop running now !!!
[    0.176900] [12] [ DEBUG] [ap] [136][service_loop]: service_schedule_loop:0x403d39f0, async:0x40881084
[    0.177900] [12] [ DEBUG] [ap] [83][service_loop]: set_ready
INFO    | Your emulator is out of date, please update by launching Android Studio:
 - Start Android Studio
 - Select menu "Tools > Android > SDK Manager"
 - Click "SDK Tools" tab
 - Check "Android Emulator" checkbox
 - Click "OK"

openvela-ap> 
openvela-ap> bttool
[    1.359000] [25] [ DEBUG] [ap] thread_schedule_loop:0x408afd48, async:0x40881a00
[    1.359700] [25] [ DEBUG] [ap] set_ready
[    1.360200] [24] [ DEBUG] [ap] bt_client_19 loop running now !!!
[    1.361800] [24] [ DEBUG] [ap] [async_queue:85]uv_async_queue_init
bttool> enable
[    2.242600] [12] [ DEBUG] [ap] [250][adapter-stm]: Process, State=Off, Event=SYS_TURN_ON
[    2.243400] [12] [ DEBUG] [ap] [227][adapter-stm]: Exit, State=Off
[    2.243900] [12] [ DEBUG] [ap] [273][adapter-stm]: Enter, PrevState=Off ---> NewState=BleTurningOn
[    2.245400] [12] [ ERROR] [ap] [356][h4]: H4: /dev/ttyHCI0 opened as fd:3602
[    2.246200] [14] [  INFO] [ap] dev:0: Sending HCI_RESET
[    2.248300] [12] [ DEBUG] [ap] [1249][adapter-svc]: adapter_notify_state_change, prev:0--->current:1
bttool> [bttool] Context:0x408bba50, Adapter state changed: 1
[    2.415000] [14] [  INFO] [ap] <inf> [bt_dev_show_info] <3914>: Identity: 00:1B:DC:F4:B4:A4 (public)
[    2.415400] [14] [  INFO] [ap] <inf> [bt_dev_show_info] <3944>: HCI: version 4.2 (0x08) revision 0x30e8, manufacturer 0x000a
[    2.415800] [14] [  INFO] [ap] <inf> [bt_dev_show_info] <3947>: LMP: version 4.2 (0x08) subver 0x30e8
[    2.417900] [14] [ ERROR] [ap] <err> [generate_dh_key] <187>: Failed to import the private key for key agreement -135
[    2.418400] [12] [ DEBUG] [ap] [292][adapter-stm]: Process, State=BleTurningOn, Event=BLE_ENABLED
[    2.419000] [12] [ DEBUG] [ap] [89][service_manager]: service_on_startup {GATTC} start ret:1
[    2.419300] [12] [ DEBUG] [ap] [89][service_manager]: service_on_startup {GATTS} start ret:1
[    2.419700] [12] [ DEBUG] [ap] [99][service_manager]: service_on_startup all profiles is startup
[    2.420100] [12] [ DEBUG] [ap] [1839][adapter-svc]: BLE transport all profiles is startup
[    2.420600] [12] [ DEBUG] [ap] [292][adapter-stm]: Process, State=BleTurningOn, Event=BLE_PROFILE_ENABLED
[    2.420900] [12] [ DEBUG] [ap] [287][adapter-stm]: Exit, State=BleTurningOn
[    2.421300] [12] [ DEBUG] [ap] [315][adapter-stm]: Enter, PrevState=BleTurningOn ---> NewState=BleOn
[    2.421600] [12] [ DEBUG] [ap] [1249][adapter-svc]: adapter_notify_state_change, prev:1--->current:2
[    2.422100] [12] [ DEBUG] [ap] [1309][adapter-svc]: adapter_on_le_enabled, enablebt:1
[    2.422600] [12] [ DEBUG] [ap] [1319][adapter-svc]: adapter_on_le_enabled, le_addr:00:1B:DC:F4:B4:A4
[bttool] Context:0x408bba50, Adapter state changed: 2
[    2.423700] [12] [ DEBUG] [ap] [331][adapter-stm]: Process, State=BleOn, Event=SYS_TURN_ON
[    2.424000] [12] [ DEBUG] [ap] [326][adapter-stm]: Exit, State=BleOn
[    2.424200] [12] [ DEBUG] [ap] [350][adapter-stm]: Enter, PrevState=BleOn ---> NewState=TurningOn
[    2.427400] [12] [ DEBUG] [ap] [1249][adapter-svc]: adapter_notify_state_change, prev:2--->current:3
[    2.428000] [12] [ DEBUG] [ap] [519][adapter-svc]: ble bonded device cnt: 0
[    2.428500] [12] [ DEBUG] [ap] [493][adapter-svc]: ble whitelist device cnt: 0
[    2.428800] [12] [ DEBUG] [ap] [451][adapter-svc]: load classic bonded device successfully:
[    2.429500] [12] [ DEBUG] [ap] [372][adapter-svc]: load_remote_uuids, No uuids found
[    2.429900] [12] [ DEBUG] [ap] [465][adapter-svc]: BONDED DEVICE[0], Name:[v13] Addr:[44:71:47:19:8B:0E] LinkKey: [07] | [0821BB4D4EEBA780C6B795ED5C78592F]
[    2.430500] [12] [ DEBUG] [ap] [372][adapter-svc]: load_remote_uuids, No uuids found
[    2.430800] [12] [ DEBUG] [ap] [465][adapter-svc]: BONDED DEVICE[1], Name:[k60aaa] Addr:[2C:FE:4F:7A:12:8B] LinkKey: [07] | [65CCE0C0A1EE731A0BEEB6710109CEB9]
[    2.431300] [12] [ DEBUG] [ap] [472][adapter-svc]: classic bonded device cnt: 2
[    2.431600] [12] [ DEBUG] [ap] [367][adapter-stm]: Process, State=TurningOn, Event=BREDR_ENABLED
[    2.433200] [12] [ DEBUG] [ap] [316][audio_transport]: audio_transport_open path{2}[a2dp_sink_ctrl] success
[    2.433600] [12] [ DEBUG] [ap] [316][audio_transport]: audio_transport_open path{3}[a2dp_sink_data] success
[    2.433900] [12] [ DEBUG] [ap] [89][service_manager]: service_on_startup {A2DP-Sink} start ret:1
[    2.434500] [12] [ DEBUG] [ap] [89][service_manager]: service_on_startup {AVRCP-CT} start ret:1
[    2.435000] [12] [ DEBUG] [ap] [99][service_manager]: service_on_startup all profiles is startup
[    2.435400] [12] [ DEBUG] [ap] [1839][adapter-svc]: BREDR transport all profiles is startup
[    2.435700] [12] [ DEBUG] [ap] [367][adapter-stm]: Process, State=TurningOn, Event=BREDR_PROFILE_ENABLED
[    2.436000] [12] [ DEBUG] [ap] [362][adapter-stm]: Exit, State=TurningOn
[    2.436400] [12] [ DEBUG] [ap] [389][adapter-stm]: Enter, PrevState=TurningOn ---> NewState=On
[    2.437000] [12] [  INFO] [ap] [1401][adapter-svc]: Adapter Info:
        Name:XIAOMI VELA-10A
        Address:00:1B:DC:F4:B4:A4
        IoCap:3
        Scanmode:2
        Bondable:1
        DeviceClass:0x00280704

[    2.437600] [12] [ DEBUG] [ap] [1249][adapter-svc]: adapter_notify_state_change, prev:3--->current:4
[    2.441800] [12] [ DEBUG] [ap] [276][a2dp_control]: a2dp_ctrl_cb, path:[a2dp_sink_ctrl], event:TRANSPORT_OPEN_EVT
[    2.442400] [12] [ DEBUG] [ap] [304][a2dp_control]: a2dp_data_cb, path:[a2dp_sink_data], event:TRANSPORT_OPEN_EVT
[    2.443100] [27] [ DEBUG] [ap] [655][sal_adapter]: zblue_set_name: XIAOMI VELA-10A
[bttool] Context:0x408bba50, Adapter state changed: 3
[bttool] Context:0x408bba50, Adapter state changed: 4
[    2.446100] [12] [  WARN] [ap] [1435][BT]: interface [bt_sal_le_enable_key_derivation] not supported
[bttool] Adapter Name: XIAOMI VELA-10A, Cap: 3, Class: 0x00280704, Mode:2
[bttool] Adapter new scan mode: 2

bttool> disable
[    7.042500] [12] [ DEBUG] [ap] [410][adapter-stm]: Process, State=On, Event=SYS_TURN_OFF_SAFE
[    7.043500] [12] [ DEBUG] [ap] [410][adapter-stm]: Process, State=On, Event=BREDR_ACL_ALL_DISCONNECTED
[    7.043900] [12] [ DEBUG] [ap] [404][adapter-stm]: Exit, State=On
[    7.044200] [12] [ DEBUG] [ap] [439][adapter-stm]: Enter, PrevState=On ---> NewState=TurningOff
[    7.044900] [12] [ DEBUG] [ap] [1249][adapter-svc]: adapter_notify_state_change, prev:4--->current:5
[    7.045500] [12] [ DEBUG] [ap] [261][a2dp_snk_stream]: a2dp_sink_on_stopped
[    7.047300] [12] [ DEBUG] [ap] [109][service_manager]: service_on_shutdown {A2DP-Sink} shutdown ret:1
[    7.047900] [12] [ DEBUG] [ap] [109][service_manager]: service_on_shutdown {AVRCP-CT} shutdown ret:1
[    7.048300] [12] [ DEBUG] [ap] [119][service_manager]: service_on_shutdown all profile is shutdown
[    7.048600] [12] [ DEBUG] [ap] [1851][adapter-svc]: BREDR transport all profiles is shutdown
[    7.049000] [12] [ DEBUG] [ap] [460][adapter-stm]: Process, State=TurningOff, Event=BREDR_PROFILE_DISABLED
[    7.049500] [12] [ DEBUG] [ap] [460][adapter-stm]: Process, State=TurningOff, Event=BREDR_DISABLED
[    7.050200] [12] [ DEBUG] [ap] [454][adapter-stm]: Exit, State=TurningOff
[    7.050600] [12] [ DEBUG] [ap] [1415][adapter-svc]: adapter_on_br_disabled
[    7.051200] [12] [ DEBUG] [ap] [485][adapter-stm]: Enter, PrevState=TurningOff ---> NewState=BleTurningOff
[    7.051800] [12] [ DEBUG] [ap] [109][service_manager]: service_on_shutdown {GATTC} shutdown ret:1
[    7.052200] [12] [ DEBUG] [ap] [109][service_manager]: service_on_shutdown {GATTC} shutdown ret:1
[    7.052900] [12] [ DEBUG] [ap] [109][service_manager]: service_on_shutdown {GATTS} shutdown ret:1
[    7.053100] [12] [ DEBUG] [ap] [119][service_manager]: service_on_shutdown all profile is shutdown
[    7.053600] [12] [ DEBUG] [ap] [1851][adapter-svc]: BLE transport all profiles is shutdown
[    7.054000] [12] [ DEBUG] [ap] [1361][adapter-svc]: adapter_on_le_disabled
[    7.054500] [12] [ DEBUG] [ap] [1249][adapter-svc]: adapter_notify_state_change, prev:5--->current:6
[    7.055200] [12] [ DEBUG] [ap] [508][adapter-stm]: Process, State=BleTurningOff, Event=BLE_PROFILE_DISABLED
[    7.055800] [12] [ DEBUG] [ap] [508][adapter-stm]: Process, State=BleTurningOff, Event=BLE_DISABLED
[    7.056200] [12] [ DEBUG] [ap] [501][adapter-stm]: Exit, State=BleTurningOff
[    7.056500] [12] [ DEBUG] [ap] [211][adapter-stm]: Enter, PrevState=BleTurningOff ---> NewState=Off
[    7.056900] [12] [ DEBUG] [ap] [1249][adapter-svc]: adapter_notify_state_change, prev:6--->current:0
[    7.057400] [12] [ DEBUG] [ap] [304][a2dp_control]: a2dp_data_cb, path:[a2dp_sink_data], event:TRANSPORT_CLOSE_EVT
[    7.057800] [12] [ DEBUG] [ap] [311][a2dp_control]: a2dp_data_cb: ## AUDIO PATH DETACHED ##
[    7.058100] [12] [ DEBUG] [ap] [276][a2dp_control]: a2dp_ctrl_cb, path:[a2dp_sink_ctrl], event:TRANSPORT_CLOSE_EVT
[    7.058500] [12] [  INFO] [ap] [110][audio_transport]: transport_connection_close_cb transport freed:0x0x4087ea90
bttool> [bttool] Context:0x408bba50, Adapter state changed: 5
[bttool] Context:0x408bba50, Adapter state changed: 6
[bttool] Context:0x408bba50, Adapter state changed: 0
[    7.063100] [27] [  WARN] [ap] <wrn> [bt_smp_pkey_ready] <4921>: Public key not available

bttool> enable
[    8.834700] [12] [ DEBUG] [ap] [250][adapter-stm]: Process, State=Off, Event=SYS_TURN_ON
[    8.834900] [12] [ DEBUG] [ap] [227][adapter-stm]: Exit, State=Off
[    8.835100] [12] [ DEBUG] [ap] [273][adapter-stm]: Enter, PrevState=Off ---> NewState=BleTurningOn
[    8.835500] [12] [ ERROR] [ap] [356][h4]: H4: /dev/ttyHCI0 opened as fd:4383
[    8.835700] [14] [  INFO] [ap] dev:0: Sending HCI_RESET
[    8.836100] [12] [ DEBUG] [ap] [1249][adapter-svc]: adapter_notify_state_change, prev:0--->current:1
bttool> [bttool] Context:0x408bba50, Adapter state changed: 1
[    8.951500] [12] [ ERROR] [ap] [232][h4]: Reading hci failed, errno 11
[    8.952000] [12] [ ALERT] [ap] dump_assert_info: Current Version: NuttX  0.0.0 c97244db18 Oct 31 2025 17:30:43 arm
[    8.952000] [12] [ ALERT] [ap] dump_assert_info: Assertion failed : at file: libuv/src/unix/linux.c:1463 task: bluetoothd process: bluetoothd 0x7dd189
[    8.952000] [12] [ ALERT] [ap] up_dump_register: R0: 40226be0 R1: 000005b7 R2: 00000000  R3: 00000000
[    8.952000] [12] [ ALERT] [ap] up_dump_register: R4: 4086f020 R5: 00006be0 R6: ffffffff  FP: 40893918
[    8.952000] [12] [ ALERT] [ap] up_dump_register: R8: 00000000 SB: 00cc83b4 SL: 40226474 R11: 000005b7
[    8.952000] [12] [ ALERT] [ap] up_dump_register: IP: 00000000 SP: 40893900 LR: 006027a9  PC: 006027a9
[    8.952000] [12] [ ALERT] [ap] up_dump_register: CPSR: 600700df
[    8.952000] [12] [ ALERT] [ap] dump_stackinfo: User Stack:
[    8.952000] [12] [ ALERT] [ap] dump_stackinfo:   base: 0x40892028
[    8.952000] [12] [ ALERT] [ap] dump_stackinfo:   size: 00008088
[    8.952000] [12] [ ALERT] [ap] dump_stackinfo:     sp: 0x40893900
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x408938e0: 40893900 00001510 40893918 40892028 402263a0 40226474 40893fc0 006028ed
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893900: 00cc83b4 000005b7 4086f0c4 4086f0c4 007dd189 00000000 00000000 00001f98
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893920: 0000005f 00000006 4086f020 40226be0 00000000 00cc83b4 4086f020 40226be0
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893940: 00000000 00cc83b4 000005b7 00000000 7474754e 00000058 408a75f8 408a75f8
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893960: 408a7600 408a0000 d3d2d1d0 d7d6d5d4 dbdad9d8 dfdedddc c3c2c1c0 c7c6c5c4
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893980: cbcac9c8 302e3000 b300302e b7b6b5b4 bbbab9b8 bfbebdbc 3963a1a0 34343237
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x408939a0: 38316264 74634f20 20313320 35323032 3a373120 343a3033 83820033 87868584
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x408939c0: 8b8a8988 8f8e8d8c 00000010 6d726110 0061c400 00cc83b4 000005b7 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x408939e0: 00000000 00d3e708 ffffffff 00000000 ffffffff ffffffff 40893a10 403d39f0
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893a00: 403d39f0 00000030 ffffffff 0061c4f9 40893a18 00d3e708 40893a28 006920a1
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893a20: 00000000 40893a88 40893b91 00627c43 ffffffff ffffffff 00000030 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893a40: 00000000 000022f7 40453444 00000000 00000000 00000000 00000001 00000341
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893a60: 403d3b50 ffffffff 00000001 40897494 404533b8 40893aa0 00000000 40893aa0
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893a80: 40893ab0 ffffffff 00000000 00000000 00000000 00000000 40893aa0 0061fb6f
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893aa0: 0000000e 00000000 00000000 00d3e708 00000001 00000200 0000111f 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893ac0: 00000001 40893b58 00000e12 00000000 00000001 00d3e708 00000947 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893ae0: 40893ae8 00d3e708 ffffffff 40221ba4 0000000c 00000001 40893b00 0061cf35
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893b00: 00000000 00d3e708 40221ba4 ffffffff 40893b18 00671aab 00000001 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893b20: 00000000 fffffffe 40893b60 00000001 40893b38 00648bf5 40882428 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893b40: 40893b48 0066b86d 40893b50 00d3e708 40882428 40893ba0 40893b60 0064b569
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893b60: 40893bf9 00000000 00000000 4088dd60 00000000 00000000 70643261 7461645f
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893b80: 00000000 00000000 70643261 7274635f 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893ba0: 00000000 00000000 00000000 00000000 4c435f54 5f45534f 6e6f6974 6f6c635f
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893bc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893be0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893c00: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893c20: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893c40: 00000004 00000004 408e29e8 408e29e8 408e29f0 408e29f0 d3d2d1d0 d7d6d5d4
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893c60: dbdad9d8 dfdedddc c3c2c1c0 c7c6c5c4 cbcac9c8 cfcecdcc b3b2b1b0 b7b6b5b4
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893c80: bbbab9b8 bfbebdbc a3a2a1a0 a7a6a5a4 abaaa9a8 afaeadac 93929190 97969594
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893ca0: 9b9a9998 9f9e9d9c 83828180 87868584 8b8a8988 8f8e8d8c 00000010 40893d00
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893cc0: 0000005f 00000061 40227b04 00000000 40227b05 90000000 40893da3 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893ce0: 40893d00 402215fc 00000001 40221604 40893cf8 0060bf7b 0060b8ce 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893d00: ffffffff 00000001 0000000c 00d3e708 40893d18 00000000 00000001 0060c199
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893d20: 40893d38 40893da3 00d3e6b8 00d3e698 00000001 0060c1b5 00cd4950 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893d40: 40893d48 00b62769 00d86f4c 00d3e694 40893da3 00000000 00000001 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893d60: 00000000 40893da3 00000000 00000000 00000000 00000000 006229ad 408582b0
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893d80: 00d3e708 408e1bd8 00d3e708 40881170 00ce45a4 408bb4a0 408bcc80 408e1bf0
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893da0: 00b6432f 408e1c0c 00000000 00000000 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893dc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893de0: 00000000 00000000 00000000 00000000 00000000 00000000 408e29e8 408e29e8
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893e00: 408e29f0 408e29f0 d3d2d1d0 d7d6d5d4 dbdad9d8 dfdedddc c3c2c1c0 c7c6c5c4
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893e20: cbcac9c8 cfcecdcc b3b2b1b0 b7b6b5b4 bbbab9b8 bfbebdbc a3a2a1a0 a7a6a5a4
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893e40: abaaa9a8 afaeadac 93929190 97969594 9b9a9998 9f9e9d9c 83828180 87868584
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893e60: 8b8a8988 8f8e8d8c 00000010 40893eb0 0068efdb 403d39f0 00000000 00061a80
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893e80: 00000000 00000000 40893eec 403d3a18 40893eb8 00000000 00000008 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893ea0: 40893ea8 0066fcff 006973be 403d39f0 40893eec 00d3e708 40893ee0 403d39f0
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893ec0: 40893eec 403d3a18 40893ee0 00000000 00000008 00000000 00000001 0068eecf
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893ee0: 00000001 00000001 00000001 00d3e708 00000000 00d3e708 40893f00 40881040
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893f00: 408c15f0 40881040 40893f28 408810c8 00000000 00000000 00000000 007e7c29
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893f20: 40881084 00621d01 40893f40 00d3e708 00000000 40881040 00ce2cf4 40893f50
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893f40: 00000000 007e7e51 40893f68 00000000 00000000 00000000 00000000 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893f60: 00000000 00000001 40892010 40893f78 00000000 007dd1ef 00000000 00d3e708
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893f80: 00000000 007dd189 40893f90 0061d7a7 40893fa0 00d3e708 40893fa0 00603d19
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893fa0: 00000000 00d3e708 00000000 00000000 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] stack_dump: 0x40893fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: backtrace:
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x68ab9a>] backtrace_unwind+0x241/0x564398
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x6713f8>] sched_backtrace+0x5f/0xfffac34c
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x61d722>] sched_dumpstack+0x3d/0x546794
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x602640>] _assert+0x1a7/0xe2c4
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x61c4f6>] __assert+0x19/0x614418
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x69209e>] uv__io_poll+0x425/0xffffdb64
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x68eecc>] uv_run+0xcf/0x7394
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x7e7c26>] service_schedule_loop+0x85/0x5418
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x7e7e4e>] service_loop_run+0xbd/0x46c
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x7dd1ec>] bluetoothd_main+0x63/0xffe92084
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x61d7a4>] nxtask_startup+0x1f/0xfffe9c4c
[    8.952000] [12] [ ALERT] [ap] sched_dumpstack: [12] [<0x603d16>] nxtask_start+0x71/0x634e18

