### PR TITLE
bluetooth: fixed the issue where the thread_loop_work_sync semaphore …

### DIFF
--- a/service/ipc/socket/src/bt_socket_client.c
+++ b/service/ipc/socket/src/bt_socket_client.c
@@ -516,7 +516,8 @@ void bt_socket_client_deinit(bt_instance_t* ins)
 
     /* Dispatch an empty work to ensure all pending work have completed, while
     `bt_socket_sync_close` guarantees no new work will enter the queue. */
-    thread_loop_work_sync(ins->client_loop, NULL, NULL, NULL);
+    if (uv_loop_alive(ins->client_loop))
+        thread_loop_work_sync(ins->client_loop, NULL, NULL, NULL);
 
     if (ins->external_loop && ins->external_async) {
         struct list_node* node;


### PR DESCRIPTION
…blocking when client_loop without run.

bug: v/78154

If bluetoothd initialization fails, it causes the client_loop to execute the deinit operation before it runs, which blocks thread_loop_work_sync and consequently blocks the bluetooth_create_instance API.

