### PR TITLE
Refactor profile connection flow to async per-device manager

### DIFF
--- a/service/stacks/zephyr/include/sal_connection_manager.h
+++ b/service/stacks/zephyr/include/sal_connection_manager.h
@@ -22,14 +22,35 @@ typedef struct {
     uint8_t profile_id;
 } cm_data_t;
 
+typedef bt_status_t (*bt_profile_conn_handler_t)(
+    bt_controller_id_t id, bt_address_t* addr);
+
+typedef struct {
+    bt_profile_conn_handler_t handler;
+    uint8_t profile_id;
+    bt_controller_id_t id;
+} bt_profile_conn_handler_node_t;
+
+bt_status_t bt_sal_profile_connect_request(bt_address_t* addr,
+    uint8_t profile_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler);
+bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr,
+    uint8_t profile_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler);
+bt_status_t bt_sal_profile_disconnect_request(bt_address_t* addr,
+    uint8_t profile_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler);
+bt_status_t bt_sal_remove_bond_internal(bt_controller_id_t id,
+    bt_address_t* addr);
+bt_status_t bt_sal_disconnect_internal(bt_controller_id_t id,
+    bt_address_t* addr, uint8_t reason);
+
 cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id);
+void bt_sal_cm_profile_connected_callback(cm_data_t* data);
 void bt_sal_cm_profile_disconnected_callback(cm_data_t* data);
+void bt_sal_cm_acl_connected_callback(cm_data_t* data);
 void bt_sal_cm_acl_disconnected_callback(cm_data_t* data);
 
 void bt_sal_cm_conn_init(void);
 bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair);
 void bt_sal_cm_conn_cleanup(void);
-
-bool bt_sal_a2dp_try_disconnect_a2dp_sink(bt_controller_id_t id, bt_address_t* addr);
-bool bt_sal_a2dp_try_disconnect_a2dp_srouce(bt_controller_id_t id, bt_address_t* addr);
-bool bt_sal_avrcp_try_disconnect_avrcp_control(bt_controller_id_t id, bt_address_t* addr);

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -80,6 +80,14 @@ static bt_list_t* bt_a2dp_conn = NULL;
 
 static void bt_list_remove_a2dp_info(struct zblue_a2dp_info_t* a2dp_info);
 
+#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr);
+#endif
+
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr);
+#endif
+
 static void flag_reset(struct zblue_a2dp_info_t* a2dp_info)
 {
     a2dp_info->state = 0x00;
@@ -901,6 +909,21 @@ static void zblue_on_stream_established(struct bt_a2dp_stream* stream)
     }
 }
 
+static void bt_sal_a2dp_notify_connected(struct zblue_a2dp_info_t* a2dp_info)
+{
+    if (a2dp_info->role == SEP_SRC) {
+#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP));
+        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP, PRIMARY_ADAPTER, a2dp_source_disconnect);
+#endif
+    } else { /* SEP_SNK */
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK));
+        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, PRIMARY_ADAPTER, a2dp_sink_disconnect);
+#endif
+    }
+}
+
 static void bt_sal_a2dp_notify_disconnected(struct zblue_a2dp_info_t* a2dp_info)
 {
     if (a2dp_info->role == SEP_SRC) {
@@ -1184,6 +1207,7 @@ static void zblue_on_connected(struct bt_a2dp* a2dp, int err)
     a2dp_info->selected_peer_endpoint = NULL;
 
     bt_list_add_tail(bt_a2dp_conn, a2dp_info);
+    bt_sal_a2dp_notify_connected(a2dp_info);
 }
 
 static void bt_list_remove_a2dp_info(struct zblue_a2dp_info_t* a2dp_info)
@@ -1558,9 +1582,9 @@ bt_status_t bt_sal_a2dp_sink_init(uint8_t max_connections)
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
 }
 
-bt_status_t bt_sal_a2dp_source_connect(bt_controller_id_t id, bt_address_t* addr)
-{
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+static bt_status_t a2dp_source_profile_connect(bt_controller_id_t id, bt_address_t* addr)
+{
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     struct zblue_a2dp_info_t* a2dp_info;
     struct bt_a2dp* a2dp;
@@ -1608,14 +1632,21 @@ bt_status_t bt_sal_a2dp_source_connect(bt_controller_id_t id, bt_address_t* addr
 error:
     bt_conn_unref(conn);
     return BT_STATUS_FAIL;
+}
+#endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
+
+bt_status_t bt_sal_a2dp_source_connect(bt_controller_id_t id, bt_address_t* addr)
+{
+#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+    return bt_sal_profile_connect_request(addr, PROFILE_A2DP, id, a2dp_source_profile_connect);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
 }
 
-bt_status_t bt_sal_a2dp_sink_connect(bt_controller_id_t id, bt_address_t* addr)
-{
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
+static bt_status_t a2dp_sink_profile_connect(bt_controller_id_t id, bt_address_t* addr)
+{
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     struct zblue_a2dp_info_t* a2dp_info;
     struct bt_a2dp* a2dp;
@@ -1663,6 +1694,13 @@ bt_status_t bt_sal_a2dp_sink_connect(bt_controller_id_t id, bt_address_t* addr)
 error:
     bt_conn_unref(conn);
     return BT_STATUS_FAIL;
+}
+#endif /* CONFIG_BLUETOOTH_A2DP_SINK */
+
+bt_status_t bt_sal_a2dp_sink_connect(bt_controller_id_t id, bt_address_t* addr)
+{
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+    return bt_sal_profile_connect_request(addr, PROFILE_A2DP_SINK, id, a2dp_sink_profile_connect);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
@@ -1690,9 +1728,9 @@ static bt_status_t bt_sal_a2dp_disconnect(struct zblue_a2dp_info_t* a2dp_info)
     return BT_STATUS_SUCCESS;
 }
 
-bt_status_t bt_sal_a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr)
-{
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr)
+{
     struct zblue_a2dp_info_t* a2dp_info;
 
     a2dp_info = (struct zblue_a2dp_info_t*)bt_list_find(bt_a2dp_conn, bt_a2dp_info_find_addr, addr);
@@ -1702,66 +1740,40 @@ bt_status_t bt_sal_a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* a
     }
 
     return bt_sal_a2dp_disconnect(a2dp_info);
+}
+#endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
+
+bt_status_t bt_sal_a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr)
+{
+#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
+    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP, id, a2dp_source_disconnect);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
 }
