### PR TITLE
Fix a use-after-free issue in A2DP endpoint handling.

### DIFF
--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -808,7 +808,10 @@ success:
     a2dp_info->config->codec_config->len = found_peer_endpoint->codec_cap->len;
     a2dp_info->selected_peer_endpoint = (struct bt_a2dp_ep*)malloc(sizeof(struct bt_a2dp_ep));
     a2dp_info->selected_peer_endpoint->codec_cap = (struct bt_a2dp_codec_ie*)malloc(sizeof(struct bt_a2dp_codec_ie));
-    memcpy(a2dp_info->selected_peer_endpoint, found_peer_endpoint, sizeof(struct bt_a2dp_ep));
+    a2dp_info->selected_peer_endpoint->codec_type = found_peer_endpoint->codec_type;
+    memcpy(a2dp_info->selected_peer_endpoint->codec_cap, found_peer_endpoint->codec_cap, sizeof(struct bt_a2dp_codec_ie));
+    memcpy(&a2dp_info->selected_peer_endpoint->sep, &found_peer_endpoint->sep, sizeof(struct bt_avdtp_sep));
+    a2dp_info->selected_peer_endpoint->stream = found_peer_endpoint->stream;
     bt_list_free(a2dp_info->peer_endpoint);
     a2dp_info->peer_endpoint = NULL;
     return;


### PR DESCRIPTION
bug: v/78393

Root cause:
`peer_endpoint->codec_cap` was freed but the pointer was not set to NULL. Later code still accessed this stale pointer and memcpy'ed from freed memory.

Fix:
Set codec_cap to NULL after free and allocate fresh memory instead of copying from a possibly freed endpoint.
