### PR TITLE
bluetooth: Resolve reconnection abnormalities after removing the bond.

### DIFF
--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -344,9 +344,9 @@ static void remove_from_connection_manager_list(bt_list_t* list, bt_address_t* a
 
         if (try_acl_disconnect) {
             bt_try_disconnect_acl(manager);
+        } else {
+            bt_list_remove(list, manager);
         }
-
-        bt_list_remove(list, manager);
     }
 }
 


### PR DESCRIPTION
bug: v/79367

During removebond, when all profiles have been disconnected, the manager is removed from the connection manager list in remove_from_connection_manager_list. However, bt_sal_remove_bond_internal is not called in bt_sal_cm_acl_disconnected, leading to the link key not being deleted. As a result, when the phone initiates a connection next time, the pairing dialog does not pop up, and the connection succeeds directly.