+
+#ifdef CONFIG_BLUETOOTH_A2DP_SINK
+static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr)
+{
+    struct zblue_a2dp_info_t* a2dp_info;
+
+    a2dp_info = (struct zblue_a2dp_info_t*)bt_list_find(bt_a2dp_conn, bt_a2dp_info_find_addr, addr);
+    if (!a2dp_info) {
+        BT_LOGW("%s, a2dp_info is NULL", __func__);
+        return BT_STATUS_PARM_INVALID;
+    }
+
+    return bt_sal_a2dp_disconnect(a2dp_info);
+}
+#endif /* CONFIG_BLUETOOTH_A2DP_SINK */
 
 bt_status_t bt_sal_a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    struct zblue_a2dp_info_t* a2dp_info;
-
-    a2dp_info = (struct zblue_a2dp_info_t*)bt_list_find(bt_a2dp_conn, bt_a2dp_info_find_addr, addr);
-    if (!a2dp_info) {
-        BT_LOGW("%s, a2dp_info is NULL", __func__);
-        return BT_STATUS_PARM_INVALID;
-    }
-
-    return bt_sal_a2dp_disconnect(a2dp_info);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP_SINK, id, a2dp_sink_disconnect);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
-}
-
-bool bt_sal_a2dp_try_disconnect_a2dp_sink(bt_controller_id_t id, bt_address_t* addr)
-{
-#ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    struct zblue_a2dp_info_t* a2dp_info;
-
-    a2dp_info = (struct zblue_a2dp_info_t*)bt_list_find(bt_a2dp_conn, bt_a2dp_info_find_addr, addr);
-    if (!a2dp_info) {
-        BT_LOGW("%s, a2dp_info is NULL", __func__);
-        return false;
-    }
-
-    if (bt_sal_a2dp_disconnect(a2dp_info))
-        return false;
-
-    return true;
-#else
-    return false;
-#endif /* CONFIG_BLUETOOTH_A2DP_SINK */
-}
-
-bool bt_sal_a2dp_try_disconnect_a2dp_srouce(bt_controller_id_t id, bt_address_t* addr)
-{
-#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-    struct zblue_a2dp_info_t* a2dp_info;
-
-    a2dp_info = (struct zblue_a2dp_info_t*)bt_list_find(bt_a2dp_conn, bt_a2dp_info_find_addr, addr);
-    if (!a2dp_info) {
-        BT_LOGW("%s, a2dp_info is NULL", __func__);
-        return false;
-    }
-
-    if (bt_sal_a2dp_disconnect(a2dp_info))
-        return false;
-
-    return true;
-#else
-    return false;
-#endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
 }
 
 bt_status_t bt_sal_a2dp_source_start_stream(bt_controller_id_t id, bt_address_t* addr)

--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -246,10 +246,12 @@ static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
     if (err) {
         state.connection_state = CONNECTION_STATE_DISCONNECTED;
         state.status = err;
+        bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN));
         goto error;
     }
 
     bt_sal_get_remote_name(BT_TRANSPORT_BREDR, &state.addr);
+    bt_sal_cm_acl_connected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN));
 
 error:
     adapter_on_connection_state_changed(&state);
@@ -1278,6 +1280,9 @@ static void STACK_CALL(disconnect)(void* args)
 {
     sal_adapter_req_t* req = args;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)&req->addr);
+    if (conn == NULL) {
+        return;
+    }
 
     SAL_CHECK(bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN), 0);
     bt_conn_unref(conn);
@@ -1285,6 +1290,32 @@ static void STACK_CALL(disconnect)(void* args)
 #endif
 
 bt_status_t bt_sal_disconnect(bt_controller_id_t id, bt_address_t* addr, uint8_t reason)
