### PR TITLE
double free

### DIFF
--- a/feature/feature_async/src/bluetooth_impl.c
+++ b/feature/feature_async/src/bluetooth_impl.c
@@ -100,5 +100,6 @@ void system_bluetooth_wrap_getAddressAsync(FeatureInstanceHandle feature, Append
 
     FeaturePromiseReject(feature, pid, status, "get address failed!");
     FeatureFreeInstanceHandle(data->feature_ins);
-    free(data);
+    if (!data)
+        free(data);
 }


### PR DESCRIPTION
bug: v/73215

rootcause: repeatedly releasing memory causes the program to crash
