### PR TITLE
Add user_data filed for sal_conection_manager connect/disconnect API.

### DIFF
--- a/service/stacks/zephyr/include/sal_connection_manager.h
+++ b/service/stacks/zephyr/include/sal_connection_manager.h
@@ -23,23 +23,24 @@ typedef struct {
 } cm_data_t;
 
 typedef bt_status_t (*bt_profile_conn_handler_t)(
-    bt_controller_id_t id, bt_address_t* addr);
+    bt_controller_id_t id, bt_address_t* addr, void* user_data);
 
 typedef struct {
     bt_profile_conn_handler_t handler;
     uint8_t profile_id;
     bt_controller_id_t id;
+    void* user_data;
 } bt_profile_conn_handler_node_t;
 
 bt_status_t bt_sal_profile_connect_request(bt_address_t* addr,
     uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler);
+    bt_profile_conn_handler_t handler, void* user_data);
 bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr,
     uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler);
+    bt_profile_conn_handler_t handler, void* user_data);
 bt_status_t bt_sal_profile_disconnect_request(bt_address_t* addr,
     uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler);
+    bt_profile_conn_handler_t handler, void* user_data);
 bt_status_t bt_sal_remove_bond_internal(bt_controller_id_t id,
     bt_address_t* addr);
 bt_status_t bt_sal_disconnect_internal(bt_controller_id_t id,

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -81,11 +81,11 @@ static bt_list_t* bt_a2dp_conn = NULL;
 static void bt_list_remove_a2dp_info(struct zblue_a2dp_info_t* a2dp_info);
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr);
+static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data);
 #endif
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr);
+static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data);
 #endif
 
 static void flag_reset(struct zblue_a2dp_info_t* a2dp_info)
@@ -914,12 +914,12 @@ static void bt_sal_a2dp_notify_connected(struct zblue_a2dp_info_t* a2dp_info)
     if (a2dp_info->role == SEP_SRC) {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
         bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP));
-        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP, PRIMARY_ADAPTER, a2dp_source_disconnect);
+        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP, PRIMARY_ADAPTER, a2dp_source_disconnect, NULL);
 #endif
     } else { /* SEP_SNK */
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
         bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK));
-        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, PRIMARY_ADAPTER, a2dp_sink_disconnect);
+        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, PRIMARY_ADAPTER, a2dp_sink_disconnect, NULL);
 #endif
     }
 }
@@ -1583,7 +1583,7 @@ bt_status_t bt_sal_a2dp_sink_init(uint8_t max_connections)
 }
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-static bt_status_t a2dp_source_profile_connect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t a2dp_source_profile_connect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     struct zblue_a2dp_info_t* a2dp_info;
@@ -1638,14 +1638,14 @@ error:
 bt_status_t bt_sal_a2dp_source_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-    return bt_sal_profile_connect_request(addr, PROFILE_A2DP, id, a2dp_source_profile_connect);
+    return bt_sal_profile_connect_request(addr, PROFILE_A2DP, id, a2dp_source_profile_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
 }
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-static bt_status_t a2dp_sink_profile_connect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t a2dp_sink_profile_connect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     struct zblue_a2dp_info_t* a2dp_info;
@@ -1700,7 +1700,7 @@ error:
 bt_status_t bt_sal_a2dp_sink_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    return bt_sal_profile_connect_request(addr, PROFILE_A2DP_SINK, id, a2dp_sink_profile_connect);
+    return bt_sal_profile_connect_request(addr, PROFILE_A2DP_SINK, id, a2dp_sink_profile_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
@@ -1729,7 +1729,7 @@ static bt_status_t bt_sal_a2dp_disconnect(struct zblue_a2dp_info_t* a2dp_info)
 }
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct zblue_a2dp_info_t* a2dp_info;
 
@@ -1746,14 +1746,14 @@ static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* a
 bt_status_t bt_sal_a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP, id, a2dp_source_disconnect);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP, id, a2dp_source_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
 }
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct zblue_a2dp_info_t* a2dp_info;
 
@@ -1770,7 +1770,7 @@ static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* add
 bt_status_t bt_sal_a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP_SINK, id, a2dp_sink_disconnect);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP_SINK, id, a2dp_sink_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -88,7 +88,7 @@ static void zblue_on_ct_passthrough_rsp(struct bt_avrcp_ct* ct, uint8_t tid, bt_
 static void zblue_on_ct_notification_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, uint8_t event_id, struct bt_avrcp_event_data* data);
 static void zblue_on_ct_get_element_attrs_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, struct net_buf* buf);
 static void zblue_on_ct_get_play_status_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, struct net_buf* buf);
-static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr);
+static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data);
 #endif
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_ABSOLUTE_VOLUME
@@ -724,7 +724,7 @@ static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
     bt_sal_cm_profile_connected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT));
-    bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, PRIMARY_ADAPTER, avrcp_control_disconnect);
+    bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, PRIMARY_ADAPTER, avrcp_control_disconnect, NULL);
 }
 
 static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
@@ -1382,7 +1382,7 @@ static void zblue_on_tg_get_play_status_req(struct bt_avrcp_tg* tg, uint8_t tid)
 #endif
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd_addr)
+static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data)
 {
     int err;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)bd_addr);
@@ -1406,14 +1406,14 @@ static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd
 bt_status_t bt_sal_avrcp_control_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-    return bt_sal_profile_connect_request(addr, PROFILE_AVRCP_CT, id, avrcp_control_connect);