+{
+#ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
+    UNUSED(id);
+    sal_adapter_req_t* req;
+    bt_status_t status;
+
+    /* disconnect profile, then disconnect acl */
+    status = bt_sal_cm_try_disconnect_profiles(addr, false);
+
+    if (status == BT_STATUS_SUCCESS) {
+        return status;
+    }
+
+    req = sal_adapter_req(id, addr, STACK_CALL(disconnect));
+    if (!req)
+        return BT_STATUS_NOMEM;
+
+    req->adpt.reason = reason;
+
+    return sal_send_req(req);
+#else
+    return BT_STATUS_NOT_SUPPORTED;
+#endif
+}
+
+bt_status_t bt_sal_disconnect_internal(bt_controller_id_t id, bt_address_t* addr, uint8_t reason)
 {
 #ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
     UNUSED(id);
@@ -1394,13 +1425,7 @@ bt_status_t bt_sal_cancel_bond(bt_controller_id_t id, bt_address_t* addr, bt_tra
 #ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
 static void STACK_CALL(remove_bond)(void* args)
 {
-    bt_status_t status;
     sal_adapter_req_t* req = args;
-
-    status = bt_sal_cm_try_disconnect_profiles(&req->addr, true);
-    if (status == BT_STATUS_SUCCESS)
-        return;
-
     SAL_CHECK(bt_br_unpair((bt_addr_t*)&req->addr), 0);
 }
 #endif
@@ -1410,12 +1435,35 @@ bt_status_t bt_sal_remove_bond(bt_controller_id_t id, bt_address_t* addr, bt_tra
 #ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
     UNUSED(id);
     sal_adapter_req_t* req;
+    bt_status_t status;
+
+    status = bt_sal_cm_try_disconnect_profiles(addr, true);
+
+    if (status == BT_STATUS_SUCCESS) {
+        return status;
+    }
 
     req = sal_adapter_req(id, addr, STACK_CALL(remove_bond));
     if (!req)
         return BT_STATUS_NOMEM;
 
     req->adpt.bond.transport = transport;
+
+    return sal_send_req(req);
+#else
+    return BT_STATUS_NOT_SUPPORTED;
+#endif
+}
+
+bt_status_t bt_sal_remove_bond_internal(bt_controller_id_t id, bt_address_t* addr)
+{
+#ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
+    UNUSED(id);
+    sal_adapter_req_t* req;
+
+    req = sal_adapter_req(id, addr, STACK_CALL(remove_bond));
+    if (!req)
+        return BT_STATUS_NOMEM;
 
     return sal_send_req(req);
 #else

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -88,6 +88,7 @@ static void zblue_on_ct_passthrough_rsp(struct bt_avrcp_ct* ct, uint8_t tid, bt_
 static void zblue_on_ct_notification_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, uint8_t event_id, struct bt_avrcp_event_data* data);
 static void zblue_on_ct_get_element_attrs_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, struct net_buf* buf);
 static void zblue_on_ct_get_play_status_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, struct net_buf* buf);
+static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr);
 #endif
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_ABSOLUTE_VOLUME
@@ -722,6 +723,8 @@ static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
     msg->data.conn_state.conn_state = PROFILE_STATE_CONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
+    bt_sal_cm_profile_connected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT));
+    bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, PRIMARY_ADAPTER, avrcp_control_disconnect);
 }
 
 static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
@@ -1378,9 +1381,9 @@ static void zblue_on_tg_get_play_status_req(struct bt_avrcp_tg* tg, uint8_t tid)
 }
 #endif
 
-bt_status_t bt_sal_avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd_addr)
-{
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd_addr)
+{
     int err;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)bd_addr);
 
@@ -1397,14 +1400,21 @@ bt_status_t bt_sal_avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd
         return BT_STATUS_FAIL;
 
     return BT_STATUS_SUCCESS;
+}
+#endif
+
+bt_status_t bt_sal_avrcp_control_connect(bt_controller_id_t id, bt_address_t* addr)
+{
+#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+    return bt_sal_profile_connect_request(addr, PROFILE_AVRCP_CT, id, avrcp_control_connect);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif
 }
 
-bt_status_t bt_sal_avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr)
-{
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr)
+{
     zblue_avrcp_info_t* avrcp_info;
     int err;
 
@@ -1424,14 +1434,21 @@ bt_status_t bt_sal_avrcp_control_disconnect(bt_controller_id_t id, bt_address_t*
         goto failed;
 
     return BT_STATUS_SUCCESS;
-#else
-    return BT_STATUS_NOT_SUPPORTED;
-#endif
 
 failed:
     bt_list_free(avrcp_info->tg_tid);
     bt_list_remove(bt_avrcp_conn, avrcp_info);
     return BT_STATUS_FAIL;
+}
+#endif
+
+bt_status_t bt_sal_avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* addr)
+{
+#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+    return bt_sal_profile_disconnect_request(addr, PROFILE_AVRCP_CT, id, avrcp_control_disconnect);
+#else
+    return BT_STATUS_NOT_SUPPORTED;
+#endif
 }
 
 bool bt_sal_avrcp_try_disconnect_avrcp_control(bt_controller_id_t id, bt_address_t* addr)

--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -23,46 +23,215 @@
 #include "utils/log.h"
 
 #define FLAG_NONE (0)
