### PR TITLE
SPP: fix sdp discovery uuid param invalid

### DIFF
--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -664,6 +664,7 @@ static bt_status_t spp_connect_with_uuid(sal_spp_connection_t* spp_conn, bt_uuid
     }
 
     spp_client->sdp_discover.func = sdp_discovered_cb;
+    spp_client->sdp_discover.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR;
     spp_client->sdp_discover.pool = &spp_sdp_pool;
     spp_client->sdp_discover.uuid = (const struct bt_uuid*)&spp_client->uuid_128;
 


### PR DESCRIPTION
bug: v/73971

sdp_discover type should be set with BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR, when request sdp discovery in last btstack

## Summary

SPP: fix sdp discovery uuid param invalid

## Impact

SPP function

## Testing

local test spp connect pass