+    return bt_sal_profile_connect_request(addr, PROFILE_AVRCP_CT, id, avrcp_control_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif
 }
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr)
+static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data)
 {
     zblue_avrcp_info_t* avrcp_info;
     int err;
@@ -1445,7 +1445,7 @@ failed:
 bt_status_t bt_sal_avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-    return bt_sal_profile_disconnect_request(addr, PROFILE_AVRCP_CT, id, avrcp_control_disconnect);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_AVRCP_CT, id, avrcp_control_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif

--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -40,6 +40,7 @@ typedef struct {
     uint8_t profile_id;
     bt_profile_conn_handler_t handler;
     bt_controller_id_t id;
+    bt_list_t* manager_list;
     void* user_data;
 } sal_async_profile_req_t;
 
@@ -152,7 +153,7 @@ static bt_profile_connection_manager_t* find_or_create_connection_manager(bt_lis
 }
 
 static sal_async_profile_req_t* sal_async_profile_req(bt_address_t* addr, bt_profile_conn_handler_t handler,
-    uint8_t profile_id, bt_controller_id_t id, void* user_data)
+    uint8_t profile_id, bt_controller_id_t id, bt_list_t* manager_list, void* user_data)
 {
     sal_async_profile_req_t* req = calloc(sizeof(sal_async_profile_req_t), 1);
 
@@ -160,6 +161,7 @@ static sal_async_profile_req_t* sal_async_profile_req(bt_address_t* addr, bt_pro
         req->profile_id = profile_id;
         req->id = id;
         req->handler = handler;
+        req->manager_list = manager_list;
         req->user_data = user_data;
         if (addr)
             memcpy(&req->device_addr, addr, sizeof(bt_address_t));
@@ -178,14 +180,14 @@ static void sal_invoke_async(service_work_t* work, void* userdata)
 
     SAL_ASSERT(req);
 
-    if (!req->user_data) {
+    if (!req->manager_list) {
         /* !req->user_data means a direct profile "disconnection" */
-        req->handler(req->id, &req->device_addr);
+        req->handler(req->id, &req->device_addr, req->user_data);
         free(req);
         return;
     }
 
-    manager_list = (bt_list_t*)req->user_data;
+    manager_list = (bt_list_t*)req->manager_list;
 
     manager = (bt_profile_connection_manager_t*)bt_list_find(manager_list,
         bt_connection_manager_find, &req->device_addr);
@@ -212,7 +214,7 @@ static void sal_invoke_async(service_work_t* work, void* userdata)
         return;
     }
 
-    status = req->handler(req->id, &req->device_addr);
+    status = req->handler(req->id, &req->device_addr, req->user_data);
 
     if (status != BT_STATUS_SUCCESS) {
         flags_clear(&manager->profile_flags, profile_id_to_flag(req->profile_id));
@@ -291,7 +293,7 @@ static bt_status_t bt_sal_trigger_profile_conn_act(bt_profile_connection_manager
         }
 
         /* async invoke to service_worker thread */
-        req = sal_async_profile_req(addr, entry_node->handler, entry_node->profile_id, entry_node->id, manager_list);
+        req = sal_async_profile_req(addr, entry_node->handler, entry_node->profile_id, entry_node->id, manager_list, entry_node->user_data);
 
         if (sal_send_async_req(req) != BT_STATUS_SUCCESS) {
             BT_LOGE("%s, profile_id: %u", __func__, entry_node->profile_id);
@@ -573,7 +575,7 @@ static bt_status_t bt_sal_try_profile_connect(bt_address_t* addr)
 }
 
 bt_status_t bt_sal_profile_connect_request(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler)
+    bt_profile_conn_handler_t handler, void* user_data)
 {
     bt_profile_connection_manager_t* manager;
     bt_profile_conn_handler_node_t* entry_node;
@@ -598,13 +600,14 @@ bt_status_t bt_sal_profile_connect_request(bt_address_t* addr, uint8_t profile_i
     entry_node->handler = handler;
     entry_node->profile_id = profile_id;
     entry_node->id = id;
+    entry_node->user_data = user_data;
     bt_list_add_tail(manager->profile_conn_handler_list, entry_node);
 
     return bt_sal_try_profile_connect(addr);
 }
 
 bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler)
+    bt_profile_conn_handler_t handler, void* user_data)
 {
     bt_profile_connection_manager_t* manager;
     bt_profile_conn_handler_node_t* entry_node;
@@ -629,18 +632,19 @@ bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr, uint8_t profi
     entry_node->handler = handler;
     entry_node->profile_id = profile_id;
     entry_node->id = id;
+    entry_node->user_data = user_data;
     bt_list_add_tail(manager->profile_conn_handler_list, entry_node);
 
     return BT_STATUS_SUCCESS;
 }
 
 bt_status_t bt_sal_profile_disconnect_request(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler)
+    bt_profile_conn_handler_t handler, void* user_data)
 {
     sal_async_profile_req_t* req;
 
     /* async invoke to service_worker thread */
-    req = sal_async_profile_req(addr, handler, profile_id, id, NULL);
+    req = sal_async_profile_req(addr, handler, profile_id, id, NULL, user_data);
 
     if (sal_send_async_req(req) != BT_STATUS_SUCCESS) {
         BT_LOGE("%s, profile_id: %u", __func__, profile_id);


### PR DESCRIPTION
bug: v/78961

rootcause: for some profile connect/disconnect stack interface like spp, have not bd_addr, but more parameter like port_id, so add user_data filed.