-#define FLAG_A2DP_SINK (1UL << (PROFILE_A2DP_SINK))
-#define FLAG_A2DP_SOURCE (1UL << (PROFILE_A2DP))
-#define FLAG_AVRCP_TARGET (1UL << (PROFILE_AVRCP_TG))
-#define FLAG_AVRCP_CONTROL (1UL << (PROFILE_AVRCP_CT))
+#define FLAG_A2DP_SINK (1ULL << (PROFILE_A2DP_SINK))
+#define FLAG_A2DP_SOURCE (1ULL << (PROFILE_A2DP))
+#define FLAG_AVRCP_TARGET (1ULL << (PROFILE_AVRCP_TG))
+#define FLAG_AVRCP_CONTROL (1ULL << (PROFILE_AVRCP_CT))
 
 typedef struct {
     bt_address_t device_addr;
-    uint32_t profile_flags;
+    uint64_t profile_flags;
     bool is_unpair;
+    bt_list_t* profile_conn_handler_list;
 } bt_profile_connection_manager_t;
 
+typedef struct {
+    bt_address_t device_addr;
+    uint8_t profile_id;
+    bt_profile_conn_handler_t handler;
+    bt_controller_id_t id;
+    void* user_data;
+} sal_async_profile_req_t;
+
+static bt_list_t* bt_sal_connecting_list = NULL;
 static bt_list_t* bt_sal_disconnecting_list = NULL;
 
-static void flags_set(uint32_t* profile_flags, uint32_t flags)
+static bt_status_t bt_sal_trigger_profile_conn_act(bt_profile_connection_manager_t* manager, bt_list_t* manager_list);
+
+static void flags_set(uint64_t* profile_flags, uint64_t flags)
 {
     *profile_flags |= flags;
 }
 
-static void flags_clear(uint32_t* profile_flags, uint32_t flags)
+static void flags_clear(uint64_t* profile_flags, uint64_t flags)
 {
     *profile_flags &= ~flags;
 }
 
-static void flags_reset(uint32_t* profile_flags)
+static inline uint64_t profile_id_to_flag(uint8_t profile_id)
 {
-    *profile_flags = FLAG_NONE;
+    SAL_ASSERT(profile_id <= PROFILE_MAX);
+
+    return (1ULL << (profile_id));
+}
+
+static bool match_profile_func(void* data, void* context)
+{
+    bt_profile_conn_handler_node_t* handler_node = (bt_profile_conn_handler_node_t*)data;
+    bt_profile_conn_handler_t* target_func = (bt_profile_conn_handler_t*)context;
+
+    if (!handler_node || !target_func) {
+        return false;
+    }
+
+    return handler_node->handler == *target_func;
+}
+
+static bool match_profile_id(void* data, void* context)
+{
+    bt_profile_conn_handler_node_t* handler_node = (bt_profile_conn_handler_node_t*)data;
+    uint8_t* profile_id = (uint8_t*)context;
+
+    if (!handler_node || !profile_id) {
+        return false;
+    }
+
+    return handler_node->profile_id == *profile_id;
 }
 
 static void bt_connection_manager_destory(void* data)
 {
-    free(data);
+    bt_profile_connection_manager_t* manager = (bt_profile_connection_manager_t*)data;
+    if (manager) {
+        if (manager->profile_conn_handler_list) {
+            bt_list_free(manager->profile_conn_handler_list);
+            manager->profile_conn_handler_list = NULL;
+        }
+
+        free(manager);
+    }
 }
 
