### PR TITLE
trigger exit_sniff when 'sco open' state change to 'sco close'

### DIFF
--- a/service/profiles/hfp_ag/hfp_ag_state_machine.c
+++ b/service/profiles/hfp_ag/hfp_ag_state_machine.c
@@ -463,7 +463,7 @@ static void process_vendor_specific_at(bt_address_t* addr, const char* at_string
         if (strncmp(at_string + 2 /* "AT" */, prefix->at_prefix, prefix_size)) {
             continue;
         }
-        value = at_string + strlen(prefix->at_prefix) + 3;  /* The value is the string after "AT+XIAOMI=" */
+        value = at_string + strlen(prefix->at_prefix) + 3; /* The value is the string after "AT+XIAOMI=" */
         if (value[0] == '\r' || value[0] == '\n') {
             break;
         }
@@ -479,8 +479,9 @@ static void process_vendor_specific_at(bt_address_t* addr, const char* at_string
     bt_sal_hfp_ag_error_response(addr, HFP_ATCMD_RESULT_CMEERR_OPERATION_NOTSUPPORTED);
 }
 
-static void hfp_ag_send_vendor_specific_at_cmd(bt_address_t* addr, const char* command, const char* value) {
-    char at_command[HFP_AT_LEN_MAX+1] = "\r\n";
+static void hfp_ag_send_vendor_specific_at_cmd(bt_address_t* addr, const char* command, const char* value)
+{
+    char at_command[HFP_AT_LEN_MAX + 1] = "\r\n";
     if (!command || !value)
         return;
 
@@ -1157,6 +1158,7 @@ static void audio_on_exit(state_machine_t* sm)
 
     AG_DBG_EXIT(sm, &agsm->addr);
 
+    bt_pm_busy(PROFILE_HFP_AG, &agsm->addr);
     bt_pm_sco_close(PROFILE_HFP_AG, &agsm->addr);
     /* set sco device unavaliable */
     bt_media_set_sco_unavailable();

--- a/service/profiles/hfp_hf/hfp_hf_state_machine.c
+++ b/service/profiles/hfp_hf/hfp_hf_state_machine.c
@@ -1422,6 +1422,7 @@ static void audio_on_exit(state_machine_t* sm)
 
     HF_DBG_EXIT(sm, &hfsm->addr);
 
+    bt_pm_busy(PROFILE_HFP_HF, &hfsm->addr);
     bt_pm_sco_close(PROFILE_HFP_HF, &hfsm->addr);
 
     /* TODO: set sco unavailable */


### PR DESCRIPTION
bug: v/79133

rootcause: In our design, sco_open will set sniff interval to 50 ~ 150 ms, then the bluetooth call finish, power manager will enter sco_close to set the sniff interval to 500ms. However, only change sniff interval is not allowed when the link is already during sniff mode, must exit sniff before make it.