### PR TITLE
bluetooth: Fix the issue of failed GATTC deletion.

### DIFF
--- a/feature/feature_async/src/bluetooth_ble_impl.c
+++ b/feature/feature_async/src/bluetooth_ble_impl.c
@@ -1640,7 +1640,7 @@ static void feature_gattc_destroy(FeatureInterfaceHandle handle)
             bt_gattc_feature_disconnect_async(gattc_info->gattc->handle, NULL, NULL);
         }
 
-        bt_gattc_feature_delete_client_async(bluetooth_instance, &gattc_info->gattc->remote_address, NULL, NULL);
+        bt_gattc_feature_delete_client_async(bluetooth_instance, gattc_info->gattc->handle, NULL, NULL);
     }
 
     free(gattc_info->gattc);

--- a/framework/btwrap/async/bt_gatt_feature.c
+++ b/framework/btwrap/async/bt_gatt_feature.c
@@ -53,7 +53,6 @@ typedef struct {
 
 struct gatt_client {
     gattc_handle_t conn;
-    bt_address_t addr;
     bt_gattc_feature_callbacks_t callbacks;
     bool connected;
     bool services_discovering;
@@ -156,25 +155,6 @@ void discovery_database_destroy(gatt_client_t* client)
         bt_list_free(client->temp_attrs);
         client->temp_attrs = NULL;
     }
-}
-
-static bool match_client_by_addr(void* element, void* context)
-{
-    bt_address_t* target_addr;
-    gatt_client_t* client;
-
-    target_addr = (bt_address_t*)context;
-    client = (gatt_client_t*)element;
-
-    return memcmp(&client->addr, target_addr, sizeof(bt_address_t)) == 0;
-}
-
-static gatt_client_t* find_client_by_addr(bt_address_t* addr)
-{
-    if (!g_gatt_client_list || !addr)
-        return NULL;
-
-    return (gatt_client_t*)bt_list_find(g_gatt_client_list, match_client_by_addr, (void*)addr);
 }
 
 static gatt_client_t* find_client_by_conn(gattc_handle_t conn)
@@ -451,7 +431,6 @@ static void feature_on_connected(void* conn_handle, bt_address_t* addr)
         return;
 
     client->connected = true;
-    memcpy(&client->addr, addr, sizeof(bt_address_t));
 
     BT_FEATURE_LOG("connected: conn=%p", conn_handle);
 
@@ -811,7 +790,6 @@ bt_status_t bt_gattc_feature_create_client_async(bt_instance_t* ins, bt_address_
         goto fail;
     }
 
-    memcpy(&client->addr, addr, sizeof(bt_address_t));
     client->ins = ins;
 
     memcpy(&client->callbacks, callbacks, callbacks->size);
@@ -875,15 +853,15 @@ static void delete_client_cb(bt_instance_t* ins, bt_status_t status, void* userd
         user_cb(ins, status, conn_handle, user_ud);
 }
 
-bt_status_t bt_gattc_feature_delete_client_async(bt_instance_t* ins, bt_address_t* addr,
+bt_status_t bt_gattc_feature_delete_client_async(bt_instance_t* ins, gattc_handle_t conn_handle,
     bt_gattc_feature_delete_client_cb_t cb, void* userdata)
 {
     gatt_client_t* client;
 
-    if (!ins || !addr)
+    if (!ins || !conn_handle)
         return BT_STATUS_PARM_INVALID;
 
-    client = find_client_by_addr(addr);
+    client = find_client_by_conn(conn_handle);
     if (!client)
         return BT_STATUS_PARM_INVALID;
 

--- a/framework/include/bt_gatt_feature.h
+++ b/framework/include/bt_gatt_feature.h
@@ -233,13 +233,13 @@ bt_status_t bt_gattc_feature_create_client_async(bt_instance_t* ins, bt_address_
 
 /**
  * @brief Delete GATT client.
- * @param ins        Bluetooth instance.
- * @param addr       Remote device address.
- * @param cb         Delete completion callback.
- * @param userdata   User context.
+ * @param ins         Bluetooth instance.
+ * @param conn_handle Connection handle (from create).
+ * @param cb          Async call status callback.
+ * @param userdata    User context.
  * @return bt_status_t
  */
-bt_status_t bt_gattc_feature_delete_client_async(bt_instance_t* ins, bt_address_t* addr,
+bt_status_t bt_gattc_feature_delete_client_async(bt_instance_t* ins, gattc_handle_t conn_handle,
     bt_gattc_feature_delete_client_cb_t cb, void* userdata);
 
 /**


### PR DESCRIPTION
bug: v/79667

When deleting a GATTC instance, the Advanced API identifies clients based on their device address. If an application creates two GATTC instances with the same device address, and attempts to delete the second instance before the server has returned the asynchronous callback for the first deletion, both deletion operations will effectively target the same underlying GATTC instance due to the identical device address.
