### PR TITLE
Extend feature get-service callback to report service array

### DIFF
--- a/framework/btwrap/async/bt_gatt_feature.c
+++ b/framework/btwrap/async/bt_gatt_feature.c
@@ -327,6 +327,18 @@ static gatt_descriptor_t* find_desc_by_attr_handle(gatt_client_t* client, uint16
     return NULL;
 }
 
+static void gatt_service_list_to_array(bt_list_t* list,
+    const gatt_service_t* out_array[])
+{
+    bt_list_node_t* node;
+    size_t i = 0;
+
+    for (node = bt_list_head(list); node != NULL;
+         node = bt_list_next(list, node)) {
+        out_array[i++] = (gatt_service_t*)bt_list_node(node);
+    }
+}
+
 static gatt_service_t* build_service_from_attr_list(bt_list_t* attr_list)
 {
     gatt_service_t* service;
@@ -443,7 +455,7 @@ static void feature_on_connected(void* conn_handle, bt_address_t* addr)
 
     BT_FEATURE_LOG("connected: conn=%p", conn_handle);
 
-    BT_GATTC_FEATURE_INVOKE_CB(client, on_connected, client->ins, BT_STATUS_SUCCESS, client->conn);
+    BT_GATTC_FEATURE_INVOKE_CB(client, on_connected, client->ins, GATT_STATUS_SUCCESS, client->conn);
 }
 
 static void feature_on_disconnected(void* conn_handle, bt_address_t* addr)
@@ -463,7 +475,7 @@ static void feature_on_disconnected(void* conn_handle, bt_address_t* addr)
     client->services_discovering = false;
     discovery_database_clear(client);
 
-    BT_GATTC_FEATURE_INVOKE_CB(client, on_disconnected, client->ins, BT_STATUS_SUCCESS,
+    BT_GATTC_FEATURE_INVOKE_CB(client, on_disconnected, client->ins, GATT_STATUS_SUCCESS,
         client->conn);
 }
 
@@ -474,6 +486,8 @@ static void feature_get_attribute_cb(bt_instance_t* ins, bt_status_t status,
     gatt_client_t* client;
     gatt_attr_desc_t* attr_node;
     gatt_service_t* service;
+    size_t service_count;
+    const gatt_service_t** service_array;
 
     (void)ins;
 
@@ -504,10 +518,23 @@ static void feature_get_attribute_cb(bt_instance_t* ins, bt_status_t status,
         free(user_data);
 
         client->services_discovering = false;
+
+        service_count = bt_list_length(client->services_db);
+        service_array = calloc(service_count, sizeof(gatt_service_t*));
+
+        if (!service_array) {
+            BT_GATTC_FEATURE_INVOKE_CB(client, on_discovered,
+                client->ins, GATT_STATUS_FAILURE,
+                client->conn, NULL, 0);
+            return;
+        }
+
+        gatt_service_list_to_array(client->services_db, service_array);
         BT_GATTC_FEATURE_INVOKE_CB(client, on_discovered,
             client->ins, GATT_STATUS_SUCCESS,
-            client->conn, NULL);
+            client->conn, service_array, service_count);
 
+        free(service_array);
         return;
     }
 
@@ -530,9 +557,6 @@ static void feature_get_attribute_cb(bt_instance_t* ins, bt_status_t status,
         if (service) {
             bt_list_add_tail(client->services_db, service);
         }
-
-        BT_GATTC_FEATURE_INVOKE_CB(client, on_discovered, client->ins, BT_STATUS_SUCCESS,
-            client->conn, service);
     }
 
     free(user_data);
@@ -553,7 +577,7 @@ static void feature_on_discovered(void* conn_handle, gatt_status_t status,
     if (status != GATT_STATUS_SUCCESS) {
         client->services_discovering = false;
         BT_GATTC_FEATURE_INVOKE_CB(client, on_discovered, client->ins, status,
-            client->conn, NULL);
+            client->conn, NULL, 0);
         return;
     }
 
@@ -584,7 +608,7 @@ static void feature_on_discovered(void* conn_handle, gatt_status_t status,
         client->services_discovering = false;
         BT_GATTC_FEATURE_INVOKE_CB(client, on_discovered,
             client->ins, GATT_STATUS_FAILURE,
-            client->conn, NULL);
+            client->conn, NULL, 0);
 
         return;
     }

--- a/framework/include/bt_gatt_feature.h
+++ b/framework/include/bt_gatt_feature.h
@@ -133,10 +133,11 @@ typedef void (*bt_gattc_feature_delete_client_cb_t)(bt_instance_t* ins, gatt_sta
  * @param ins         Bluetooth instance.
  * @param status      Operation status.
  * @param conn_handle Connection handle.
- * @param service     Retrieved service (single entry).
+ * @param services    Array of discovered services (pointer array).
+ * @param count       Number of services in the array.
  */
 typedef void (*bt_gattc_feature_get_service_cb_t)(bt_instance_t* ins, gatt_status_t status, gattc_handle_t conn_handle,
-    const gatt_service_t* service);
+    const gatt_service_t* services[], size_t count);
 
 /**
  * @brief Read characteristic callback.


### PR DESCRIPTION
bug: v/77564

The original bt_gattc_feature_get_service_cb_t callback only returned a single gatt_service_t pointer. This is insufficient for feature-layer use cases that require receiving all discovered services at once.

This patch updates the callback signature by adding:

- const gatt_service_t *services[] : array of discovered service pointers
- size_t count                     : number of services in the array

This allows the feature layer to receive a batch of services in a single notification and avoids repeated per-service callbacks.