-static bool bt_cm_disconnect_find(void* data, void* context)
+static bool bt_connection_manager_find(void* data, void* context)
 {
     bt_profile_connection_manager_t* manager = (bt_profile_connection_manager_t*)data;
     if (!manager)
         return false;
 
     return memcmp(&manager->device_addr, context, sizeof(bt_address_t)) == 0;
+}
+
+static void profile_entry_destroy(void* data)
+{
+    if (data) {
+        bt_profile_conn_handler_node_t* handler_node = (bt_profile_conn_handler_node_t*)data;
+        free(handler_node);
+    }
+}
+
+static bt_profile_connection_manager_t* find_or_create_connection_manager(bt_list_t* list, bt_address_t* addr)
+{
+    bt_profile_connection_manager_t* manager;
+
+    if (!addr || !list) {
+        return NULL;
+    }
+
+    manager = (bt_profile_connection_manager_t*)bt_list_find(list, bt_connection_manager_find, addr);
+
+    if (manager != NULL) {
+        return manager;
+    }
+
+    manager = (bt_profile_connection_manager_t*)zalloc(sizeof(*manager));
+
+    if (!manager) {
+        return NULL;
+    }
+
+    memcpy(&manager->device_addr, addr, sizeof(bt_address_t));
+
+    manager->profile_conn_handler_list = bt_list_new(profile_entry_destroy);
+    if (!manager->profile_conn_handler_list) {
+        free(manager);
+        return NULL;
+    }
+
+    bt_list_add_tail(list, manager);
+    return manager;
+}
+
+static sal_async_profile_req_t* sal_async_profile_req(bt_address_t* addr, bt_profile_conn_handler_t handler,
+    uint8_t profile_id, bt_controller_id_t id, void* user_data)
+{
+    sal_async_profile_req_t* req = calloc(sizeof(sal_async_profile_req_t), 1);
+
+    if (req) {
+        req->profile_id = profile_id;
+        req->id = id;
+        req->handler = handler;
+        req->user_data = user_data;
+        if (addr)
+            memcpy(&req->device_addr, addr, sizeof(bt_address_t));
+    }
+
+    return req;
+}
+
+static void sal_invoke_async(service_work_t* work, void* userdata)
+{
+    sal_async_profile_req_t* req = userdata;
+    bt_status_t status;
+    bt_profile_connection_manager_t* manager;
+    bt_profile_conn_handler_node_t* handler_node;
+    bt_list_t* manager_list;
+
+    SAL_ASSERT(req);
+
+    if (!req->user_data) {
+        /* !req->user_data means a direct profile "disconnection" */
+        req->handler(req->id, &req->device_addr);
+        free(req);
+        return;
+    }
+
+    manager_list = (bt_list_t*)req->user_data;
+
+    manager = (bt_profile_connection_manager_t*)bt_list_find(manager_list,
+        bt_connection_manager_find, &req->device_addr);
+
+    if (!manager) {
+        BT_LOGW("%s, manager not found.", __func__);
+        free(req);
+        return;
+    }
+
+    if (!bt_list_find(manager->profile_conn_handler_list, match_profile_func, (void*)&req->handler)) {
+        BT_LOGW("%s, handler_node handler not found.", __func__);
+        flags_clear(&manager->profile_flags, profile_id_to_flag(req->profile_id));
+        free(req);
+        return;
+    }
+
+    handler_node = bt_list_find(manager->profile_conn_handler_list, match_profile_id, (void*)&req->profile_id);
+
+    if (!handler_node) {
+        BT_LOGW("%s, handler_node not found.", __func__);
+        flags_clear(&manager->profile_flags, profile_id_to_flag(req->profile_id));
+        free(req);
+        return;
+    }
+
+    status = req->handler(req->id, &req->device_addr);
+
+    if (status != BT_STATUS_SUCCESS) {
+        flags_clear(&manager->profile_flags, profile_id_to_flag(req->profile_id));
+    }
+
+    free(req);
+}
+
+static bt_status_t sal_send_async_req(sal_async_profile_req_t* req)
+{
+    if (!req)
+        return BT_STATUS_PARM_INVALID;
+
+    if (!service_loop_work((void*)req, sal_invoke_async, NULL)) {
+        free(req);
+        return BT_STATUS_FAIL;
+    }
+
+    return BT_STATUS_SUCCESS;
 }
 
 cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id)
@@ -81,6 +250,7 @@ cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id)
 void bt_sal_cm_conn_init(void)
 {
     bt_sal_disconnecting_list = bt_list_new(bt_connection_manager_destory);
+    bt_sal_connecting_list = bt_list_new(bt_connection_manager_destory);
 }
 
 void cm_data_destory(cm_data_t* data)
@@ -88,78 +258,150 @@ void cm_data_destory(cm_data_t* data)
     free(data);
 }
 
