### PR TITLE
Resolved the issue where the Vela Bluetooth service failed to compile within the Android build system

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -19,11 +19,11 @@ frameworkBluetooth_cc_library {
     srcs : [
         "framework/common/*.c",
         "framework/socket/*.c",
-        "service/common/bt_time.c",
         "service/common/index_allocator.c",
         "service/ipc/socket/src/bt_socket_client.c",
         "service/ipc/socket/src/bt_socket_adapter.c",
         "service/ipc/socket/src/bt_socket_advertiser.c",
+        "service/ipc/socket/src/bt_socket_avrcp_control.c",
         "service/ipc/socket/src/bt_socket_scan.c",
         "service/ipc/socket/src/bt_socket_gattc.c",
         "service/ipc/socket/src/bt_socket_gatts.c",

--- a/Android.bp
+++ b/Android.bp
@@ -75,6 +75,10 @@ frameworkBluetooth_cc_library {
         "//apex_available:platform",
         "com.android.btservices",
     ],
+
+    header_libs: [
+        "kernel_modules_headers",
+    ],
 }
 
 frameworkBluetooth_cc_binary {

--- a/framework/common/uv_thread_loop.c
+++ b/framework/common/uv_thread_loop.c
@@ -365,7 +365,7 @@ static void after_work_sync_cb(uv_work_t* req, int status)
 void thread_loop_work_sync(uv_loop_t* loop, void* user_data, thread_work_cb_t work_cb,
     thread_after_work_cb_t after_work_cb)
 {
-    signal_work_t* work = zalloc(sizeof(*work));
+    signal_work_t* work = (signal_work_t*)calloc(1, sizeof(signal_work_t));
     if (work == NULL)
         return;
 

--- a/framework/include/bluetooth.h
+++ b/framework/include/bluetooth.h
@@ -215,11 +215,6 @@ typedef enum {
 
 typedef uint8_t bt_128key_t[16];
 
-typedef struct {
-    uint8_t hash[16];
-    uint8_t rand[16];
-} bt_oob_data_t;
-
 #define COD_SERVICE_BITS(c) (c & 0xFFE000) /* The major service classes field */
 #define COD_DEVICE_MAJOR_BITS(c) (c & 0x001F00) /* The major device classes field */
 #define COD_DEVICE_CLASS_BITS(c) (c & 0x001FFC) /* The device classes field, including major and minor */

--- a/framework/socket/bluetooth.c
+++ b/framework/socket/bluetooth.c
@@ -23,6 +23,10 @@
 #include "manager_service.h"
 #include "service_loop.h"
 
+#ifdef CONFIG_NET_RPMSG
+#include <netpacket/rpmsg.h>
+#endif
+
 bt_instance_t* bluetooth_create_instance(void)
 {
     bt_status_t status;

--- a/service/stacks/include/sal_adapter_classic_interface.h
+++ b/service/stacks/include/sal_adapter_classic_interface.h
@@ -27,6 +27,11 @@
 #include "bluetooth_define.h"
 #include "power_manager.h"
 
+typedef struct {
+    uint8_t hash[16];
+    uint8_t rand[16];
+} bt_oob_data_t;
+
 /* service adapter layer for BREDR */
 // #ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
 bt_status_t bt_sal_init(const bt_vhal_interface* vhal);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

Resolved the issue where the Vela Bluetooth service failed to compile within the Android build system. Therefore, this submission updates `Android.bp` and resolves certain compilation errors within some source files.

