### PR TITLE
L2CAP Service update

### DIFF
--- a/framework/api/bt_l2cap.c
+++ b/framework/api/bt_l2cap.c
@@ -49,5 +49,10 @@ bt_status_t BTSYMBOLS(bt_l2cap_disconnect)(bt_instance_t* ins, void* handle, uin
 
 bt_status_t BTSYMBOLS(bt_l2cap_stop_listen)(bt_instance_t* ins, void* handle, uint16_t psm)
 {
-    return l2cap_stop_listen_channel(handle, psm);
+    return l2cap_stop_listen_channel(handle, BT_TRANSPORT_BLE, psm);
+}
+
+bt_status_t BTSYMBOLS(bt_l2cap_stop_listen_with_transport)(bt_instance_t* ins, void* handle, bt_transport_t transport, uint16_t psm)
+{
+    return l2cap_stop_listen_channel(handle, transport, psm);
 }

--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -491,8 +491,10 @@ void euv_pipe_close(euv_pipe_t* handle)
         BT_LOGE("%s, unkown mode", __func__);
         handle->srv_pipe[EUV_PIPE_TYPE_SERVER_LOCAL].data = handle;
         uv_close((uv_handle_t*)&handle->srv_pipe[EUV_PIPE_TYPE_SERVER_LOCAL], euv_close_callback);
+#ifdef CONFIG_NET_RPMSG
         handle->srv_pipe[EUV_PIPE_TYPE_SERVER_RPMSG].data = handle;
         uv_close((uv_handle_t*)&handle->srv_pipe[EUV_PIPE_TYPE_SERVER_RPMSG], euv_close_callback);
+#endif
         return;
     }
 

--- a/framework/include/bt_l2cap.h
+++ b/framework/include/bt_l2cap.h
@@ -150,10 +150,26 @@ bt_status_t BTSYMBOLS(bt_l2cap_disconnect)(bt_instance_t* ins, void* handle, uin
  *
  * @param ins - bluetooth client instance.
  * @param handle - L2CAP APP handle.
+ * @param psm - LE PSM used for listen.
+ * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ *
+ * @note This function is only used for LE transport scenario.
+ */
+bt_status_t BTSYMBOLS(bt_l2cap_stop_listen)(bt_instance_t* ins, void* handle, uint16_t psm);
+
+/**
+ * @brief Stop L2CAP listen with transport
+ *
+ * This function used to stop L2CAP listen rather than disconnect all conected
+ * L2CAP channels for a specific PSM.
+ *
+ * @param ins - bluetooth client instance.
+ * @param handle - L2CAP APP handle.
+ * @param transport - bt_transport_t, LE or BR/EDR.
  * @param psm - PSM used for listen.
  * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
  */
-bt_status_t BTSYMBOLS(bt_l2cap_stop_listen)(bt_instance_t* ins, void* handle, uint16_t psm);
+bt_status_t BTSYMBOLS(bt_l2cap_stop_listen_with_transport)(bt_instance_t* ins, void* handle, bt_transport_t transport, uint16_t psm);
 
 #ifdef __cplusplus
 }