-static bt_status_t bt_try_disconnect_acl(bt_profile_connection_manager_t* manager)
+static bt_status_t bt_sal_trigger_profile_conn_act(bt_profile_connection_manager_t* manager, bt_list_t* manager_list)
 {
-    struct bt_conn* conn;
-    int ret;
+    bt_list_node_t* node;
+    bt_profile_conn_handler_node_t* entry_node;
+    uint64_t bit_flag;
+    bt_address_t* addr;
+    bt_list_t* list;
+    sal_async_profile_req_t* req;
 
-    if (manager->profile_flags != FLAG_NONE) {
-        BT_LOGI("%s, Disconnecting profile.", __func__);
-        return BT_STATUS_BUSY;
+    if (!manager) {
+        return BT_STATUS_PARM_INVALID;
     }
 
-    if (manager->is_unpair) {
-        return bt_br_unpair((bt_addr_t*)&manager->device_addr);
+    list = manager->profile_conn_handler_list;
+
+    if (!manager_list || !list) {
+        return BT_STATUS_NOMEM;
     }
 
-    conn = bt_conn_lookup_addr_br((bt_addr_t*)&manager->device_addr);
-    if (conn == NULL) {
-        BT_LOGE("%s, conn not found.", __func__);
-        return BT_STATUS_FAIL;
+    addr = &manager->device_addr;
+
+    for (node = bt_list_head(list); node != NULL; node = bt_list_next(list, node)) {
+        entry_node = (bt_profile_conn_handler_node_t*)bt_list_node(node);
+
+        if (!entry_node || !entry_node->handler)
+            continue;
+
+        bit_flag = profile_id_to_flag(entry_node->profile_id);
+        if (bit_flag && (manager->profile_flags & bit_flag)) {
+            continue;
+        }
+
+        /* async invoke to service_worker thread */
+        req = sal_async_profile_req(addr, entry_node->handler, entry_node->profile_id, entry_node->id, manager_list);
+
+        if (sal_send_async_req(req) != BT_STATUS_SUCCESS) {
+            BT_LOGE("%s, profile_id: %u", __func__, entry_node->profile_id);
+            free(req);
+            continue;
+        }
+
+        flags_set(&manager->profile_flags, profile_id_to_flag(entry_node->profile_id));
     }
 
-    ret = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-    bt_conn_unref(conn);
-
-    if (ret) {
-        BT_LOGE("%s, bt_conn_disconnect failed.", __func__);
-        return BT_STATUS_FAIL;
-    }
     return BT_STATUS_SUCCESS;
 }
 
+static bt_status_t bt_try_disconnect_acl(bt_profile_connection_manager_t* manager)
+{
+    if (manager->profile_flags != FLAG_NONE) {
+        BT_LOGD("%s, Disconnecting profile.", __func__);
+        return BT_STATUS_BUSY;
+    }
+
+    return bt_sal_disconnect_internal(PRIMARY_ADAPTER, &manager->device_addr, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+}
+
+static void remove_from_connection_manager_list(bt_list_t* list, bt_address_t* addr, uint8_t profile_id,
+    bool try_acl_disconnect)
+{
+    if (list == NULL) {
+        return;
+    }
+
+    bt_profile_connection_manager_t* manager = bt_list_find(list, bt_connection_manager_find, addr);
+    bt_profile_conn_handler_node_t* handler_node;
+
+    if (manager == NULL) {
+        BT_LOGW("%s, manager not found.", __func__);
+        return;
+    }
+
+    flags_clear(&manager->profile_flags, profile_id_to_flag(profile_id));
+    handler_node = bt_list_find(manager->profile_conn_handler_list, match_profile_id,
+        (void*)&profile_id);
+
+    if (handler_node == NULL) {
+        BT_LOGW("%s, handler_node not found.", __func__);
+        return;
+    }
+
+    bt_list_remove(manager->profile_conn_handler_list, handler_node);
+
+    if (bt_list_is_empty(manager->profile_conn_handler_list)) {
+
+        if (try_acl_disconnect) {
+            bt_try_disconnect_acl(manager);
+        }
+
+        bt_list_remove(list, manager);
+    }
+}
+
 static void bt_sal_cm_profile_disconnected(void* data)
+{
+    if (data == NULL) {
+        return;
+    }
+
+    cm_data_t* cm_data = data;
+
+    remove_from_connection_manager_list(bt_sal_connecting_list,
+        &cm_data->addr,
+        cm_data->profile_id,
+        false);
+
+    remove_from_connection_manager_list(bt_sal_disconnecting_list,
+        &cm_data->addr,
+        cm_data->profile_id,
+        true);
+
+    cm_data_destory(cm_data);
+}
+
+static void bt_sal_cm_acl_connected(void* data)
+{
+    if (data == NULL)
+        return;
+
+    cm_data_t* cm_data;
+    bt_profile_connection_manager_t* manager;
+
+    cm_data = (cm_data_t*)data;
+
+    manager = bt_list_find(bt_sal_connecting_list, bt_connection_manager_find, &cm_data->addr);
+
+    if (manager != NULL) {
+        bt_sal_trigger_profile_conn_act(manager, bt_sal_connecting_list);
+    }
+
+    cm_data_destory(cm_data);
+}
+
+static void bt_sal_cm_profile_connected(void* data)
 {
     if (data == NULL)
         return;
 
     cm_data_t* cm_data = data;
-    bt_profile_connection_manager_t* manager;
 
-    if (bt_sal_disconnecting_list == NULL) {
-        cm_data_destory(cm_data);
-        return;
-    }
-
-    manager = bt_list_find(bt_sal_disconnecting_list, bt_cm_disconnect_find, &cm_data->addr);
-    if (manager == NULL) {
-        BT_LOGW("%s, manager not found.", __func__);
-        cm_data_destory(cm_data);
-        return;
-    }
-
-    switch (cm_data->profile_id) {
-    case PROFILE_A2DP_SINK: {
-        flags_clear(&manager->profile_flags, FLAG_A2DP_SINK);
-        break;
-    }
-    case PROFILE_A2DP: {
-        flags_clear(&manager->profile_flags, FLAG_A2DP_SOURCE);
-        break;
-    }
-    case PROFILE_AVRCP_TG: {
-        flags_clear(&manager->profile_flags, FLAG_AVRCP_TARGET);
-        break;
-    }
-    case PROFILE_AVRCP_CT: {
-        flags_clear(&manager->profile_flags, FLAG_AVRCP_CONTROL);
-        break;
-    }
-    default:
-        break;
-    }
-
-    bt_try_disconnect_acl(manager);
+    /*
+     * To avoid generating duplicate profile connect requests for an
+     * already-connected profile, we do not change the manager state.
+     */
 
     cm_data_destory(cm_data);
 }
@@ -172,21 +414,37 @@ static void bt_sal_cm_acl_disconnected(void* data)
     cm_data_t* cm_data = data;
     bt_profile_connection_manager_t* manager;
 
-    if (bt_sal_disconnecting_list == NULL) {
-        cm_data_destory(cm_data);
-        return;
+    if (bt_sal_connecting_list != NULL) {
+        manager = bt_list_find(bt_sal_connecting_list, bt_connection_manager_find, &cm_data->addr);
+        if (manager != NULL) {
+            bt_list_remove(bt_sal_connecting_list, manager);
+        } else {
+            BT_LOGW("%s, manager not found.", __func__);
+        }
     }
 
-    manager = bt_list_find(bt_sal_disconnecting_list, bt_cm_disconnect_find, &cm_data->addr);
-    if (manager == NULL) {
-        BT_LOGW("%s, manager not found.", __func__);
-        cm_data_destory(cm_data);
-        return;
+    if (bt_sal_disconnecting_list != NULL) {
+        manager = bt_list_find(bt_sal_disconnecting_list, bt_connection_manager_find, &cm_data->addr);
+        if (manager != NULL) {
+            if (manager->is_unpair) {
+                /* must call stack api in service worker */
+                bt_sal_remove_bond_internal(PRIMARY_ADAPTER, &manager->device_addr);
+            }
+            bt_list_remove(bt_sal_disconnecting_list, manager);
+        } else {
+            BT_LOGW("%s, manager not found.", __func__);
+        }
     }
-
-    bt_list_remove(bt_sal_disconnecting_list, manager);
 
     cm_data_destory(cm_data);
+}
+
+void bt_sal_cm_profile_connected_callback(cm_data_t* data)
+{
+    if (data == NULL)
+        return;
+
+    do_in_service_loop(bt_sal_cm_profile_connected, data);
 }
 
 void bt_sal_cm_profile_disconnected_callback(cm_data_t* data)
@@ -195,6 +453,14 @@ void bt_sal_cm_profile_disconnected_callback(cm_data_t* data)
         return;
 
     do_in_service_loop(bt_sal_cm_profile_disconnected, data);
+}
+
+void bt_sal_cm_acl_connected_callback(cm_data_t* data)
+{
+    if (data == NULL)
+        return;
+
+    do_in_service_loop(bt_sal_cm_acl_connected, data);
 }
 
 void bt_sal_cm_acl_disconnected_callback(cm_data_t* data)
@@ -208,15 +474,50 @@ void bt_sal_cm_acl_disconnected_callback(cm_data_t* data)
 bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair)
 {
     bt_profile_connection_manager_t* manager;
-    uint32_t flag = FLAG_NONE;
+    struct bt_conn* conn;
+    struct bt_conn_info info;
+
+    if (!addr)
+        return BT_STATUS_PARM_INVALID;
 
     if (bt_sal_disconnecting_list == NULL)
         return BT_STATUS_FAIL;
 
-    manager = bt_list_find(bt_sal_disconnecting_list, bt_cm_disconnect_find, addr);
+    conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
+    if (!conn) {
+        return BT_STATUS_FAIL;
+    }
+
+    if (bt_conn_get_info(conn, &info) < 0) {
+        return BT_STATUS_FAIL;
+    }
+
+    bt_conn_unref(conn);
+
+    if (info.state != BT_CONN_STATE_CONNECTED && info.state != BT_CONN_STATE_DISCONNECTING) {
+        return BT_STATUS_NOT_READY;
+    }
+
+    manager = bt_list_find(bt_sal_disconnecting_list, bt_connection_manager_find, addr);
+
     if (manager) {
-        BT_LOGW("%s, Disconnecting.", __func__);
-        return BT_STATUS_BUSY;
+        if (manager->is_unpair) {
+            BT_LOGD("removeboned procedure still running");
+            return BT_STATUS_SUCCESS;
+        }
+
+        manager->is_unpair = manager->is_unpair || is_unpair;
+
+        if (info.state == BT_CONN_STATE_DISCONNECTING) {
+            BT_LOGD("ACL disconnecting procedure still running");
+            return BT_STATUS_SUCCESS;
+        }
+
+        if (bt_list_is_empty(manager->profile_conn_handler_list)) {
+            return bt_try_disconnect_acl(manager);
+        }
+
+        return bt_sal_trigger_profile_conn_act(manager, bt_sal_disconnecting_list);
     }
 
     manager = (bt_profile_connection_manager_t*)zalloc(sizeof(bt_profile_connection_manager_t));
@@ -226,30 +527,135 @@ bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair
     }
 
     memcpy(&manager->device_addr, addr, sizeof(bt_address_t));
-    flags_reset(&manager->profile_flags);
     manager->is_unpair = is_unpair;
     bt_list_add_tail(bt_sal_disconnecting_list, manager);
 
-#ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    if (bt_sal_a2dp_try_disconnect_a2dp_sink(PRIMARY_ADAPTER, addr))
-        flag |= FLAG_A2DP_SINK;
-#endif
-#ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-    if (bt_sal_a2dp_try_disconnect_a2dp_srouce(PRIMARY_ADAPTER, addr))
-        flag |= FLAG_A2DP_SOURCE;
-#endif
-#ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-    if (bt_sal_avrcp_try_disconnect_avrcp_control(PRIMARY_ADAPTER, addr))
-        flag |= FLAG_AVRCP_CONTROL;
-#endif
-
-    flags_set(&manager->profile_flags, flag);
-
     return bt_try_disconnect_acl(manager);
+}
+
+static bt_status_t bt_sal_try_profile_connect(bt_address_t* addr)
+{
+    bt_profile_connection_manager_t* manager;
+    struct bt_conn* conn;
+    struct bt_conn_info info;
+
+    if (!addr)
+        return BT_STATUS_PARM_INVALID;
+
+    manager = find_or_create_connection_manager(bt_sal_connecting_list, addr);
+    if (!manager)
+        return BT_STATUS_NOMEM;
+
+    conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
+    if (!conn) {
+        return bt_sal_connect(PRIMARY_ADAPTER, addr);
+    }
+
+    if (bt_conn_get_info(conn, &info) < 0) {
+        return BT_STATUS_FAIL;
+    }
+
+    bt_conn_unref(conn);
+
+    switch (info.state) {
+    case BT_CONN_STATE_CONNECTING:
+        return BT_STATUS_SUCCESS;
+    case BT_CONN_STATE_DISCONNECTED:
+        return bt_sal_connect(PRIMARY_ADAPTER, addr);
+    case BT_CONN_STATE_DISCONNECTING:
+        return BT_STATUS_BUSY;
+    case BT_CONN_STATE_CONNECTED:
+    default:
+        break;
+    }
+
+    return bt_sal_trigger_profile_conn_act(manager, bt_sal_connecting_list);
+}
+
+bt_status_t bt_sal_profile_connect_request(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler)
+{
+    bt_profile_connection_manager_t* manager;
+    bt_profile_conn_handler_node_t* entry_node;
+
+    if (!addr || !handler)
+        return BT_STATUS_PARM_INVALID;
+
+    manager = find_or_create_connection_manager(bt_sal_connecting_list, addr);
+    if (!manager) {
+        return BT_STATUS_NOMEM;
+    }
+
+    if (bt_list_find(manager->profile_conn_handler_list, match_profile_func, (void*)&handler)) {
+        return BT_STATUS_SUCCESS;
+    }
+
+    entry_node = (bt_profile_conn_handler_node_t*)zalloc(sizeof(bt_profile_conn_handler_node_t));
+    if (!entry_node) {
+        return BT_STATUS_NOMEM;
+    }
+
+    entry_node->handler = handler;
+    entry_node->profile_id = profile_id;
+    entry_node->id = id;
+    bt_list_add_tail(manager->profile_conn_handler_list, entry_node);
+
+    return bt_sal_try_profile_connect(addr);
+}
+
+bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler)
+{
+    bt_profile_connection_manager_t* manager;
+    bt_profile_conn_handler_node_t* entry_node;
+
+    if (!addr || !handler)
+        return BT_STATUS_PARM_INVALID;
+
+    manager = find_or_create_connection_manager(bt_sal_disconnecting_list, addr);
+    if (!manager) {
+        return BT_STATUS_NOMEM;
+    }
+
+    if (bt_list_find(manager->profile_conn_handler_list, match_profile_func, (void*)&handler)) {
+        return BT_STATUS_SUCCESS;
+    }
+
+    entry_node = (bt_profile_conn_handler_node_t*)zalloc(sizeof(bt_profile_conn_handler_node_t));
+    if (!entry_node) {
+        return BT_STATUS_NOMEM;
+    }
+
+    entry_node->handler = handler;
+    entry_node->profile_id = profile_id;
+    entry_node->id = id;
+    bt_list_add_tail(manager->profile_conn_handler_list, entry_node);
+
+    return BT_STATUS_SUCCESS;
+}
+
+bt_status_t bt_sal_profile_disconnect_request(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler)
+{
+    sal_async_profile_req_t* req;
+
+    /* async invoke to service_worker thread */
+    req = sal_async_profile_req(addr, handler, profile_id, id, NULL);
+
+    if (sal_send_async_req(req) != BT_STATUS_SUCCESS) {
+        BT_LOGE("%s, profile_id: %u", __func__, profile_id);
+        free(req);
+        return BT_STATUS_FAIL;
+    }
+
+    return BT_STATUS_SUCCESS;
 }
 
 void bt_sal_cm_conn_cleanup(void)
 {
     bt_list_free(bt_sal_disconnecting_list);
     bt_sal_disconnecting_list = NULL;
+
+    bt_list_free(bt_sal_connecting_list);
+    bt_sal_connecting_list = NULL;
 }


### PR DESCRIPTION
  - Add profile connection entry type and bt_profile_conn_entry_t structure.
  - Introduce bt_sal_profile_connect_request, bt_sal_profile_disconnect_register and bt_sal_profile_disconnect APIs.
  - Add internal worker APIs: bt_sal_remove_bond_internal, bt_sal_disconnect_internal.
  - Expand connection manager data model:
    - separate connecting / disconnecting manager lists
    - support dynamic profile_conn_entries per device
    - change profile flags to 64-bit and add profile_id -> flag helper
    - add async request wrapper and service-worker invocation for profile actions
  - Implement profile connect/disconnect orchestration:
    - trigger profile actions on ACL connect
    - ensure profile disconnect handlers run before ACL teardown
    - handle unpair flow by removing bond after ACL disconnect
  - Update A2DP/AVRCP and adapter code to use new APIs:
    - register profile disconnect handlers and notify profile-connected events
    - use bt_sal_profile_connect_request / bt_sal_profile_disconnect wrappers
    - invoke cm callbacks on ACL connect/disconnect paths