### PR TITLE
fix dangling user_data pointer in characteristic allocation

### DIFF
--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -95,6 +95,12 @@ struct add_characteristic {
     gatt_element_t* element;
 };
 
+struct gatt_user_data {
+    gatt_element_t* element;
+    uint16_t len;
+    uint8_t value[];
+};
+
 struct gatt_ccc_wrapper {
     /**
      * NOTE: `ccc` must be the first member!
@@ -153,13 +159,20 @@ static ssize_t read_value(struct bt_conn* conn, const struct bt_gatt_attr* attr,
     bt_address_t addr;
     gatt_element_t* element;
     uint32_t request_id;
+    struct gatt_user_data* user_data;
 
     if (!attr || !attr->user_data) {
-        BT_LOGE("%s, user_data is NULL", __func__);
+        BT_LOGE("%s, user_data or context is NULL", __func__);
         return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
     }
 
-    element = (gatt_element_t*)attr->user_data;
+    user_data = (struct gatt_user_data*)attr->user_data;
+
+    element = (gatt_element_t*)user_data->element;
+    if (!element) {
+        BT_LOGE("%s, element is NULL", __func__);
+        return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+    }
 
     get_le_addr_from_conn(conn, &addr);
 
@@ -176,13 +189,20 @@ static ssize_t write_value(struct bt_conn* conn, const struct bt_gatt_attr* attr
     gatt_element_t* element;
     uint32_t request_id;
     int ret;
+    struct gatt_user_data* user_data;
 
     if (!attr || !attr->user_data) {
-        BT_LOGE("%s, user_data is NULL", __func__);
+        BT_LOGE("%s, user_data or context is NULL", __func__);
         return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
     }
 
-    element = (gatt_element_t*)attr->user_data;
+    user_data = (struct gatt_user_data*)attr->user_data;
+
+    element = (gatt_element_t*)user_data->element;
+    if (!element) {
+        BT_LOGE("%s, element is NULL", __func__);
+        return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+    }
 
     if (flags & GATT_WRITE_FLAGS_RELIABLE_WRITE) {
         BT_LOGE("%s, reliable write is not supported", __func__);
@@ -307,6 +327,7 @@ static int alloc_characteristic(struct add_characteristic* ch)
 {
     struct bt_gatt_attr *attr_chrc, *attr_value;
     struct bt_gatt_chrc* chrc_data;
+    struct gatt_user_data user_data = { 0 };
 
     /* Add Characteristic Declaration */
     attr_chrc = gatt_db_add(&(struct bt_gatt_attr)BT_GATT_ATTRIBUTE(BT_UUID_GATT_CHRC, BT_GATT_PERM_READ, bt_gatt_attr_read_chrc, NULL, (&(struct bt_gatt_chrc) {})), sizeof(*chrc_data));
@@ -319,7 +340,9 @@ static int alloc_characteristic(struct add_characteristic* ch)
         return -EINVAL;
     }
 
-    attr_value = gatt_db_add(&(struct bt_gatt_attr)BT_GATT_ATTRIBUTE(ch->uuid, ch->permissions & GATT_PERM_MASK, read_value, write_value, ch->element), 0);
+    user_data.element = ch->element;
+
+    attr_value = gatt_db_add(&(struct bt_gatt_attr)BT_GATT_ATTRIBUTE(ch->uuid, ch->permissions & GATT_PERM_MASK, read_value, write_value, &user_data), sizeof(user_data));
     if (!attr_value) {
         BT_LOGE("%s, attr_value allocation failed", __func__);
         return -EINVAL;
@@ -957,6 +980,7 @@ static void send_indication_destory(struct bt_gatt_indicate_params* params)
 
 static void send_indication_result(struct bt_conn* conn, struct bt_gatt_indicate_params* params, uint8_t err)
 {
+    struct gatt_user_data* user_data;
     gatt_element_t* element;
     bt_address_t addr;
     bt_status_t status = GATT_STATUS_SUCCESS;
@@ -966,7 +990,8 @@ static void send_indication_result(struct bt_conn* conn, struct bt_gatt_indicate
         return;
     }
 
-    element = (gatt_element_t*)params->attr->user_data;
+    user_data = (struct gatt_user_data*)params->attr->user_data;
+    element = (gatt_element_t*)user_data->element;
 
     if (!element) {
         BT_LOGE("%s, element is NULL", __func__);


### PR DESCRIPTION
## Fix dangling user_data pointer in characteristic allocation

**Bug:** v/79370

### Problem
The previous implementation directly passed the `gatt_element_t*` pointer as `user_data` when allocating characteristic attributes, which led to potential dangling pointer issues due to inconsistent memory management:

1. **Stack pointer lifetime issue**: In `alloc_characteristic()`, the function passed `ch->element` (a stack-local pointer) directly to `gatt_db_add()` with `user_data_len = 0`, triggering shallow copy:
   ```c
   // Old code - shallow copy when user_data_len == 0
   attr->user_data = pattern->user_data;  // Points to ch->element
   ```

2. **Memory management conflict**: The `remove_service()` function unconditionally calls `free()` on all `user_data` pointers:
   ```c
   for (i = 0; i < count; i++) {
       free(start[i].user_data);  // Assumes all user_data are heap-allocated
       free((void*)start[i].uuid);
   }
   ```
   This creates two critical problems:
   - **Dangling pointer**: `ch->element` pointed to memory that was already freed by gatts_service.c, accessing it causes crashes

### Solution
Introduce a wrapper structure with deep copy to ensure consistent heap-based memory management:

1. **Define wrapper structure**:
   ```c
   struct gatt_user_data {
       gatt_element_t* element;
       uint16_t len;
       uint8_t value[];  // Flexible array member for future extension
   };
   ```

2. **Use deep copy during allocation**:
   ```c
   struct gatt_user_data user_data = { 0 };
   user_data.element = ch->element;
   
   attr_value = gatt_db_add(..., sizeof(user_data));  // Triggers malloc + memcpy
   ```

3. **Update accessor functions** (`read_value`, `write_value`, `send_indication_result`):
   ```c
   struct gatt_user_data* user_data = (struct gatt_user_data*)attr->user_data;
   gatt_element_t* element = user_data->element;
   ```

4. **Safe cleanup**: Now all `user_data` pointers are heap-allocated and can be safely freed in `remove_service()`

**Signed-off-by:** zhongzhijie1 <zhongzhijie1@xiaomi.com>