### PR TITLE
scan: Replace lib_dumpbuffer with BT_DUMPBUFFER.

### DIFF
--- a/framework/common/advertiser_data_helper.c
+++ b/framework/common/advertiser_data_helper.c
@@ -93,7 +93,7 @@ static void advertiser_data_info(adv_data_t* ad)
     }
 
     syslog(4, "AdvType:(%s)\n", show_ad_type_desc(ad->type));
-    lib_dumpbuffer("AdvData:", ad->data, ad->len - 1);
+    BT_DUMPBUFFER("AdvData:", ad->data, ad->len - 1);
 
     switch (ad->type) {
     case BT_AD_FLAGS:


### PR DESCRIPTION
The current execution time of `on_scan_result_cb` is excessively long. Replace `lib_dumpbuffer` with `BT_DUMPBUFFER` (disabled by default) to reduce callback execution time, thereby preventing watchdog timeouts.