--- a/framework/include/bt_l2cap.h
+++ b/framework/include/bt_l2cap.h
@@ -26,6 +26,8 @@ extern "C" {
 #define BTSYMBOLS(s) s
 #endif
 
+#define INVALID_L2CAP_LISTEN_ID 0xFFFF
+
 enum {
     LE_PSM_DYNAMIC_MIN = 0x0080,
     LE_PSM_DYNAMIC_MAX = 0x00FF,
@@ -63,7 +65,7 @@ typedef struct {
     uint16_t outgoing_mtu; /* Outgoing transmit MTU */
     uint16_t id; /* Connected L2CAP Channel socket id */
     // for L2CAP listen only.
-    uint16_t listen_id; /* New L2CAP Listen socket id */
+    uint16_t listen_id; /* New L2CAP Listen socket id, INVALID_L2CAP_LISTEN_ID indicates invalid */
     char proxy_name[16]; /* Proxy name for server */
 } l2cap_connect_params_t;
 

--- a/framework/socket/bt_l2cap.c
+++ b/framework/socket/bt_l2cap.c
@@ -142,6 +142,23 @@ bt_status_t bt_l2cap_stop_listen(bt_instance_t* ins, void* handle, uint16_t psm)
 
     BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
 
+    packet.l2cap_pl._bt_l2cap_stop_listen.transport = BT_TRANSPORT_BLE;
+    packet.l2cap_pl._bt_l2cap_stop_listen.psm = psm;
+    status = bt_socket_client_sendrecv(ins, &packet, BT_L2CAP_STOP_LISTEN);
+    if (status != BT_STATUS_SUCCESS)
+        return status;
+
+    return packet.l2cap_r.status;
+}
+
+bt_status_t bt_l2cap_stop_listen_with_transport(bt_instance_t* ins, void* handle, bt_transport_t transport, uint16_t psm)
+{
+    bt_message_packet_t packet;
+    bt_status_t status;
+
+    BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
+
+    packet.l2cap_pl._bt_l2cap_stop_listen.transport = transport;
     packet.l2cap_pl._bt_l2cap_stop_listen.psm = psm;
     status = bt_socket_client_sendrecv(ins, &packet, BT_L2CAP_STOP_LISTEN);
     if (status != BT_STATUS_SUCCESS)

--- a/service/ipc/socket/include/bt_message_l2cap.h
+++ b/service/ipc/socket/include/bt_message_l2cap.h
@@ -39,8 +39,8 @@ BT_L2CAP_MESSAGE_START,
 {
 #endif
 
-#include "bt_l2cap.h"
 #include "bt_ipc_code.h"
+#include "bt_l2cap.h"
 
 #define BT_IPC_CODE_COMMAND_L2CAP_BEGIN BT_IPC_CODE(BT_IPC_CODE_TYPE_COMMAND, BT_IPC_CODE_GROUP_L2CAP, 0)
 // TODO: Add new BT IPC Code sequentially
@@ -74,6 +74,7 @@ BT_L2CAP_MESSAGE_START,
         } _bt_l2cap_disconnect;
 
         struct {
+            uint8_t transport; /* bt_transport_t */
             uint16_t psm;
         } _bt_l2cap_stop_listen;
 

--- a/service/ipc/socket/src/bt_socket_l2cap.c
+++ b/service/ipc/socket/src/bt_socket_l2cap.c
@@ -134,7 +134,9 @@ void bt_socket_server_l2cap_process(service_poll_t* poll, int fd,
     default:
         switch (BT_IPC_GET_SUBCODE(packet->code)) {
         case L2CAP_SUBCODE_STOP_LISTEN:
-            packet->l2cap_r.status = BTSYMBOLS(bt_l2cap_stop_listen)(ins, ins->l2cap_cookie,
+            packet->l2cap_r.status = BTSYMBOLS(bt_l2cap_stop_listen_with_transport)(ins,
+                ins->l2cap_cookie,
+                packet->l2cap_pl._bt_l2cap_stop_listen.transport,
                 packet->l2cap_pl._bt_l2cap_stop_listen.psm);
             break;
         default:

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -424,6 +424,31 @@ static void free_l2cap_channel(void* context)
     free(channel);
 }
 
+static void l2cap_cleanup_app(void* app_handle)
+{
+    bt_list_node_t* node;
+    bt_list_node_t* next;
+    bt_list_t* list;
+
+    // remove all channels
+    BT_LOGD("%s, remove all L2CAP channels belong to app 0x%p", __func__, app_handle);
+    list = g_l2cap_manager.channel_list;
+    for (node = bt_list_head(list); node != NULL; node = next) {
+        l2cap_channel_t* channel = (l2cap_channel_t*)bt_list_node(node);
+        next = bt_list_next(list, node);
+        if (channel->app_handle == app_handle) {
+            BT_LOGD("%s, remove L2CAP channel(id: %" PRIu16 "/ cid: 0x%" PRIx16 ") from list",
+                __func__, channel->id, channel->local_cid);
+
+            if (channel->channel_connected) {
+                bt_sal_l2cap_disconnect_channel(channel->local_cid); // disconnect channel
+            }
+
+            bt_list_remove_node(list, node);
+        }
+    }
+}
+
 static void l2cap_receive_data_from_app(euv_pipe_t* pipe, const uint8_t* buf, ssize_t size)
 {
     l2cap_channel_t* channel;
@@ -821,6 +846,13 @@ bool l2cap_unregister_callbacks(void** remote, void* cookie)
         BT_LOGI("%s, adapter is not enabled", __func__);
         return true;
     }
+
+    if (!cookie) {
+        BT_LOGE("%s, invalid arg", __func__);
+        return false;
+    }
+
+    l2cap_cleanup_app((void*)cookie);
 
     return bt_remote_callbacks_unregister(g_l2cap_manager.callbacks, remote, (remote_callback_t*)cookie);
 }

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -78,8 +78,8 @@
  * Private Types
  ****************************************************************************/
 typedef enum {
-    L2CAP_CHANNEL_ROLE_SERVER,
-    L2CAP_CHANNEL_ROLE_ACCEPT,
+    L2CAP_CHANNEL_ROLE_SERVER_LISTEN,
+    L2CAP_CHANNEL_ROLE_SERVER_ACCEPT,
     L2CAP_CHANNEL_ROLE_CLIENT,
 } l2cap_channel_role_t;
 
@@ -212,7 +212,7 @@ static l2cap_channel_t* alloc_free_channel(void* handle, bt_address_t* addr, uin
     int id;
     l2cap_channel_t* channel;
 
-    if (addr && role == L2CAP_CHANNEL_ROLE_SERVER) {
+    if (addr && role == L2CAP_CHANNEL_ROLE_SERVER_LISTEN) {
         // this check is not necessary?
         BT_LOGW("%s, server channel remote addr is not NULL", __func__);
         return NULL;
@@ -342,8 +342,8 @@ static l2cap_channel_t* find_l2cap_channel_by_conn_param(bt_address_t* addr, uin
         }
         break;
     }
-    case L2CAP_CHANNEL_ROLE_SERVER:
-    case L2CAP_CHANNEL_ROLE_ACCEPT: {
+    case L2CAP_CHANNEL_ROLE_SERVER_LISTEN:
+    case L2CAP_CHANNEL_ROLE_SERVER_ACCEPT: {
         // server and accept find by psm
         for (node = bt_list_head(list); node != NULL; node = bt_list_next(list, node)) {
             l2cap_channel_t* channel = (l2cap_channel_t*)bt_list_node(node);
@@ -375,13 +375,13 @@ static void free_le_dynamic_psm(uint16_t psm)
         return;
     }
 
-    channel = find_l2cap_channel_by_conn_param(NULL, psm, L2CAP_CHANNEL_ROLE_SERVER, false);
+    channel = find_l2cap_channel_by_conn_param(NULL, psm, L2CAP_CHANNEL_ROLE_SERVER_LISTEN, false);
     if (channel) {
         BT_LOGI("%s, psm %" PRIu16 " is used to listen", __func__, psm);
         return;
     }
 
-    channel = find_l2cap_channel_by_conn_param(NULL, psm, L2CAP_CHANNEL_ROLE_ACCEPT, true);
+    channel = find_l2cap_channel_by_conn_param(NULL, psm, L2CAP_CHANNEL_ROLE_SERVER_ACCEPT, true);
     if (channel) {
         BT_LOGI("%s, psm %" PRIu16 " is used to accept", __func__, psm);
         return;
@@ -542,7 +542,7 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
         return;
     }
 
-    role = param->is_client ? L2CAP_CHANNEL_ROLE_CLIENT : L2CAP_CHANNEL_ROLE_SERVER;
+    role = param->is_client ? L2CAP_CHANNEL_ROLE_CLIENT : L2CAP_CHANNEL_ROLE_SERVER_LISTEN;
     channel = find_l2cap_channel_by_conn_param(addr, param->psm, role, false);
     if (!channel) {
         BT_LOGE("%s, find L2CAP channel null, local cid: 0x%" PRIx16, __func__, param->local_cid);
@@ -557,11 +557,11 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
         return;
     }
 
-    if (role == L2CAP_CHANNEL_ROLE_SERVER) {
+    if (role == L2CAP_CHANNEL_ROLE_SERVER_LISTEN) {
         memcpy(&channel->addr, addr, sizeof(channel->addr));
         channel->local_cid = param->local_cid;
-        channel->role = L2CAP_CHANNEL_ROLE_ACCEPT;
-        new_listen_channel = alloc_free_channel((void*)channel->app_handle, NULL, channel->psm, L2CAP_CHANNEL_ROLE_SERVER);
+        channel->role = L2CAP_CHANNEL_ROLE_SERVER_ACCEPT;
+        new_listen_channel = alloc_free_channel((void*)channel->app_handle, NULL, channel->psm, L2CAP_CHANNEL_ROLE_SERVER_LISTEN);
         if (!new_listen_channel) {
             BT_LOGE("%s, allocate new listen channel for psm: %" PRIx16 "failed", __func__, channel->psm);
             return;
@@ -833,7 +833,7 @@ bt_status_t l2cap_listen_channel(void* handle, l2cap_config_option_t* option)
         }
     }
 
-    channel = alloc_free_channel(handle, NULL, option->psm, L2CAP_CHANNEL_ROLE_SERVER);
+    channel = alloc_free_channel(handle, NULL, option->psm, L2CAP_CHANNEL_ROLE_SERVER_LISTEN);
     if (!channel) {
         status = BT_STATUS_NOMEM;
         goto out;
@@ -948,7 +948,7 @@ bt_status_t l2cap_stop_listen_channel(void* handle, uint16_t psm)
     CHECK_ADAPTER_ENABLED(BT_STATUS_NOT_ENABLED);
 
     pthread_mutex_lock(&g_l2cap_manager.l2cap_lock);
-    channel = find_l2cap_channel_by_conn_param(NULL, psm, L2CAP_CHANNEL_ROLE_SERVER, false);
+    channel = find_l2cap_channel_by_conn_param(NULL, psm, L2CAP_CHANNEL_ROLE_SERVER_LISTEN, false);
     if (!channel) {
         status = BT_STATUS_NOT_FOUND;
         BT_LOGE("%s, L2CAP(psm: 0x%" PRIx16 ") not found", __func__, psm);

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -869,6 +869,12 @@ bt_status_t l2cap_listen_channel(void* handle, l2cap_config_option_t* option)
 
     CHECK_ADAPTER_ENABLED(BT_STATUS_NOT_ENABLED);
 
+    if (option->transport != BT_TRANSPORT_BLE) {
+        // TBD: support BR/EDR later
+        BT_LOGW("%s, only support LE transport", __func__);
+        return BT_STATUS_UNSUPPORTED;
+    }
+
     pthread_mutex_lock(&g_l2cap_manager.l2cap_lock);
     if (option->psm == 0) {
         option->psm = alloc_le_dynamic_psm();
@@ -994,12 +1000,18 @@ exit:
     return status;
 }
 
-bt_status_t l2cap_stop_listen_channel(void* handle, uint16_t psm)
+bt_status_t l2cap_stop_listen_channel(void* handle, bt_transport_t transport, uint16_t psm)
 {
     bt_status_t status = BT_STATUS_SUCCESS;
     l2cap_channel_t* channel;
 
     CHECK_ADAPTER_ENABLED(BT_STATUS_NOT_ENABLED);
+
+    if (transport != BT_TRANSPORT_BLE) {
+        // TBD: support BR/EDR later
+        BT_LOGW("%s, only support LE transport", __func__);
+        return BT_STATUS_UNSUPPORTED;
+    }
 
     pthread_mutex_lock(&g_l2cap_manager.l2cap_lock);
     channel = find_l2cap_channel_by_conn_param(NULL, psm, L2CAP_CHANNEL_ROLE_SERVER_LISTEN, false);

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -74,6 +74,11 @@
  */
 #define PSM_BIT_MASK(psm) (1ULL << (psm - LE_PSM_DYNAMIC_MIN))
 
+/**
+ * \def L2CAP Tx SDU watermark
+ */
+#define L2CAP_TX_QUOTA 16
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -92,6 +97,7 @@ typedef struct {
     l2cap_endpoint_param_t incoming;
     l2cap_endpoint_param_t outgoing;
     uint16_t tx_mtu;
+    uint16_t tx_quota;
     uint16_t id;
     l2cap_channel_role_t role;
     bool channel_connected;
@@ -449,6 +455,9 @@ static void l2cap_receive_data_from_app(euv_pipe_t* pipe, const uint8_t* buf, ss
             BT_LOGW("%s, L2CAP channel not connected", __func__);
         } else {
             bt_sal_l2cap_send_packet(channel->local_cid, (uint8_t*)buf, size);
+            if (!(--channel->tx_quota)) {
+                euv_pipe_read_stop(channel->pipe);
+            }
         }
     }
 
@@ -577,6 +586,7 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
     memcpy(&channel->incoming, &param->incoming, sizeof(channel->incoming));
     memcpy(&channel->outgoing, &param->outgoing, sizeof(channel->outgoing));
     channel->tx_mtu = MIN(param->outgoing.mtu, CONFIG_BLUETOOTH_L2CAP_OUTGOING_MTU);
+    channel->tx_quota = L2CAP_TX_QUOTA; // TODO: need to adjust quota according to mtu and memory
 
     // restart read pipe to adjust mtu
     ret = euv_pipe_read_stop(channel->pipe);
@@ -594,7 +604,8 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
     }
 
     BT_LOGI("L2CAP channel(id: %" PRIu16 "/cid: 0x%" PRIx16 ") connected", channel->id, channel->local_cid);
-    BT_LOGD("L2CAP channel(id: %" PRIu16 "/cid: 0x%" PRIx16 ") mtu: %" PRIu16, channel->id, channel->local_cid, channel->tx_mtu);
+    BT_LOGD("L2CAP channel(id: %" PRIu16 "/cid: 0x%" PRIx16 ") Tx mtu: %" PRIu16 ", Tx quota: %" PRIu16,
+        channel->id, channel->local_cid, channel->tx_mtu, channel->tx_quota);
     channel->channel_connected = true;
 
     // notify app
@@ -659,9 +670,19 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, uint8_t* pa
 
 static void handle_packet_sent(bt_address_t* addr, uint16_t cid)
 {
-    // do nothing for now.
-    UNUSED(addr);
-    UNUSED(cid);
+    l2cap_channel_t* channel;
+
+    channel = find_l2cap_channel_by_cid(cid);
+    if (!channel) {
+        BT_LOGE("%s, find L2CAP channel null, local cid: 0x%" PRIx16, __func__, cid);
+        return;
+    }
+
+    if (channel->pipe && !channel->tx_quota) {
+        euv_pipe_read_start(channel->pipe, channel->tx_mtu, l2cap_receive_data_from_app, NULL);
+    }
+
+    channel->tx_quota++;
 }
 
 static void handle_l2cap_event(void* data)

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -569,7 +569,7 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
     int ret;
     l2cap_channel_t* channel;
     l2cap_channel_t* new_listen_channel = NULL;
-    l2cap_connect_params_t conn_param;
+    l2cap_connect_params_t conn_param = { .listen_id = INVALID_L2CAP_LISTEN_ID };
     l2cap_channel_role_t role;
 
     if (!addr || !param) {

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -233,6 +233,7 @@ static l2cap_channel_t* alloc_free_channel(void* handle, bt_address_t* addr, uin
     channel = (l2cap_channel_t*)calloc(1, sizeof(l2cap_channel_t));
     if (!channel) {
         BT_LOGE("%s, alloc l2cap channel failed", __func__);
+        index_free(g_l2cap_manager.id_allocator, id);
         return NULL;
     }
 

--- a/service/src/l2cap_service.h
+++ b/service/src/l2cap_service.h
@@ -47,7 +47,7 @@ bool l2cap_unregister_callbacks(void** remote, void* cookie);
 bt_status_t l2cap_listen_channel(void* handle, l2cap_config_option_t* option);
 bt_status_t l2cap_connect_channel(void* handle, bt_address_t* addr, l2cap_config_option_t* option);
 bt_status_t l2cap_disconnect_channel(void* handle, uint16_t id);
-bt_status_t l2cap_stop_listen_channel(void* handle, uint16_t psm);
+bt_status_t l2cap_stop_listen_channel(void* handle, bt_transport_t transport, uint16_t psm);
 
 bt_status_t l2cap_service_init(void);
 void l2cap_service_cleanup(void);

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -22,6 +22,10 @@
 #include "euv_pipe.h"
 #include "uv_thread_loop.h"
 
+#define L2CAP_TRANS_MTU_CFG 1000
+#define L2CAP_TRANS_MPS_CFG 251
+#define L2CAP_TRANS_CREDIT_CFG 30
+
 typedef struct {
     struct list_node node;
     euv_pipe_t* pipe;
@@ -355,24 +359,26 @@ static int connect_cmd(void* handle, int argc, char* argv[])
     if (bt_addr_str2ba(argv[0], &addr) < 0)
         return CMD_INVALID_ADDR;
 
-    conn_option.psm = atoi(argv[1]);
-    // defaule param
-    conn_option.transport = BT_TRANSPORT_BLE;
-    conn_option.mode = L2CAP_CHANNEL_MODE_LE_CREDIT_BASED_FLOW_CONTROL;
-    conn_option.mtu = 128;
-    conn_option.le_mps = 128;
-    conn_option.init_credits = 0xffff;
-    if (bt_l2cap_connect(handle, g_l2cap_handle, &addr, &conn_option) != BT_STATUS_SUCCESS) {
-        PRINT("connect %s failed\n", argv[0]);
+    msg = (l2cap_msg_t*)zalloc(sizeof(l2cap_msg_t));
+    if (!msg) {
+        PRINT("allocate msg failed");
         return CMD_ERROR;
     }
 
-    PRINT("L2cap channel(id:%" PRIu16 ") connecting\n", conn_option.id);
-    msg = (l2cap_msg_t*)malloc(sizeof(l2cap_msg_t));
-    if (!msg) {
-        PRINT("allocate msg failed\n");
+    conn_option.psm = strtoul(argv[1], NULL, 0);
+    // defaule param
+    conn_option.transport = BT_TRANSPORT_BLE;
+    conn_option.mode = L2CAP_CHANNEL_MODE_LE_CREDIT_BASED_FLOW_CONTROL;
+    conn_option.mtu = L2CAP_TRANS_MTU_CFG;
+    conn_option.le_mps = L2CAP_TRANS_MPS_CFG;
+    conn_option.init_credits = L2CAP_TRANS_CREDIT_CFG;
+    if (bt_l2cap_connect(handle, g_l2cap_handle, &addr, &conn_option) != BT_STATUS_SUCCESS) {
+        PRINT("connect %s failed", argv[0]);
+        free(msg);
         return CMD_ERROR;
     }
+
+    PRINT("L2cap channel(id:%" PRIu16 ") connecting", conn_option.id);
 
     msg->id = conn_option.id;
     msg->psm = conn_option.psm;
@@ -395,27 +401,29 @@ static int listen_cmd(void* handle, int argc, char* argv[])
     }
 
     if (argc < 1)
-        return CMD_PARAM_NOT_ENOUGH;
+        conn_option.psm = 0;
+    else
+        conn_option.psm = strtoul(argv[0], NULL, 0);
 
-    conn_option.psm = atoi(argv[0]);
+    msg = (l2cap_msg_t*)zalloc(sizeof(l2cap_msg_t));
+    if (!msg) {
+        PRINT("allocate msg failed");
+        return CMD_ERROR;
+    }
+
     // default param
     conn_option.transport = BT_TRANSPORT_BLE;
     conn_option.mode = L2CAP_CHANNEL_MODE_LE_CREDIT_BASED_FLOW_CONTROL;
-    conn_option.mtu = 128;
-    conn_option.le_mps = 128;
-    conn_option.init_credits = 0xffff;
+    conn_option.mtu = L2CAP_TRANS_MTU_CFG;
+    conn_option.le_mps = L2CAP_TRANS_MPS_CFG;
+    conn_option.init_credits = L2CAP_TRANS_CREDIT_CFG;
     if (bt_l2cap_listen(handle, g_l2cap_handle, &conn_option) != BT_STATUS_SUCCESS) {
         PRINT("listen 0x%" PRIx16 " failed", conn_option.psm);
+        free(msg);
         return CMD_ERROR;
     }
 
-    PRINT("L2cap channel(id:%" PRIu16 "/psm:0x%x) start listen\n", conn_option.id, conn_option.psm);
-    msg = (l2cap_msg_t*)malloc(sizeof(l2cap_msg_t));
-    if (!msg) {
-        PRINT("allocate msg failed\n");
-        return CMD_ERROR;
-    }
-
+    PRINT("L2cap channel(id:%" PRIu16 "/psm:0x%" PRIx16 ") start listen", conn_option.id, conn_option.psm);
     msg->id = conn_option.id;
     msg->psm = conn_option.psm;
     msg->is_listening = true;
@@ -437,9 +445,13 @@ static int disconnect_cmd(void* handle, int argc, char* argv[])
     if (argc < 1)
         return CMD_PARAM_NOT_ENOUGH;
 
-    id = atoi(argv[0]);
-    PRINT("L2cap channel(id:%" PRIu16 ") disconnecting\n", id);
-    bt_l2cap_disconnect(handle, g_l2cap_handle, id);
+    id = strtoul(argv[0], NULL, 10);
+    if (bt_l2cap_disconnect(handle, g_l2cap_handle, id) != BT_STATUS_SUCCESS) {
+        PRINT("disconnect %" PRIu16 " failed", id);
+        return CMD_ERROR;
+    }
+
+    PRINT("L2cap channel(id:%" PRIu16 ") disconnecting", id);
 
     return CMD_OK;
 }
@@ -470,9 +482,9 @@ static int write_cmd(void* handle, int argc, char* argv[])
         return CMD_ERROR;
     }
 
-    msg->id = atoi(argv[0]);
+    msg->id = strtoul(argv[0], NULL, 10);
     msg->buf = buf;
-    msg->len = strlen(argv[1]);
+    msg->len = strlen((char*)buf);
     do_in_thread_loop(&g_l2cap_thread, do_l2cap_write, msg);
 
     return CMD_OK;

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -75,6 +75,23 @@ static struct list_node channel_list = LIST_INITIAL_VALUE(channel_list);
 static l2cap_trans_ctx_t g_trans_ctx = { 0 };
 static sem_t speed_tx_sem;
 
+static void cleanup_l2cap_channel(void* data)
+{
+    struct list_node* node;
+    struct list_node* tmp;
+    struct list_node* list = &channel_list;
+
+    list_for_every_safe(list, node, tmp)
+    {
+        list_delete(node);
+        if (((l2cap_chnl_t*)node)->pipe) {
+            euv_pipe_disconnect(((l2cap_chnl_t*)node)->pipe);
+        }
+
+        free(node);
+    }
+}
+
 static l2cap_chnl_t* find_channel_by_id(uint16_t id)
 {
     struct list_node* node;
@@ -742,6 +759,7 @@ int l2cap_command_init(void* handle)
 
 void l2cap_command_uninit(void* handle)
 {
+    do_in_thread_loop(&g_l2cap_thread, cleanup_l2cap_channel, NULL);
     bt_l2cap_unregister_callbacks(handle, g_l2cap_handle);
     thread_loop_exit(&g_l2cap_thread);
     sem_destroy(&speed_tx_sem);

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -28,6 +28,7 @@ typedef struct {
     uint16_t psm;
     uint16_t cid;
     uint16_t id;
+    bool is_listening;
 } l2cap_chnl_t;
 
 typedef struct {
@@ -36,6 +37,7 @@ typedef struct {
     uint16_t psm;
     uint16_t cid;
     uint16_t listen_id; // for server listen
+    bool is_listening;
     char* proxy_name;
     uint8_t* buf;
     uint16_t len;
@@ -121,28 +123,23 @@ static void data_path_connected_cb(euv_pipe_t* pipe, int status, void* data)
 
 static void add_l2cap_channel(void* data)
 {
-    l2cap_msg_t* msg;
+    l2cap_msg_t* msg = (l2cap_msg_t*)data;
     l2cap_chnl_t* channel;
 
-    if (!data) {
-        PRINT("invalid arg\n");
-        return;
-    }
-
-    msg = (l2cap_msg_t*)data;
     channel = (l2cap_chnl_t*)zalloc(sizeof(l2cap_chnl_t));
     if (!channel) {
-        PRINT("allocate channel failed\n");
+        PRINT("allocate channel failed");
         goto free_msg;
         // TBD: cancel l2cap channel listen or connect immediately?
     }
 
-    PRINT("L2cap channel(id:%" PRIu16 ") alloc success\n", msg->id);
+    PRINT("L2cap channel(id:%" PRIu16 ") alloc success", msg->id);
     channel->id = msg->id;
     channel->psm = msg->psm;
+    channel->is_listening = msg->is_listening;
     channel->pipe = euv_pipe_connect(&g_l2cap_thread, msg->proxy_name, data_path_connected_cb, channel);
     if (!channel->pipe) {
-        PRINT("connect pipe failed\n");
+        PRINT("connect pipe failed");
         free(channel);
         goto free_msg;
     }
@@ -157,37 +154,32 @@ free_msg:
 static void l2cap_channel_connected_process(void* data)
 {
     int ret;
-    l2cap_msg_t* msg;
+    l2cap_msg_t* msg = (l2cap_msg_t*)data;
     l2cap_chnl_t* channel;
 
-    if (!data) {
-        PRINT("invalid arg\n");
-        return;
-    }
-
-    msg = (l2cap_msg_t*)data;
     channel = find_channel_by_id(msg->id);
     if (channel == NULL) {
-        PRINT("channel not found\n");
+        PRINT("%s, channel not found", __func__);
         goto free_msg;
     }
 
     channel->cid = msg->cid;
-    PRINT("L2cap channel(id:%" PRIu16 "/cid:%x) connected\n", msg->id, msg->cid);
+    PRINT("L2cap channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") connected", msg->id, msg->cid);
     ret = euv_pipe_read_start(channel->pipe, 2048, read_complete_cb, NULL);
     if (ret) {
-        PRINT("start read pipe failed\n");
+        PRINT("start read pipe failed");
         // disconnect data path, l2cap service will disconnect l2cap channel
         euv_pipe_disconnect(channel->pipe);
         list_delete(&channel->node);
         free(channel);
         goto free_msg;
     }
-
-    // Clone listen channel
-    if (msg->listen_id > 0 && msg->proxy_name) {
-        PRINT("prepare a new listen channel(id: %" PRIu16 ") for PSM:0x%x\n", msg->listen_id, msg->psm);
-        msg->id = msg->listen_id; // for reusing add_l2cap_channel method.
+    if (msg->listen_id >= 0 && msg->proxy_name) {
+        channel->is_listening = false; /* listen channel transfer to connected(accept) channel */
+        PRINT("prepare a new listen channel(id: %" PRIu16 ") for PSM:0x%" PRIx16, msg->listen_id, msg->psm);
+        /* Create a new channel for listening */
+        msg->id = msg->listen_id;
+        msg->is_listening = true;
         add_l2cap_channel((void*)msg);
         return;
     }
@@ -253,6 +245,34 @@ static void do_l2cap_write(void* data)
     free(msg);
 }
 
+static void do_l2cap_stop_listen(void* data)
+{
+    l2cap_msg_t* msg = (l2cap_msg_t*)data;
+    struct list_node* node;
+    struct list_node* tmp;
+    struct list_node* list = &channel_list;
+    l2cap_chnl_t* channel;
+
+    list_for_every_safe(list, node, tmp)
+    {
+        channel = (l2cap_chnl_t*)node;
+        if (channel->is_listening && channel->psm == msg->psm) {
+            PRINT("free listen channel(id:%" PRIu16 ") for psm:0x%" PRIx16, channel->id, msg->psm);
+            if (channel->pipe) {
+                euv_pipe_disconnect(channel->pipe);
+                channel->pipe = NULL;
+            }
+
+            list_delete(&channel->node);
+            free(channel);
+            channel = NULL;
+            break;
+        }
+    }
+
+    free(msg);
+}
+
 static void on_connected(void* handle, l2cap_connect_params_t* params)
 {
     l2cap_msg_t* msg;
@@ -272,7 +292,8 @@ static void on_connected(void* handle, l2cap_connect_params_t* params)
     msg->psm = params->psm;
     msg->cid = params->cid;
     if (params->listen_id > 0) {
-        PRINT("new listen(id: %" PRIu16 "/ proxy_name: %s) for listen psm: 0x%x)", params->listen_id, params->proxy_name, params->psm);
+        PRINT("new listen(id: %" PRIu16 "/ proxy_name: %s) for listen psm: 0x%" PRIx16,
+            params->listen_id, params->proxy_name, params->psm);
         msg->listen_id = params->listen_id;
         msg->proxy_name = strdup(params->proxy_name);
     }
@@ -350,6 +371,7 @@ static int connect_cmd(void* handle, int argc, char* argv[])
     msg->id = conn_option.id;
     msg->psm = conn_option.psm;
     msg->proxy_name = strdup(conn_option.proxy_name);
+    msg->is_listening = false;
     memcpy(&msg->addr, &addr, sizeof(bt_address_t));
     do_in_thread_loop(&g_l2cap_thread, add_l2cap_channel, msg);
 
@@ -377,7 +399,7 @@ static int listen_cmd(void* handle, int argc, char* argv[])
     conn_option.le_mps = 128;
     conn_option.init_credits = 0xffff;
     if (bt_l2cap_listen(handle, g_l2cap_handle, &conn_option) != BT_STATUS_SUCCESS) {
-        PRINT("listen %d failed\n", conn_option.psm);
+        PRINT("listen 0x%" PRIx16 " failed", conn_option.psm);
         return CMD_ERROR;
     }
 
@@ -390,6 +412,7 @@ static int listen_cmd(void* handle, int argc, char* argv[])
 
     msg->id = conn_option.id;
     msg->psm = conn_option.psm;
+    msg->is_listening = true;
     msg->proxy_name = strdup(conn_option.proxy_name);
     do_in_thread_loop(&g_l2cap_thread, add_l2cap_channel, msg);
 
@@ -449,10 +472,43 @@ static int write_cmd(void* handle, int argc, char* argv[])
     return CMD_OK;
 }
 
+static int stop_listen_cmd(void* handle, int argc, char* argv[])
+{
+    uint16_t psm;
+    l2cap_msg_t* msg;
+
+    if (!handle || !g_l2cap_handle) {
+        PRINT("L2CAP tool not ready!");
+        return CMD_ERROR;
+    }
+
+    if (argc < 1)
+        return CMD_PARAM_NOT_ENOUGH;
+
+    msg = (l2cap_msg_t*)zalloc(sizeof(l2cap_msg_t));
+    if (!msg) {
+        PRINT("allocate msg failed");
+        return CMD_ERROR;
+    }
+
+    psm = strtoul(argv[0], NULL, 0);
+    if (bt_l2cap_stop_listen_with_transport(handle, g_l2cap_handle, BT_TRANSPORT_BLE, psm) != BT_STATUS_SUCCESS) {
+        PRINT("stop listen 0x%" PRIX16 " failed", psm);
+        return CMD_ERROR;
+    }
+
+    PRINT("L2cap stop listen psm:0x%" PRIx16, psm);
+    msg->psm = psm;
+    do_in_thread_loop(&g_l2cap_thread, do_l2cap_stop_listen, msg);
+
+    return CMD_OK;
+}
+
 static bt_command_t g_l2cap_commands[] = {
     { "connect", connect_cmd, 0, "\"connect l2cap channel      param: <address> <psm>\"" },
     { "listen", listen_cmd, 0, "\"listen l2cap channel        param: <psm>\"" },
     { "disconnect", disconnect_cmd, 0, "\"disconnect l2cap channel  param: <id>\"" },
+    { "stoplisten", stop_listen_cmd, 0, "\"stop listen l2cap channel  param: <psm>\"" },
     { "write", write_cmd, 0, "\"write data to peer   param: <id> <data>\"" },
 };
 

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -28,7 +28,7 @@ typedef struct {
     uint16_t psm;
     uint16_t cid;
     uint16_t id;
-} l2cap_channel_t;
+} l2cap_chnl_t;
 
 typedef struct {
     bt_address_t addr;
@@ -45,15 +45,15 @@ static uv_loop_t g_l2cap_thread;
 static void* g_l2cap_handle;
 static struct list_node channel_list = LIST_INITIAL_VALUE(channel_list);
 
-static l2cap_channel_t* find_channel_by_id(uint16_t id)
+static l2cap_chnl_t* find_channel_by_id(uint16_t id)
 {
     struct list_node* node;
     struct list_node* list = &channel_list;
-    l2cap_channel_t* channel;
+    l2cap_chnl_t* channel;
 
     list_for_every(list, node)
     {
-        channel = (l2cap_channel_t*)node;
+        channel = (l2cap_chnl_t*)node;
         if (channel->id == id) {
             return channel;
         }
@@ -62,15 +62,15 @@ static l2cap_channel_t* find_channel_by_id(uint16_t id)
     return NULL;
 }
 
-static l2cap_channel_t* find_channel_by_pipe(euv_pipe_t* pipe)
+static l2cap_chnl_t* find_channel_by_pipe(euv_pipe_t* pipe)
 {
     struct list_node* node;
     struct list_node* list = &channel_list;
-    l2cap_channel_t* channel;
+    l2cap_chnl_t* channel;
 
     list_for_every(list, node)
     {
-        channel = (l2cap_channel_t*)node;
+        channel = (l2cap_chnl_t*)node;
         if (channel->pipe == pipe) {
             return channel;
         }
@@ -86,7 +86,7 @@ static void write_complete_cb(euv_pipe_t* handle, uint8_t* buf, int status)
 
 static void read_complete_cb(euv_pipe_t* pipe, const uint8_t* buf, ssize_t nread)
 {
-    l2cap_channel_t* channel;
+    l2cap_chnl_t* channel;
 
     // need lock
     if (nread < 0) {
@@ -112,7 +112,7 @@ static void read_complete_cb(euv_pipe_t* pipe, const uint8_t* buf, ssize_t nread
 
 static void data_path_connected_cb(euv_pipe_t* pipe, int status, void* data)
 {
-    l2cap_channel_t* channel = (l2cap_channel_t*)data;
+    l2cap_chnl_t* channel = (l2cap_chnl_t*)data;
     // need lock
     PRINT("l2cap channel(id:%" PRIu16 ") data path establish status:%d\n", channel->id, status); // euv thread
 
@@ -122,7 +122,7 @@ static void data_path_connected_cb(euv_pipe_t* pipe, int status, void* data)
 static void add_l2cap_channel(void* data)
 {
     l2cap_msg_t* msg;
-    l2cap_channel_t* channel;
+    l2cap_chnl_t* channel;
 
     if (!data) {
         PRINT("invalid arg\n");
@@ -130,7 +130,7 @@ static void add_l2cap_channel(void* data)
     }
 
     msg = (l2cap_msg_t*)data;
-    channel = (l2cap_channel_t*)zalloc(sizeof(l2cap_channel_t));
+    channel = (l2cap_chnl_t*)zalloc(sizeof(l2cap_chnl_t));
     if (!channel) {
         PRINT("allocate channel failed\n");
         goto free_msg;
@@ -158,7 +158,7 @@ static void l2cap_channel_connected_process(void* data)
 {
     int ret;
     l2cap_msg_t* msg;
-    l2cap_channel_t* channel;
+    l2cap_chnl_t* channel;
 
     if (!data) {
         PRINT("invalid arg\n");
@@ -202,7 +202,7 @@ free_msg:
 static void l2cap_channel_disconnected_process(void* data)
 {
     l2cap_msg_t* msg;
-    l2cap_channel_t* channel;
+    l2cap_chnl_t* channel;
 
     if (!data) {
         PRINT("invalid arg\n");
@@ -231,7 +231,7 @@ static void l2cap_channel_disconnected_process(void* data)
 static void do_l2cap_write(void* data)
 {
     l2cap_msg_t* msg;
-    l2cap_channel_t* channel;
+    l2cap_chnl_t* channel;
 
     if (!data) {
         PRINT("invalid arg\n");

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -174,7 +174,8 @@ static void l2cap_channel_connected_process(void* data)
         free(channel);
         goto free_msg;
     }
-    if (msg->listen_id >= 0 && msg->proxy_name) {
+
+    if (msg->listen_id != INVALID_L2CAP_LISTEN_ID) {
         channel->is_listening = false; /* listen channel transfer to connected(accept) channel */
         PRINT("prepare a new listen channel(id: %" PRIu16 ") for PSM:0x%" PRIx16, msg->listen_id, msg->psm);
         /* Create a new channel for listening */
@@ -291,11 +292,16 @@ static void on_connected(void* handle, l2cap_connect_params_t* params)
     msg->id = params->id;
     msg->psm = params->psm;
     msg->cid = params->cid;
-    if (params->listen_id > 0) {
+    msg->listen_id = params->listen_id;
+    if (params->listen_id != INVALID_L2CAP_LISTEN_ID) {
         PRINT("new listen(id: %" PRIu16 "/ proxy_name: %s) for listen psm: 0x%" PRIx16,
             params->listen_id, params->proxy_name, params->psm);
-        msg->listen_id = params->listen_id;
         msg->proxy_name = strdup(params->proxy_name);
+        if (!msg->proxy_name) {
+            PRINT("%s, allocate proxy name failed", __func__);
+            free(msg);
+            return;
+        }
     }
 
     memcpy(&msg->addr, &params->addr, sizeof(bt_address_t));

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -456,6 +456,19 @@ static bt_command_t g_l2cap_commands[] = {
     { "write", write_cmd, 0, "\"write data to peer   param: <id> <data>\"" },
 };
 
+static void usage(void)
+{
+    int i;
+
+    printf("Usage:\n");
+    printf("\tpsm: Protocol/Service Multiplexer value(128~191, 0 only for start listen)\n");
+    printf("\tid: L2CAP Sock id, which is returned by connect/listen command\n");
+    printf("\tCommands:\n");
+    for (i = 0; i < ARRAY_SIZE(g_l2cap_commands); i++) {
+        printf("\t%-8s\t%s\n", g_l2cap_commands[i].cmd, g_l2cap_commands[i].help);
+    }
+}
+
 int l2cap_command_exec(void* handle, int argc, char* argv[])
 {
     int ret = CMD_USAGE_FAULT;
@@ -463,6 +476,9 @@ int l2cap_command_exec(void* handle, int argc, char* argv[])
     if (argc > 0) {
         ret = execute_command_in_table(handle, g_l2cap_commands, ARRAY_SIZE(g_l2cap_commands), argc, argv);
     }
+
+    if (ret < 0)
+        usage();
 
     return ret;
 }

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -47,9 +47,33 @@ typedef struct {
     uint16_t len;
 } l2cap_msg_t;
 
+typedef struct {
+    void* handle;
+    enum {
+        TRANS_IDLE = 0,
+        TRANS_WRITING,
+        TRANS_SENDING,
+        TRANS_RECVING,
+        TRANS_ECHO,
+    } state;
+    uint8_t* bulk_buf;
+    int32_t bulk_count;
+    uint32_t bulk_length;
+    uint32_t trans_total_size;
+    uint32_t received_size;
+    uint64_t start_timestamp;
+    uint64_t end_timestamp;
+} l2cap_trans_ctx_t;
+
+static const char* TRANS_START = "START:";
+static const char* TRANS_START_ACK = "START_ACK";
+static const char* TRANS_EOF = "EOF";
+
 static uv_loop_t g_l2cap_thread;
 static void* g_l2cap_handle;
 static struct list_node channel_list = LIST_INITIAL_VALUE(channel_list);
+static l2cap_trans_ctx_t g_trans_ctx = { 0 };
+static sem_t speed_tx_sem;
 
 static l2cap_chnl_t* find_channel_by_id(uint16_t id)
 {
@@ -68,21 +92,9 @@ static l2cap_chnl_t* find_channel_by_id(uint16_t id)
     return NULL;
 }
 
-static l2cap_chnl_t* find_channel_by_pipe(euv_pipe_t* pipe)
+static void l2cap_trans_reset(void)
 {
-    struct list_node* node;
-    struct list_node* list = &channel_list;
-    l2cap_chnl_t* channel;
-
-    list_for_every(list, node)
-    {
-        channel = (l2cap_chnl_t*)node;
-        if (channel->pipe == pipe) {
-            return channel;
-        }
-    }
-
-    return NULL;
+    memset(&g_trans_ctx, 0, sizeof(g_trans_ctx));
 }
 
 static void write_complete_cb(euv_pipe_t* handle, uint8_t* buf, int status)
@@ -90,39 +102,124 @@ static void write_complete_cb(euv_pipe_t* handle, uint8_t* buf, int status)
     free(buf);
 }
 
+static void bulk_trans_complete(euv_pipe_t* handle, uint8_t* buf, int status)
+{
+    l2cap_trans_ctx_t* ctx = &g_trans_ctx;
+
+    ctx->bulk_count--;
+    if (ctx->bulk_count)
+        euv_pipe_write(handle, buf, ctx->bulk_length, bulk_trans_complete);
+    else
+        free(buf);
+}
+
+static bool bulk_buf_gen(uint8_t** buf, uint32_t length)
+{
+    uint32_t data_len;
+    struct bulk_buf_t {
+        char delimiter[4];
+        uint32_t length;
+        uint8_t filled_data[0];
+    } * bulk_buf;
+
+    if (length < sizeof(struct bulk_buf_t)) {
+        PRINT("bulk length is too short");
+        return false;
+    }
+
+    bulk_buf = malloc(length);
+    if (!bulk_buf) {
+        PRINT("allocate bulk buffer failed");
+        return false;
+    }
+
+    strncpy(bulk_buf->delimiter, "Vela", 4);
+    bulk_buf->length = length;
+    data_len = length - sizeof(struct bulk_buf_t);
+    for (uint32_t i = 0; i < data_len; i++) {
+        bulk_buf->filled_data[i] = (uint8_t)(i % 256);
+    }
+
+    *buf = (uint8_t*)bulk_buf;
+    return true;
+}
+
+static void show_result(uint64_t start, uint64_t end, uint32_t bytes)
+{
+    float use = (float)(end - start) / 1000;
+    float spd = (float)(bytes / 1024) / use;
+
+    PRINT("transmit done, total: %" PRIu32 " bytes, use: %f seconds, speed: %f KB/s", bytes, use, spd);
+}
+
+static void handle_l2cap_data_recv(euv_pipe_t* handle, const uint8_t* buf, ssize_t size)
+{
+    l2cap_trans_ctx_t* ctx = &g_trans_ctx;
+    if (ctx->state != TRANS_IDLE && handle != ctx->handle) {
+        PRINT("l2cap is testing ,ignore it");
+        return;
+    }
+
+    switch (ctx->state) {
+    case TRANS_IDLE:
+        if (strncmp((const char*)buf, TRANS_START, strlen(TRANS_START)) == 0) {
+            l2cap_trans_reset();
+            ctx->handle = handle;
+            ctx->state = TRANS_RECVING;
+            sscanf((const char*)buf, "START:%" PRIu32 ";", &ctx->trans_total_size);
+            PRINT("receive start, waiting for %" PRIu32 " bytes transmit done", ctx->trans_total_size);
+            euv_pipe_write(handle, (uint8_t*)TRANS_START_ACK, strlen(TRANS_START_ACK), NULL);
+            ctx->start_timestamp = get_timestamp_msec();
+        } else
+            lib_dumpbuffer("read data:", buf, size); // no need to free
+        break;
+    case TRANS_SENDING:
+        if (strncmp((const char*)buf, TRANS_EOF, strlen(TRANS_EOF)) == 0) {
+            ctx->end_timestamp = get_timestamp_msec();
+            show_result(ctx->start_timestamp, ctx->end_timestamp, ctx->trans_total_size);
+            l2cap_trans_reset();
+        } else if (strncmp((const char*)buf, TRANS_START_ACK, strlen(TRANS_START_ACK)) == 0) {
+            sem_post(&speed_tx_sem);
+            if (!bulk_buf_gen(&ctx->bulk_buf, ctx->bulk_length)) {
+                l2cap_trans_reset();
+                PRINT("generate bulk buffer failed");
+                // TBD: send error to peer to end test
+                return;
+            }
+
+            ctx->start_timestamp = get_timestamp_msec();
+            euv_pipe_write(handle, ctx->bulk_buf, ctx->bulk_length, bulk_trans_complete);
+        }
+        break;
+    case TRANS_RECVING:
+        ctx->received_size += size;
+        if (ctx->received_size >= ctx->trans_total_size) {
+            ctx->end_timestamp = get_timestamp_msec();
+            show_result(ctx->start_timestamp, ctx->end_timestamp, ctx->trans_total_size);
+            euv_pipe_write(handle, (uint8_t*)TRANS_EOF, strlen(TRANS_EOF), NULL);
+            l2cap_trans_reset();
+        }
+        break;
+    default:
+        break;
+    }
+}
+
 static void read_complete_cb(euv_pipe_t* pipe, const uint8_t* buf, ssize_t nread)
 {
-    l2cap_chnl_t* channel;
+    if (nread > 0) {
+        handle_l2cap_data_recv(pipe, buf, nread);
 
-    // need lock
-    if (nread < 0) {
-        PRINT("read failed:%s\n", uv_strerror(nread));
-        euv_pipe_read_stop(pipe);
-        channel = find_channel_by_pipe(pipe);
-        if (channel == NULL) {
-            PRINT("channel not found\n");
-            return;
-        }
-
-        euv_pipe_disconnect(channel->pipe);
-        channel->pipe = NULL;
-        list_delete(&channel->node);
-        free(channel);
-    } else if (nread == 0) {
-        if (buf)
-            free((void*)buf);
-    } else {
-        lib_dumpbuffer("read data:", buf, nread);
+    } else if (nread < 0) {
+        PRINT("read failed:%s, wait for connection disconnect", uv_strerror(nread));
     }
 }
 
 static void data_path_connected_cb(euv_pipe_t* pipe, int status, void* data)
 {
     l2cap_chnl_t* channel = (l2cap_chnl_t*)data;
-    // need lock
-    PRINT("l2cap channel(id:%" PRIu16 ") data path establish status:%d\n", channel->id, status); // euv thread
 
-    // do nothing
+    PRINT("l2cap channel(id:%" PRIu16 ") data path establish status:%d", channel->id, status);
 }
 
 static void add_l2cap_channel(void* data)
@@ -198,23 +295,21 @@ free_msg:
 
 static void l2cap_channel_disconnected_process(void* data)
 {
-    l2cap_msg_t* msg;
+    l2cap_msg_t* msg = (l2cap_msg_t*)data;
     l2cap_chnl_t* channel;
 
-    if (!data) {
-        PRINT("invalid arg\n");
-        return;
-    }
-
-    msg = (l2cap_msg_t*)data;
     channel = find_channel_by_id(msg->id);
     if (channel == NULL) {
-        PRINT("channel not found\n");
+        PRINT("%s, channel not found", __func__);
         free(msg);
         return;
     }
 
-    PRINT("free channel(id:%" PRIu16 ")\n", msg->id);
+    if (g_trans_ctx.handle == channel->pipe) {
+        l2cap_trans_reset();
+    }
+
+    PRINT("free channel(id:%" PRIu16 ")", msg->id);
     if (channel->pipe) {
         euv_pipe_disconnect(channel->pipe);
         channel->pipe = NULL;
@@ -276,6 +371,43 @@ static void do_l2cap_stop_listen(void* data)
     }
 
     free(msg);
+}
+
+static void do_l2cap_speed_test(void* data)
+{
+    l2cap_msg_t* msg = (l2cap_msg_t*)data;
+    l2cap_chnl_t* channel;
+    l2cap_trans_ctx_t* trans_ctx = &g_trans_ctx;
+    uint16_t times;
+    uint16_t id;
+    static uint8_t start[100];
+
+    id = msg->id;
+    times = msg->len;
+    free(msg);
+
+    channel = find_channel_by_id(id);
+    if (channel == NULL || channel->pipe == NULL) {
+        PRINT("channel not found or pipe disconnected");
+        return;
+    }
+
+    if (trans_ctx->state != TRANS_IDLE) {
+        PRINT("l2cap is testing");
+        return;
+    }
+
+    trans_ctx->handle = channel->pipe;
+    trans_ctx->state = TRANS_SENDING;
+    trans_ctx->bulk_length = L2CAP_TRANS_MTU_CFG;
+    trans_ctx->bulk_count = times;
+    trans_ctx->trans_total_size = L2CAP_TRANS_MTU_CFG * times;
+
+    PRINT("L2cap channel(id:%" PRIu16 ") speed test", id);
+    memset(start, 0, sizeof(start));
+    sprintf((char*)start, "START:%" PRIu32 ";", trans_ctx->trans_total_size);
+    euv_pipe_write(channel->pipe, start, strlen((const char*)start), NULL);
+    PRINT("transmit start, waiting for %" PRIu32 " bytes transmit done", trans_ctx->trans_total_size);
 }
 
 static void on_connected(void* handle, l2cap_connect_params_t* params)
@@ -522,12 +654,53 @@ static int stop_listen_cmd(void* handle, int argc, char* argv[])
     return CMD_OK;
 }
 
+static int speed_test_cmd(void* handle, int argc, char* argv[])
+{
+    l2cap_msg_t* msg;
+    struct timespec ts;
+
+    if (!handle || !g_l2cap_handle) {
+        PRINT("L2CAP tool not ready!");
+        return CMD_ERROR;
+    }
+
+    if (argc < 2)
+        return CMD_PARAM_NOT_ENOUGH;
+
+    msg = (l2cap_msg_t*)malloc(sizeof(l2cap_msg_t));
+    if (!msg) {
+        PRINT("allocate msg failed");
+        return CMD_ERROR;
+    }
+
+    msg->id = strtoul(argv[0], NULL, 10);
+    msg->len = strtoul(argv[1], NULL, 10);
+    if (msg->id < 0 || msg->len <= 0) {
+        PRINT("invalid param");
+        free(msg);
+        return CMD_ERROR;
+    }
+
+    do_in_thread_loop(&g_l2cap_thread, do_l2cap_speed_test, msg);
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += 2;
+    if (sem_timedwait(&speed_tx_sem, &ts) < 0) {
+        PRINT("wait speed test ack failed");
+        l2cap_trans_reset();
+        return CMD_ERROR;
+    }
+
+    return CMD_OK;
+}
+
 static bt_command_t g_l2cap_commands[] = {
     { "connect", connect_cmd, 0, "\"connect l2cap channel      param: <address> <psm>\"" },
     { "listen", listen_cmd, 0, "\"listen l2cap channel        param: <psm>\"" },
     { "disconnect", disconnect_cmd, 0, "\"disconnect l2cap channel  param: <id>\"" },
     { "stoplisten", stop_listen_cmd, 0, "\"stop listen l2cap channel  param: <psm>\"" },
     { "write", write_cmd, 0, "\"write data to peer   param: <id> <data>\"" },
+    { "speed", speed_test_cmd, 0, "\"speed test l2cap channel    param: <id> <iteration>\"" },
 };
 
 static void usage(void)
@@ -559,6 +732,7 @@ int l2cap_command_exec(void* handle, int argc, char* argv[])
 
 int l2cap_command_init(void* handle)
 {
+    sem_init(&speed_tx_sem, 0, 0);
     thread_loop_init(&g_l2cap_thread);
     thread_loop_run(&g_l2cap_thread, true, "bttool-l2cap");
     g_l2cap_handle = bt_l2cap_register_callbacks(handle, &l2cap_callback);
@@ -570,5 +744,6 @@ void l2cap_command_uninit(void* handle)
 {
     bt_l2cap_unregister_callbacks(handle, g_l2cap_handle);
     thread_loop_exit(&g_l2cap_thread);
+    sem_destroy(&speed_tx_sem);
     memset(&g_l2cap_thread, 0, sizeof(g_l2cap_thread));
 }


### PR DESCRIPTION
Fixed bug in the L2CAP service and enhanced bttool's testing capabilities for L2CAP.

1. Implemented transmission flow control to prevent protocol stack overflow.
2. Add an input parameter for the `bt_l2cap_stop_listen` on a transport type to resolve the distinction between BR/EDR and LE modes.
3. Add resource cleanup for application deactivation to eliminate memory leaks caused by app unregistering.
4. Integrated `stoplisten` command into bttool to simulate stop-listen operation testing.
5. Incorporated throughput testing module into bttool, introducing `speed` command for verifying transmission throughput.
6. Optimize parameter input for bttool's `l2cap` command.
