### PR TITLE
adapt zephyr smp ctkd bond state report.

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -130,10 +130,10 @@ static void zblue_on_passkey_confirm(struct bt_conn* conn, unsigned int passkey)
 static void zblue_on_cancel(struct bt_conn* conn);
 static void zblue_on_pairing_confirm(struct bt_conn* conn);
 static void zblue_on_pincode_entry(struct bt_conn* conn, bool highsec);
+static void zblue_on_br_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_key);
 static void zblue_on_link_key_notify(struct bt_conn* conn, uint8_t* key, uint8_t key_type);
-static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded);
-static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err reason);
-static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
+static void zblue_on_br_pairing_failed(struct bt_conn* conn, enum bt_security_err reason);
+static void zblue_on_br_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
 static void zblue_register_callback(void);
 static void zblue_unregister_callback(void);
 
@@ -156,10 +156,10 @@ static struct bt_conn_cb g_conn_cbs = {
 };
 
 static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
+    .pairing_complete_ctkd = zblue_on_br_pairing_complete_ctkd,
     .link_key_notify = zblue_on_link_key_notify,
-    .pairing_complete = zblue_on_pairing_complete,
-    .pairing_failed = zblue_on_pairing_failed,
-    .bond_deleted = zblue_on_bond_deleted,
+    .pairing_failed = zblue_on_br_pairing_failed,
+    .bond_deleted = zblue_on_br_bond_deleted,
 };
 
 static struct bt_conn_auth_cb g_conn_auth_cbs = {
@@ -384,6 +384,25 @@ static void zblue_on_pincode_entry(struct bt_conn* conn, bool highsec)
     adapter_on_pin_request(&addr, 0, true, NULL);
 }
 
+static void zblue_on_br_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_key)
+{
+    bt_address_t addr;
+    const bt_addr_le_t* dst;
+
+    if (!is_link_key) {
+        return;
+    }
+
+    dst = bt_conn_get_dst(conn);
+    if (!dst) {
+        return;
+    }
+
+    memcpy(addr.addr, dst->a.val, sizeof(addr.addr));
+
+    adapter_on_bond_state_changed(&addr, BOND_STATE_BONDED, BT_TRANSPORT_BREDR, BT_STATUS_SUCCESS, true);
+}
+
 static void zblue_on_link_key_notify(struct bt_conn* conn, uint8_t* key, uint8_t key_type)
 {
     bt_address_t addr;
@@ -397,26 +416,7 @@ static void zblue_on_link_key_notify(struct bt_conn* conn, uint8_t* key, uint8_t
     adapter_on_bond_state_changed(&addr, BOND_STATE_BONDED, BT_TRANSPORT_BREDR, BT_STATUS_SUCCESS, false);
 }
 
-static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded)
-{
-    bt_address_t addr;
-    bond_state_t state;
-
-    if (!bt_conn_get_dst_br(conn)) {
-        return;
-    }
-
-    if (bonded) {
-        state = BOND_STATE_BONDED;
-        /* Start timer, waiting for linkkey notify */
-    } else {
-        state = BOND_STATE_NONE;
-        zblue_conn_get_addr(conn, &addr);
-        adapter_on_bond_state_changed(&addr, state, BT_TRANSPORT_BREDR, BT_STATUS_AUTH_FAILURE, false);
-    }
-}
-
-static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err reason)
+static void zblue_on_br_pairing_failed(struct bt_conn* conn, enum bt_security_err reason)
 {
     bt_address_t addr;
 
@@ -429,7 +429,7 @@ static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err r
     bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
 }
 
-static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer)
+static void zblue_on_br_bond_deleted(uint8_t id, const bt_addr_le_t* peer)
 {
     bt_address_t addr;
 

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -75,6 +75,7 @@ extern void z_sys_init(void);
 static void zblue_on_connected(struct bt_conn* conn, uint8_t err);
 static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason);
 static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level, enum bt_security_err err);
+static void zblue_on_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_key);
 static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded);
 static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err reason);
 static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
@@ -112,6 +113,7 @@ static struct bt_conn_cb g_conn_cbs = {
 };
 
 static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
+    .pairing_complete_ctkd = zblue_on_pairing_complete_ctkd,
     .pairing_complete = zblue_on_pairing_complete,
     .pairing_failed = zblue_on_pairing_failed,
     .bond_deleted = zblue_on_bond_deleted,
@@ -455,6 +457,27 @@ static void zblue_on_phy_updated(struct bt_conn* conn, struct bt_conn_le_phy_inf
     }
 }
 #endif /*CONFIG_BT_USER_PHY_UPDATE*/
+
+static void zblue_on_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_key)
+{
+    bt_address_t addr;
+    const bt_addr_t* dst;
+
+    if (is_link_key) {
+        return;
+    }
+
+    BT_LOGD("%s", __func__);
+
+    dst = bt_conn_get_dst_br(conn);
+    if (!dst) {
+        return;
+    }
+
+    memcpy(addr.addr, dst->val, sizeof(addr.addr));
+
+    adapter_on_bond_state_changed(&addr, BOND_STATE_BONDED, BT_TRANSPORT_BLE, BT_STATUS_SUCCESS, true);
+}
 
 static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded)
 {

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -284,8 +284,8 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
         memcpy(&state.addr, remote_addr, sizeof(state.addr));
         state.addr_type = adapter_get_le_remote_address_type(remote_addr);
     } else {
-        memcpy(&state.addr, &le_addr, sizeof(state.addr));
-        state.addr_type = info.le.dst->type;
+        memcpy(&state.addr, info.le.remote->a.val, sizeof(state.addr));
+        state.addr_type = info.le.remote->type;
     }
 
     slot = le_conn_find(&state.addr);
@@ -334,7 +334,7 @@ static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,
     if (remote_addr) {
         memcpy(&addr, remote_addr, sizeof(addr.addr));
     } else {
-        memcpy(&addr, &le_addr, sizeof(addr.addr));
+        memcpy(&addr, info.le.remote->a.val, sizeof(addr.addr));
     }
 
     if (err && !adapter_get_pts_mode()) {
@@ -366,7 +366,7 @@ static void zblue_on_param_updated(struct bt_conn* conn, uint16_t interval, uint
     if (remote_addr) {
         memcpy(&addr, remote_addr, sizeof(addr.addr));
     } else {
-        memcpy(&addr, &le_addr, sizeof(addr.addr));
+        memcpy(&addr, info.le.remote->a.val, sizeof(addr.addr));
     }
 
     BT_LOGD("%s, interval:%d, latency:%d, timeout:%d", __func__, interval, latency, timeout);
@@ -443,7 +443,7 @@ static void zblue_on_phy_updated(struct bt_conn* conn, struct bt_conn_le_phy_inf
     if (remote_addr) {
         memcpy(&addr, remote_addr, sizeof(addr.addr));
     } else {
-        memcpy(&addr, &le_addr, sizeof(addr.addr));
+        memcpy(&addr, info.le.remote->a.val, sizeof(addr.addr));
     }
 
     if_gatts_on_phy_updated(&addr, tx_mode, rx_mode, GATT_STATUS_SUCCESS);
@@ -458,18 +458,16 @@ static void zblue_on_phy_updated(struct bt_conn* conn, struct bt_conn_le_phy_inf
 
 static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded)
 {
-    struct bt_conn_info info;
     bt_address_t addr;
     bond_state_t state;
 
     BT_LOGD("%s", __func__);
-    bt_conn_get_info(conn, &info);
 
-    if (info.type != BT_CONN_TYPE_LE) {
+    if (get_le_addr_from_conn(conn, &addr) != BT_STATUS_SUCCESS) {
+        BT_LOGE("%s, get_le_addr_from_conn failed", __func__);
         return;
     }
 
-    memcpy(&addr, info.le.remote->a.val, sizeof(addr));
     if (bonded) {
         state = BOND_STATE_BONDED;
     } else {
@@ -481,17 +479,15 @@ static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded)
 
 static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err reason)
 {
-    struct bt_conn_info info;
     bt_address_t addr;
 
     BT_LOGD("%s", __func__);
-    bt_conn_get_info(conn, &info);
 
-    if (info.type != BT_CONN_TYPE_LE) {
+    if (get_le_addr_from_conn(conn, &addr) != BT_STATUS_SUCCESS) {
+        BT_LOGE("%s, get_le_addr_from_conn failed", __func__);
         return;
     }
 
-    memcpy(&addr, info.le.dst->a.val, sizeof(addr));
     adapter_on_bond_state_changed(&addr, BOND_STATE_NONE, BT_TRANSPORT_BLE, BT_STATUS_AUTH_FAILURE, false);
     if (!adapter_get_pts_mode())
         bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
@@ -636,7 +632,7 @@ bt_status_t get_le_addr_from_conn(struct bt_conn* conn, bt_address_t* addr)
         memcpy(addr, resolved_addr, sizeof(bt_address_t));
         BT_LOGD("%s: fallback to bt_conn_info and resolved RPA to identity address", __func__);
     } else {
-        memcpy(addr, info.le.dst->a.val, sizeof(bt_address_t));
+        memcpy(addr, info.le.remote->a.val, sizeof(bt_address_t));
     }
 
     return BT_STATUS_SUCCESS;


### PR DESCRIPTION
depends-on: [open-vela/external_zblue/pull/109]