### PR TITLE
gatt: fixed abnormal address release issues caused by service removal.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -536,6 +536,7 @@ ifneq ($(CONFIG_BLUETOOTH_STACK_BREDR_ZBLUE)$(CONFIG_BLUETOOTH_STACK_LE_ZBLUE),)
 	CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/service/stacks/zephyr/include
 	CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/external/zblue/zblue/port/include/
 	CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/external/zblue/zblue/subsys/bluetooth/host
+	CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/external/zblue/zblue/subsys/settings/include/settings
 	CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/external/zblue/zblue/port/include/kernel/include
 endif
 	CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/service/ipc

--- a/service/common/bluetooth_define.h
+++ b/service/common/bluetooth_define.h
@@ -36,7 +36,7 @@
 
 #define BT_KVDB_VERSION_KEY "persist.bluetooth.version"
 #define BT_STORAGE_VERSION_STR_LEN 12 /* vxxx_xxx_xxx. e.g. v5_0_0 */
-#define BT_STORAGE_CURRENT_VERSION "v5_0_2"
+#define BT_STORAGE_CURRENT_VERSION "v5_0_3"
 
 typedef enum {
     BT_LINKKEY_TYPE_COMBINATION_KEY,
@@ -80,7 +80,7 @@ typedef struct {
     uint8_t link_key[16];
     uint32_t class_of_device;
     uint8_t uuids[CONFIG_BLUETOOTH_MAX_SAVED_REMOTE_UUIDS_LEN];
-} __attribute__((aligned(4))) remote_device_properties_v5_0_2_t;
+} __attribute__((aligned(4))) remote_device_properties_v5_0_3_t;
 
 typedef struct {
     bt_address_t addr;
@@ -89,7 +89,7 @@ typedef struct {
     uint8_t device_type;
     uint8_t smp_key[80];
     uint8_t local_csrk[16];
-} __attribute__((aligned(4))) remote_device_le_properties_v5_0_2_t;
+} __attribute__((aligned(4))) remote_device_le_properties_v5_0_3_t;
 
 typedef struct {
     char name[BT_LOC_NAME_MAX_LEN + 1];
@@ -98,10 +98,11 @@ typedef struct {
     uint32_t io_capability;
     uint32_t scan_mode;
     uint32_t bondable;
-} __attribute__((aligned(4))) adapter_storage_v5_0_2_t;
+    uint8_t irk[16];
+} __attribute__((aligned(4))) adapter_storage_v5_0_3_t;
 
-typedef remote_device_properties_v5_0_2_t remote_device_properties_t;
-typedef remote_device_le_properties_v5_0_2_t remote_device_le_properties_t;
-typedef adapter_storage_v5_0_2_t adapter_storage_t;
+typedef remote_device_properties_v5_0_3_t remote_device_properties_t;
+typedef remote_device_le_properties_v5_0_3_t remote_device_le_properties_t;
+typedef adapter_storage_v5_0_3_t adapter_storage_t;
 
 #endif /* __BLUETOOTH_DEFINE_H_ */

--- a/service/common/bluetooth_define.h
+++ b/service/common/bluetooth_define.h
@@ -88,6 +88,7 @@ typedef struct {
     // only can add member after "addr_type" if needed, see function bt_storage_save_le_remote_device for reasons.
     uint8_t device_type;
     uint8_t smp_key[80];
+    uint8_t local_csrk[16];
 } __attribute__((aligned(4))) remote_device_le_properties_v5_0_2_t;
 
 typedef struct {

--- a/service/common/storage.h
+++ b/service/common/storage.h
@@ -51,6 +51,7 @@ int bt_storage_load_le_bonded_device(load_storage_callback_t cb);
 #define BT_KVDB_ADAPTERINFO_IOCAP "persist.bluetooth.adapterInfo.io_capability"
 #define BT_KVDB_ADAPTERINFO_SCAN "persist.bluetooth.adapterInfo.scan_mode"
 #define BT_KVDB_ADAPTERINFO_BOND "persist.bluetooth.adapterInfo.bondable"
+#define BT_KVDB_ADAPTERINFO_IRK "persist.bluetooth.adapterInfo.irk"
 
 #define BT_KVDB_ADAPTERINFO "persist.bluetooth.adapterInfo."
 #define BT_KVDB_BTBOND "persist.bluetooth.btbonded."

--- a/service/common/storage_property.c
+++ b/service/common/storage_property.c
@@ -43,6 +43,7 @@ static void storage_save_adapter_info(service_work_t* work, void* userdata)
     adapter_storage_t* adapter = (adapter_storage_t*)userdata;
     property_set_binary(BT_KVDB_VERSION_KEY, BT_STORAGE_CURRENT_VERSION, strlen(BT_STORAGE_CURRENT_VERSION) + 1, false);
     property_set_binary(BT_KVDB_ADAPTERINFO_NAME, adapter->name, strlen(adapter->name) + 1, false);
+    property_set_binary(BT_KVDB_ADAPTERINFO_IRK, adapter->irk, sizeof(adapter->irk), false);
     property_set_int32(BT_KVDB_ADAPTERINFO_COD, adapter->class_of_device);
     property_set_int32(BT_KVDB_ADAPTERINFO_IOCAP, adapter->io_capability);
     property_set_int32(BT_KVDB_ADAPTERINFO_SCAN, adapter->scan_mode);
@@ -126,6 +127,7 @@ static void storage_get_key(const char* key, void* data, uint16_t value_len, voi
         adapter->io_capability = property_get_int32(BT_KVDB_ADAPTERINFO_IOCAP, ERROR_ADAPTERINFO_VALUE);
         adapter->scan_mode = property_get_int32(BT_KVDB_ADAPTERINFO_SCAN, ERROR_ADAPTERINFO_VALUE);
         adapter->bondable = property_get_int32(BT_KVDB_ADAPTERINFO_BOND, ERROR_ADAPTERINFO_VALUE);
+        property_get_binary(BT_KVDB_ADAPTERINFO_IRK, adapter->irk, sizeof(adapter->irk));
         return;
     }
 

--- a/service/src/adapter_internel.h
+++ b/service/src/adapter_internel.h
@@ -229,9 +229,11 @@ void adapter_on_br_enabled(void);
 void adapter_on_br_disabled(void);
 
 /* adapter sal callback invoke functions */
+void adapter_on_adapter_info_load(void);
 void adapter_on_adapter_state_changed(uint8_t stack_state);
 void adapter_on_device_found(bt_discovery_result_t* result);
 void adapter_on_scan_mode_changed(bt_scan_mode_t mode);
+void adapter_on_irk_changed(const char* irk, uint8_t size);
 void adapter_on_discovery_state_changed(bt_discovery_state_t state);
 void adapter_on_remote_name_recieved(bt_address_t* addr, const char* name);
 void adapter_on_connect_request(bt_address_t* addr, uint32_t cod);
@@ -260,6 +262,7 @@ void adapter_on_le_local_oob_data_got(bt_address_t* addr, bt_128key_t c_val, bt_
 /* adapter sal invoke functions */
 uint8_t* adapter_get_smp_data(bt_address_t* addr);
 uint8_t* adapter_get_local_csrk(bt_address_t* addr);
+uint8_t* adapter_get_local_irk(void);
 bt_address_t* adapter_get_le_remote_address(bt_address_t* addr, ble_addr_type_t addr_type);
 ble_addr_type_t adapter_get_le_remote_address_type(bt_address_t* addr);
 uint8_t* adapter_get_link_key(bt_address_t* addr);

--- a/service/src/adapter_internel.h
+++ b/service/src/adapter_internel.h
@@ -258,8 +258,12 @@ void adapter_on_le_bonded_device_update(remote_device_le_properties_t* props, ui
 void adapter_on_le_local_oob_data_got(bt_address_t* addr, bt_128key_t c_val, bt_128key_t r_val);
 
 /* adapter sal invoke functions */
+uint8_t* adapter_get_smp_data(bt_address_t* addr);
+uint8_t* adapter_get_local_csrk(bt_address_t* addr);
 bt_address_t* adapter_get_le_remote_address(bt_address_t* addr, ble_addr_type_t addr_type);
 ble_addr_type_t adapter_get_le_remote_address_type(bt_address_t* addr);
+uint8_t* adapter_get_link_key(bt_address_t* addr);
+bt_link_key_type_t adapter_get_link_key_type(bt_address_t* addr);
 
 /* adapter framework invoke functions */
 void adapter_init(void);

--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -269,6 +269,13 @@ uint8_t* adapter_get_local_csrk(bt_address_t* addr)
     return NULL;
 }
 
+uint8_t* adapter_get_local_irk(void)
+{
+    adapter_service_t* adapter = &g_adapter_service;
+
+    return adapter->properties.irk;
+}
+
 ble_addr_type_t adapter_get_le_remote_address_type(bt_address_t* addr)
 {
     bt_device_t* device;
@@ -373,6 +380,7 @@ static void adapter_properties_copy(adapter_properties_t* prop, adapter_storage_
     prop->io_capability = storage->io_capability;
     prop->scan_mode = storage->scan_mode;
     prop->bondable = storage->bondable;
+    memcpy(prop->irk, storage->irk, sizeof(prop->irk));
 }
 
 static int get_devices_cnt(int flag, uint8_t transport)
@@ -661,6 +669,7 @@ static void adapter_save_properties(void)
     storage.io_capability = prop->io_capability;
     storage.scan_mode = prop->scan_mode;
     storage.bondable = prop->bondable;
+    memcpy(storage.irk, prop->irk, sizeof(storage.irk));
     bt_storage_save_adapter_info(&storage);
 }
 
@@ -1342,6 +1351,15 @@ void adapter_notify_state_change(bt_adapter_state_t prev, bt_adapter_state_t cur
     CALLBACK_FOREACH(CBLIST, adapter_callbacks_t, on_adapter_state_changed, current);
 }
 
+void adapter_on_adapter_info_load(void)
+{
+    adapter_service_t* adapter = &g_adapter_service;
+    adapter_storage_t storage = { 0 };
+
+    bt_storage_load_adapter_info(&storage);
+    adapter_properties_copy(&adapter->properties, &storage);
+}
+
 void adapter_on_adapter_state_changed(uint8_t stack_state)
 {
     uint16_t event;
@@ -1349,12 +1367,11 @@ void adapter_on_adapter_state_changed(uint8_t stack_state)
 
     switch (stack_state) {
     case BT_BREDR_STACK_STATE_ON: {
-        adapter_storage_t storage;
         int ret;
 
-        bt_storage_load_adapter_info(&storage);
-        adapter_properties_copy(&adapter->properties, &storage);
-
+#if !defined(CONFIG_BLUETOOTH_STACK_LE_ZBLUE)
+        adapter_on_adapter_info_load();
+#endif
         /* load bonded devices to stack (name/address/cod/alias/linkkey) */
         ret = bt_storage_load_bonded_device(bonded_device_loaded);
         if (ret < 0) {
@@ -1512,6 +1529,18 @@ static void handle_scan_mode_changed(void* data)
     CALLBACK_FOREACH(CBLIST, adapter_callbacks_t, on_scan_mode_changed, scan_mode);
 }
 
+static void handle_irk_changed(void* data)
+{
+    adapter_service_t* adapter = &g_adapter_service;
+    uint8_t* irk = (uint8_t*)data;
+
+    adapter_lock();
+    memcpy(adapter->properties.irk, irk, sizeof(adapter->properties.irk));
+    adapter_save_properties();
+    adapter_unlock();
+    free(data);
+}
+
 static void process_link_role_changed_evt(bt_address_t* addr, bt_link_role_t role)
 {
     bt_device_t* device;
@@ -1582,6 +1611,14 @@ void adapter_on_scan_mode_changed(bt_scan_mode_t mode)
 
     *scan_mode = mode;
     do_in_service_loop(handle_scan_mode_changed, scan_mode);
+}
+
+void adapter_on_irk_changed(const char* irk, uint8_t size)
+{
+    uint8_t* local_irk = malloc(size);
+
+    memcpy(local_irk, irk, size);
+    do_in_service_loop(handle_irk_changed, local_irk);
 }
 
 void adapter_on_discovery_state_changed(bt_discovery_state_t state)

--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -75,6 +75,7 @@ typedef struct adapter_properties {
     uint32_t io_capability;
     uint8_t scan_mode;
     bool bondable;
+    uint8_t irk[16];
     bt_uuid_t uuids[10];
 } adapter_properties_t;
 
@@ -248,6 +249,26 @@ bt_address_t* adapter_get_le_remote_address(bt_address_t* addr, ble_addr_type_t 
     return NULL;
 }
 
+uint8_t* adapter_get_smp_data(bt_address_t* addr)
+{
+    bt_device_t* device;
+
+    if ((device = adapter_find_device(addr, BT_TRANSPORT_BLE)))
+        return device_get_smp_key(device);
+
+    return NULL;
+}
+
+uint8_t* adapter_get_local_csrk(bt_address_t* addr)
+{
+    bt_device_t* device;
+
+    if ((device = adapter_find_device(addr, BT_TRANSPORT_BLE)))
+        return device_get_local_csrk(device);
+
+    return NULL;
+}
+
 ble_addr_type_t adapter_get_le_remote_address_type(bt_address_t* addr)
 {
     bt_device_t* device;
@@ -259,6 +280,32 @@ ble_addr_type_t adapter_get_le_remote_address_type(bt_address_t* addr)
     }
 
     return device_get_address_type(device);
+}
+
+uint8_t* adapter_get_link_key(bt_address_t* addr)
+{
+    bt_device_t* device;
+
+    device = adapter_find_device(addr, BT_TRANSPORT_BREDR);
+    if (!device) {
+        BT_LOGE("device not found");
+        return NULL;
+    }
+
+    return device_get_link_key(device);
+}
+
+bt_link_key_type_t adapter_get_link_key_type(bt_address_t* addr)
+{
+    bt_device_t* device;
+
+    device = adapter_find_device(addr, BT_TRANSPORT_BREDR);
+    if (!device) {
+        BT_LOGE("device not found");
+        return 0;
+    }
+
+    return device_get_link_key_type(device);
 }
 
 static bt_device_t* adapter_find_create_le_device(bt_address_t* addr, ble_addr_type_t addr_type)
@@ -506,6 +553,7 @@ static void le_bonded_device_loaded(void* data, uint16_t length, uint16_t items)
             device_set_bond_state(device, BOND_STATE_BONDED, false, NULL);
             device_set_smp_key(device, remote->smp_key);
             device_set_identity_address(device, (bt_address_t*)remote->smp_key);
+            device_set_local_csrk(device, remote->local_csrk);
             bt_addr_ba2str(&remote->addr, addr_str);
             uint8_t* ltk = &remote->smp_key[12];
             BT_LOGD("LE BOND DEVICE[%d], Addr:[%s] Atype:[%d] LTK: [%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X]",
@@ -549,6 +597,32 @@ static void adapter_update_bonded_device(void)
 }
 
 #ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
+static void adapter_update_le_bonded_device(void)
+{
+    bt_list_t* list = g_adapter_service.le_devices;
+    bt_list_node_t* node;
+
+    int size = get_devices_cnt(DFLAG_BONDED, BT_TRANSPORT_BLE);
+    if (!size) {
+        bt_storage_save_le_bonded_device(NULL, 0);
+        return;
+    }
+
+    remote_device_le_properties_t remotes[size];
+    memset(remotes, 0x00, sizeof(remote_device_le_properties_t) * size);
+
+    size = 0;
+    for (node = bt_list_head(list); node != NULL; node = bt_list_next(list, node)) {
+        bt_device_t* device = bt_list_node(node);
+        if (device_is_bonded(device)) {
+            device_get_le_property(device, &remotes[size]);
+            size++;
+        }
+    }
+
+    bt_storage_save_le_bonded_device(remotes, size);
+}
+
 static void adapter_update_whitelist(void)
 {
     BT_LOGD("%s", __func__);
@@ -1162,6 +1236,7 @@ static void process_le_bonded_device_update_evt(remote_device_le_properties_t* p
         /* store smp key to mapped device struct */
         device_set_smp_key(device, prop->smp_key);
         device_set_identity_address(device, (bt_address_t*)prop->smp_key);
+        device_set_local_csrk(device, prop->local_csrk);
 
         bt_addr_ba2str(&prop->addr, addr_str);
         uint8_t* ltk = &prop->smp_key[12];
@@ -1173,7 +1248,7 @@ static void process_le_bonded_device_update_evt(remote_device_le_properties_t* p
     }
 
     /* update all bonded le device to storage */
-    bt_storage_save_le_bonded_device(props, bonded_devices_cnt);
+    adapter_update_le_bonded_device();
     free(props);
     adapter_unlock();
 }

--- a/service/src/device.c
+++ b/service/src/device.c
@@ -64,6 +64,7 @@ typedef struct remote_device {
     bt_address_t identity_addr;
     uint16_t appearance;
     uint8_t smp_data[80];
+    uint8_t local_csrk[16];
     ble_phy_type_t tx_phy;
     ble_phy_type_t rx_phy;
     // uint8_t scan_repetition_mode;
@@ -142,6 +143,16 @@ void device_set_identity_address(bt_device_t* device, bt_address_t* addr)
     } else {
         bt_addr_set_empty(&device->remote.identity_addr);
     }
+}
+
+uint8_t* device_get_local_csrk(bt_device_t* device)
+{
+    return device->remote.local_csrk;
+}
+
+void device_set_local_csrk(bt_device_t* device, uint8_t* local_csrk)
+{
+    memcpy(device->remote.local_csrk, local_csrk, 16);
 }
 
 ble_addr_type_t device_get_address_type(bt_device_t* device)
@@ -557,6 +568,7 @@ void device_get_le_property(bt_device_t* device, remote_device_le_properties_t* 
     prop->addr_type = device->remote.addr_type;
     memcpy(prop->smp_key, device->remote.smp_data, 80);
     prop->device_type = device->remote.device_type;
+    memcpy(prop->local_csrk, device->remote.local_csrk, 16);
 }
 
 void device_set_flags(bt_device_t* device, uint32_t flags)

--- a/service/src/device.h
+++ b/service/src/device.h
@@ -37,6 +37,8 @@ bt_transport_t device_get_transport(bt_device_t* device);
 bt_address_t* device_get_address(bt_device_t* device);
 bt_address_t* device_get_identity_address(bt_device_t* device);
 void device_set_identity_address(bt_device_t* device, bt_address_t* addr);
+uint8_t* device_get_local_csrk(bt_device_t* device);
+void device_set_local_csrk(bt_device_t* device, uint8_t* local_csrk);
 ble_addr_type_t device_get_address_type(bt_device_t* device);
 void device_set_address_type(bt_device_t* device, ble_addr_type_t type);
 void device_set_device_type(bt_device_t* device, bt_device_type_t type);

--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -41,6 +41,11 @@
 #include "sal_connection_manager.h"
 #include "sal_interface.h"
 
+#include <settings_zblue.h>
+#include <zephyr/settings/settings.h>
+
+#include "keys.h"
+
 #include "utils/log.h"
 
 #define BT_INVALID_CONNECTION_HANDLE 0xFFFF
@@ -132,11 +137,14 @@ static void zblue_on_cancel(struct bt_conn* conn);
 static void zblue_on_pairing_confirm(struct bt_conn* conn);
 static void zblue_on_pincode_entry(struct bt_conn* conn, bool highsec);
 static void zblue_on_br_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_key);
-static void zblue_on_link_key_notify(struct bt_conn* conn, uint8_t* key, uint8_t key_type);
 static void zblue_on_br_pairing_failed(struct bt_conn* conn, enum bt_security_err reason);
 static void zblue_on_br_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
 static void zblue_register_callback(void);
 static void zblue_unregister_callback(void);
+#if defined(CONFIG_SETTINGS_ZBLUE)
+static int zblue_on_link_key_notify(uint8_t dev_id, bt_addr_le_t* addr, const char* key_value, uint8_t value_len);
+static int zblue_on_link_key_load(bt_addr_le_t* addr, uint8_t* key_value, uint8_t value_len);
+#endif
 
 static bt_security_t g_security_level = BT_SECURITY_L2;
 
@@ -156,9 +164,15 @@ static struct bt_conn_cb g_conn_cbs = {
     .role_changed = zblue_on_role_changed,
 };
 
+#if defined(CONFIG_SETTINGS_ZBLUE)
+static struct bt_settings_zblue_cb g_settting_cbs = {
+    .linkkey_notify = zblue_on_link_key_notify,
+    .linkkey_load = zblue_on_link_key_load,
+};
+#endif
+
 static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
     .pairing_complete_ctkd = zblue_on_br_pairing_complete_ctkd,
-    .link_key_notify = zblue_on_link_key_notify,
     .pairing_failed = zblue_on_br_pairing_failed,
     .bond_deleted = zblue_on_br_bond_deleted,
 };
@@ -406,18 +420,77 @@ static void zblue_on_br_pairing_complete_ctkd(struct bt_conn* conn, bool is_link
     adapter_on_bond_state_changed(&addr, BOND_STATE_BONDED, BT_TRANSPORT_BREDR, BT_STATUS_SUCCESS, true);
 }
 
-static void zblue_on_link_key_notify(struct bt_conn* conn, uint8_t* key, uint8_t key_type)
+#ifdef CONFIG_SETTINGS_ZBLUE
+static int zblue_on_link_key_notify(uint8_t dev_id, bt_addr_le_t* addr, const char* key_value, uint8_t value_len)
 {
-    bt_address_t addr;
+    bt_address_t br_addr;
+    bt_128key_t key;
+    bt_link_key_type_t key_type = 0;
+    struct bt_keys_link_key* link_key;
 
-    if (!bt_conn_get_dst_br(conn)) {
-        return;
+    link_key = (struct bt_keys_link_key*)zalloc(sizeof(struct bt_keys_link_key));
+    if (!link_key) {
+        BT_LOGE("%s link_key malloc fail", __func__);
+        return -ENOSPC;
     }
 
-    zblue_conn_get_addr(conn, &addr);
-    adapter_on_link_key_update(&addr, key, key_type);
-    adapter_on_bond_state_changed(&addr, BOND_STATE_BONDED, BT_TRANSPORT_BREDR, BT_STATUS_SUCCESS, false);
+    memcpy(link_key->storage_start, key_value, value_len);
+    memcpy(br_addr.addr, addr->a.val, sizeof(br_addr.addr));
+    memcpy(key, link_key->val, 16);
+    key_type = link_key->key_type;
+    free(link_key);
+
+    adapter_on_bond_state_changed(&br_addr, BOND_STATE_BONDED, BT_TRANSPORT_BREDR, BT_STATUS_SUCCESS, false);
+    adapter_on_link_key_update(&br_addr, key, key_type);
+    return 0;
 }
+
+static int zblue_on_link_key_load(bt_addr_le_t* addr, uint8_t* key_value, uint8_t value_len)
+{
+    struct bt_keys_link_key* link_key;
+    bt_address_t br_addr;
+    uint8_t* key;
+
+    memcpy(br_addr.addr, addr->a.val, sizeof(br_addr.addr));
+
+    if (!key_value) {
+        BT_LOGD("%s delete key_value", __func__);
+        adapter_on_link_key_removed(&br_addr, BT_STATUS_SUCCESS);
+        return 0;
+    }
+
+    link_key = (struct bt_keys_link_key*)zalloc(sizeof(struct bt_keys_link_key));
+    if (!link_key) {
+        BT_LOGE("%s link_key malloc fail", __func__);
+        return -ENOSPC;
+    }
+
+    key = adapter_get_link_key(&br_addr);
+    if (!key) {
+        BT_LOGE("%s link_key malloc fail", __func__);
+        free(link_key);
+        return -EINVAL;
+    }
+
+    memcpy(link_key->val, key, 16);
+
+    link_key->key_type = adapter_get_link_key_type(&br_addr);
+    switch (link_key->key_type) {
+    case BT_LK_COMBINATION:
+    case BT_LK_AUTH_COMBINATION_P192:
+        link_key->flags |= BT_LINK_KEY_AUTHENTICATED;
+        break;
+    case BT_LK_AUTH_COMBINATION_P256:
+        link_key->flags |= BT_LINK_KEY_AUTHENTICATED | BT_LINK_KEY_SC;
+        break;
+    default:
+        break;
+    }
+
+    memcpy(key_value, link_key->storage_start, value_len);
+    return value_len;
+}
+#endif
 
 static void zblue_on_br_pairing_failed(struct bt_conn* conn, enum bt_security_err reason)
 {
@@ -547,6 +620,9 @@ static void zblue_register_callback(void)
     bt_conn_cb_register(&g_conn_cbs);
     bt_conn_auth_cb_register(&g_conn_auth_cbs);
     bt_conn_auth_info_cb_register(&g_conn_auth_info_cbs);
+#ifdef CONFIG_SETTINGS_ZBLUE
+    bt_setting_cb_register(&g_settting_cbs);
+#endif
 }
 
 static void zblue_unregister_callback(void)
@@ -1503,18 +1579,38 @@ bt_status_t bt_sal_get_remote_device_info(bt_controller_id_t id, bt_address_t* a
     return BT_STATUS_SUCCESS;
 }
 
+static void STACK_CALL(set_bond)(void* args)
+{
+    sal_adapter_req_t* req = args;
+    bt_addr_le_t le_addr;
+
+    memcpy(le_addr.a.val, req->addr.addr, sizeof(le_addr.a.val));
+    le_addr.type = BT_LE_ADDR_TYPE_PUBLIC;
+
+    bt_settings_load(req->id, 0, "link_key", &le_addr);
+}
+
 bt_status_t bt_sal_set_bonded_devices(bt_controller_id_t id, remote_device_properties_t* props, int cnt)
 {
+
 #ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
-    UNUSED(id);
-    struct bt_bond_info_br bondinfo;
+    sal_adapter_req_t* req;
+    bt_status_t status;
 
     for (int i = 0; i < cnt; i++) {
-        memcpy(&bondinfo.addr, &props->addr, 6);
-        memcpy(&bondinfo.key, &props->link_key, 16);
-        bondinfo.key_type = props->link_key_type;
-        if (bt_set_bond_info_br(&bondinfo))
-            break;
+        req = sal_adapter_req(id, &props->addr, STACK_CALL(set_bond));
+        if (!req) {
+            BT_LOGE("%s, req null", __func__);
+            return BT_STATUS_NOMEM;
+        }
+
+        status = sal_send_req(req);
+        if (status) {
+            BT_LOGE("%s send req error, ret: %d", __func__, status);
+            return status;
+        }
+
+        props++;
     }
 
     return BT_STATUS_SUCCESS;
@@ -1524,15 +1620,20 @@ bt_status_t bt_sal_set_bonded_devices(bt_controller_id_t id, remote_device_prope
 }
 
 #ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
-static void get_bonded_devices(const struct bt_bond_info_br* info,
+static void get_bonded_devices(const struct bt_bond_info* info,
     void* user_data)
 {
     struct device_context* ctx = user_data;
+    uint8_t* link_key;
 
     if (ctx->got < ctx->cnt) {
         memcpy(&ctx->props->addr, &info->addr, 6);
-        memcpy(&ctx->props->link_key, &info->key, 16);
-        ctx->props->link_key_type = info->key_type;
+        link_key = adapter_get_link_key(&ctx->props->addr);
+        if (link_key) {
+            memcpy(ctx->props->link_key, link_key, 16);
+            ctx->props->link_key_type = adapter_get_link_key_type(&ctx->props->addr);
+        }
+
         ctx->props++;
         ctx->got++;
     }

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -29,6 +29,7 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>
 
+#include <settings_zblue.h>
 #include <zephyr/settings/settings.h>
 
 #include "keys.h"
@@ -47,6 +48,10 @@ typedef union {
         struct bt_conn_le_create_param create;
         struct bt_le_conn_param conn;
     } conn_param;
+    struct {
+        void* key;
+        uint8_t id;
+    } le_set_bond;
     int security_level;
     bool bondable;
 } sal_adapter_args_t;
@@ -81,6 +86,11 @@ static void zblue_on_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_ke
 static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded);
 static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err reason);
 static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
+static void zblue_convert_le_addr(bt_address_t* addr, ble_addr_type_t type, bt_addr_le_t* le_addr);
+#if defined(CONFIG_SETTINGS_ZBLUE)
+static int zblue_on_ltk_notify(uint8_t dev_id, uint8_t id, bt_addr_le_t* addr, const char* key_value, uint8_t value_len);
+static int zblue_on_ltk_load(bt_addr_le_t* addr, uint8_t* key_value, uint8_t value_len);
+#endif
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 static void zblue_on_phy_updated(struct bt_conn* conn, struct bt_conn_le_phy_info* info);
 #endif
@@ -121,6 +131,13 @@ static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
     .bond_deleted = zblue_on_bond_deleted,
 };
 
+#if defined(CONFIG_SETTINGS_ZBLUE)
+static struct bt_settings_zblue_cb g_settting_cbs = {
+    .ltk_notify = zblue_on_ltk_notify,
+    .ltk_load = zblue_on_ltk_load,
+};
+#endif
+
 static struct bt_conn_auth_cb g_conn_auth_cbs;
 static le_conn_info_t g_le_conn_info[CONFIG_BT_MAX_CONN];
 static bt_security_t g_security_level = BT_SECURITY_L2;
@@ -155,6 +172,175 @@ static uint8_t zblue_convert_addr_type(ble_addr_type_t addr_type)
 
     return type;
 }
+
+#if defined(CONFIG_SETTINGS_ZBLUE)
+/**
+ * struct smp_key {
+ *     uint8_t id_addr[6];
+ *     uint8_t id_addr_type;
+ *     uint8_t id_num;
+ *
+ *     uint8_t enc_size;
+ *
+ *     uint8_t flags;
+ *
+ *     uint8_t ltk[16];
+ *     uint8_t ediv[2];
+ *     uint8_t rand[8];
+ *
+ *     uint8_t irk[16];
+ *
+ *     uint8_t csrk[16];
+ *
+ *     uint8_t rpa_addr[6];
+ *     uint8_t rpa_addr_type;
+ *     uint8_t id_num;
+ *
+ *     uint16_t keys;
+ * };
+ */
+static int zblue_on_ltk_notify(uint8_t dev_id, uint8_t id, bt_addr_le_t* addr, const char* key_value, uint8_t value_len)
+{
+    remote_device_le_properties_t* prop;
+    struct bt_keys* keys;
+    bt_address_t le_addr;
+    BT_LOGD("%s, DEMO", __func__);
+
+    if (!key_value) {
+        BT_LOGD("%s, delete key_value", __func__);
+        return 0;
+    }
+
+    prop = zalloc(sizeof(remote_device_le_properties_t));
+    if (!prop) {
+        BT_LOGD("%s, prop malloc failed", __func__);
+        return -ENOSPC;
+    }
+
+    keys = (struct bt_keys*)zalloc(sizeof(struct bt_keys));
+    if (!keys) {
+        BT_LOGD("%s, keys malloc failed", __func__);
+        return -ENOSPC;
+    }
+
+    memcpy(keys->storage_start, key_value, value_len);
+
+    memcpy(le_addr.addr, keys->irk.rpa.val, sizeof(le_addr.addr));
+    if (!bt_addr_is_empty(&le_addr)) {
+        memcpy(prop->addr.addr, keys->irk.rpa.val, sizeof(prop->addr.addr));
+        prop->addr_type = BT_LE_ADDR_TYPE_RANDOM;
+    } else {
+        memcpy(prop->addr.addr, addr->a.val, sizeof(prop->addr.addr));
+        prop->addr_type = BT_LE_ADDR_TYPE_PUBLIC;
+    }
+
+    /**
+     * smp[0 ~ 5]  id_addr
+     * smp[6] id_addr type
+     * smp[7] id_addr cap/id_num
+     */
+    memcpy(&prop->smp_key[0], addr->a.val, 6);
+    prop->smp_key[6] = addr->type;
+    prop->smp_key[7] = id;
+
+    /* SMP[8] LTK_len */
+    prop->smp_key[8] = keys->enc_size;
+
+    /* smp[9] LTK fea/flags */
+    prop->smp_key[9] = keys->flags;
+    /* smp[10 ~ 11] div[2](unused); */
+
+    /**
+     * smp[12 ~ 27] LTK key
+     * smp[28 ~ 29] ediv(legacy)
+     * smp[30 ~ 37] rand(legacy)
+     */
+    if (keys->keys & BT_KEYS_PERIPH_LTK) {
+        memcpy(&prop->smp_key[12], keys->periph_ltk.val, 16);
+        memcpy(&prop->smp_key[28], keys->periph_ltk.ediv, 2);
+        memcpy(&prop->smp_key[30], keys->periph_ltk.rand, 8);
+    } else {
+        memcpy(&prop->smp_key[12], keys->ltk.val, 16);
+        memcpy(&prop->smp_key[28], keys->ltk.ediv, 2);
+        memcpy(&prop->smp_key[30], keys->ltk.rand, 8);
+    }
+
+    /* smp[38 ~ 53] IRK */
+    memcpy(&prop->smp_key[38], keys->irk.val, 16);
+    /* smp[54 ~ 69] CSRK(remote) */
+    memcpy(&prop->smp_key[54], keys->remote_csrk.val, 16);
+
+    // smp[70 ~ 77] addr { addr[6], type[1], cap[1]/id_num[1] };
+    memcpy(&prop->smp_key[70], prop->addr.addr, sizeof(prop->addr.addr));
+    prop->smp_key[76] = prop->addr_type;
+
+    /* smp[78 ~ 79] RFU/keys; */
+    memcpy(&prop->smp_key[78], &keys->keys, 2);
+
+    memcpy(prop->local_csrk, keys->local_csrk.val, 16);
+
+    adapter_on_le_bonded_device_update(prop, 1);
+    free(prop);
+    free(keys);
+
+    return 0;
+}
+
+static int zblue_on_ltk_load(bt_addr_le_t* addr, uint8_t* key_value, uint8_t value_len)
+{
+    BT_LOGD("%s, DEMO", __func__);
+    uint8_t *smp_data, *local_csrk;
+    bt_address_t le_addr, *remote_addr;
+    struct bt_keys* keys;
+
+    keys = (struct bt_keys*)zalloc(sizeof(struct bt_keys));
+    if (!keys) {
+        BT_LOGE("%s, malloc failed", __func__);
+        return -ENOSPC;
+    }
+
+    /* get information */
+    memcpy(&le_addr, addr->a.val, sizeof(le_addr.addr));
+    remote_addr = adapter_get_le_remote_address(&le_addr, addr->type);
+    local_csrk = adapter_get_local_csrk(remote_addr);
+    smp_data = adapter_get_smp_data(remote_addr);
+    if (!smp_data) {
+        BT_LOGE("%s, smp_data is NULL", __func__);
+        return -EINVAL;
+    }
+
+    /* Rearrange data */
+    keys->enc_size = smp_data[8];
+    keys->flags = smp_data[9];
+
+    memcpy(&keys->keys, &smp_data[78], 2);
+
+    if (keys->keys & BT_KEYS_PERIPH_LTK) {
+        memcpy(keys->periph_ltk.val, &smp_data[12], 16);
+        memcpy(keys->periph_ltk.ediv, &smp_data[28], 2);
+        memcpy(keys->periph_ltk.rand, &smp_data[30], 8);
+    } else {
+        memcpy(keys->ltk.val, &smp_data[12], 16);
+        memcpy(keys->ltk.ediv, &smp_data[28], 2);
+        memcpy(keys->ltk.rand, &smp_data[30], 8);
+    }
+
+    memcpy(keys->irk.val, &smp_data[38], 16);
+
+    memcpy(keys->irk.rpa.val, remote_addr->addr, sizeof(remote_addr->addr));
+
+    memcpy(keys->remote_csrk.val, &smp_data[54], 16);
+
+    if (local_csrk)
+        memcpy(keys->local_csrk.val, local_csrk, 16);
+
+    memcpy(key_value, keys->storage_start, value_len);
+
+    free(keys);
+
+    return value_len;
+}
+#endif
 
 static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
 {
@@ -527,6 +713,7 @@ static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer)
     bt_address_t addr;
     bool is_ctkd = false;
     bt_address_t* remote_addr;
+    remote_device_le_properties_t* prop = zalloc(sizeof(remote_device_le_properties_t) * 0);
 
     BT_LOGD("%s", __func__);
 
@@ -538,6 +725,8 @@ static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer)
     }
 
     adapter_on_bond_state_changed(remote_addr, BOND_STATE_NONE, BT_TRANSPORT_BLE, BT_STATUS_SUCCESS, is_ctkd);
+    adapter_on_le_bonded_device_update(prop, 0);
+    free(prop);
 }
 
 static void zblue_register_callback(void)
@@ -546,6 +735,9 @@ static void zblue_register_callback(void)
 #ifdef CONFIG_BT_SMP
     bt_conn_le_auth_cb_register(&g_conn_auth_cbs);
     bt_conn_auth_info_cb_register(&g_conn_auth_info_cbs);
+#endif
+#ifdef CONFIG_SETTINGS_ZBLUE
+    bt_setting_cb_register(&g_settting_cbs);
 #endif
 }
 
@@ -991,10 +1183,41 @@ bt_status_t bt_sal_le_get_address(bt_controller_id_t id, bt_address_t* addr)
     return BT_STATUS_SUCCESS;
 }
 
+static void STACK_CALL(le_set_bond)(void* args)
+{
+    sal_adapter_req_t* req = args;
+    bt_addr_le_t le_addr;
+
+    zblue_convert_le_addr(&req->addr, req->addr_type, &le_addr);
+
+    bt_settings_load(req->id, req->adpt.le_set_bond.id, req->adpt.le_set_bond.key, &le_addr);
+}
+
 bt_status_t bt_sal_le_set_bonded_devices(bt_controller_id_t id, remote_device_le_properties_t* props, uint16_t prop_cnt)
 {
-    /* stack handle this case: */
-    SAL_NOT_SUPPORT;
+    sal_adapter_req_t* req;
+    bt_status_t status;
+
+    for (int i = 0; i < prop_cnt; i++) {
+        req = sal_adapter_req(id, (bt_address_t*)props->smp_key, STACK_CALL(le_set_bond));
+        req->addr_type = props->smp_key[6];
+        req->adpt.le_set_bond.id = props->smp_key[7];
+        req->adpt.le_set_bond.key = "keys";
+        if (!req) {
+            BT_LOGE("%s, req null", __func__);
+            return BT_STATUS_NOMEM;
+        }
+
+        status = sal_send_req(req);
+        if (status) {
+            BT_LOGE("%s send req error, ret: %d", __func__, status);
+            return status;
+        }
+
+        props++;
+    }
+
+    return BT_STATUS_SUCCESS;
 }
 
 static void STACK_CALL(security_connect)(void* args)

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -88,6 +88,8 @@ static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err r
 static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
 static void zblue_convert_le_addr(bt_address_t* addr, ble_addr_type_t type, bt_addr_le_t* le_addr);
 #if defined(CONFIG_SETTINGS_ZBLUE)
+static int zblue_on_irk_notify(uint8_t dev_id, const char* key_value, uint8_t value_len);
+static int zblue_on_irk_load(uint8_t* key_value, uint8_t value_len);
 static int zblue_on_ltk_notify(uint8_t dev_id, uint8_t id, bt_addr_le_t* addr, const char* key_value, uint8_t value_len);
 static int zblue_on_ltk_load(bt_addr_le_t* addr, uint8_t* key_value, uint8_t value_len);
 #endif
@@ -133,6 +135,8 @@ static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
 
 #if defined(CONFIG_SETTINGS_ZBLUE)
 static struct bt_settings_zblue_cb g_settting_cbs = {
+    .irk_notify = zblue_on_irk_notify,
+    .irk_load = zblue_on_irk_load,
     .ltk_notify = zblue_on_ltk_notify,
     .ltk_load = zblue_on_ltk_load,
 };
@@ -174,6 +178,38 @@ static uint8_t zblue_convert_addr_type(ble_addr_type_t addr_type)
 }
 
 #if defined(CONFIG_SETTINGS_ZBLUE)
+static int zblue_on_irk_notify(uint8_t dev_id, const char* key_value, uint8_t value_len)
+{
+    BT_LOGD("%s", __func__);
+
+    adapter_on_irk_changed(key_value, value_len);
+
+    return 0;
+}
+
+static bool irk_is_empty(const uint8_t* irk)
+{
+    for (int i = 0; i < 16; i++) {
+        if (irk[i] != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static int zblue_on_irk_load(uint8_t* key_value, uint8_t value_len)
+{
+    uint8_t* irk;
+
+    irk = adapter_get_local_irk();
+    if (irk_is_empty(irk)) {
+        return 0;
+    }
+
+    memcpy(key_value, irk, value_len);
+    return value_len;
+}
 /**
  * struct smp_key {
  *     uint8_t id_addr[6];
@@ -754,10 +790,6 @@ static void zblue_on_ready_cb(bt_controller_id_t dev_id, int err)
 {
     UNUSED(dev_id);
 
-    if (IS_ENABLED(CONFIG_SETTINGS)) {
-        settings_load();
-    }
-
     if (err) {
         BT_LOGD("zblue init failed (err %d)\n", err);
         adapter_on_adapter_state_changed(BT_BREDR_STACK_STATE_OFF);
@@ -765,6 +797,11 @@ static void zblue_on_ready_cb(bt_controller_id_t dev_id, int err)
     }
 
     zblue_register_callback();
+    adapter_on_adapter_info_load();
+    if (IS_ENABLED(CONFIG_SETTINGS)) {
+        settings_load();
+    }
+
     adapter_on_adapter_state_changed(BLE_STACK_STATE_ON);
 }
 

--- a/tools/storage_update/storage_update.c
+++ b/tools/storage_update/storage_update.c
@@ -79,6 +79,10 @@ static int bt_storage_update_item_size[BT_STORAGE_VERSION_MAX][BT_STORAGE_UPDATE
         sizeof(remote_device_properties_v5_0_2_t),
         sizeof(remote_device_le_properties_v5_0_2_t),
         sizeof(remote_device_le_properties_v5_0_2_t) },
+    { sizeof(adapter_storage_v5_0_3_t),
+        sizeof(remote_device_properties_v5_0_3_t),
+        sizeof(remote_device_le_properties_v5_0_3_t),
+        sizeof(remote_device_le_properties_v5_0_3_t) },
 #endif
     /*   Reserve for future version   */
 };
@@ -104,6 +108,7 @@ const static bt_storage_update_func_t verison_map[] = {
 #ifdef BLUETOOTH_STORAGE_VERSION_5
     bt_storage_update_v5_0_0_to_v5_0_1,
     bt_storage_update_v5_0_1_to_v5_0_2,
+    bt_storage_update_v5_0_2_to_v5_0_3,
 #endif
     /*   Reserve for future version   */
 };
@@ -543,6 +548,8 @@ int bt_storage_get_version(void)
 #ifdef BLUETOOTH_STORAGE_VERSION_5
     if (!strncasecmp(version_str, "v5_0_2", strlen(version_str))) {
         return BT_STORAGE_VERSION_5_0_2;
+    } else if (!strncasecmp(version_str, "v5_0_3", strlen(version_str))) {
+        return BT_STORAGE_VERSION_5_0_3;
     }
 #endif
 
@@ -629,6 +636,9 @@ static bt_storage_update_properties_t* bt_storage_update_load_info(int storage_v
         break;
     case BT_STORAGE_VERSION_5_0_2:
         storage_info = bt_storage_load_info_v5_0_2();
+        break;
+    case BT_STORAGE_VERSION_5_0_3:
+        storage_info = bt_storage_load_info_v5_0_3();
         break;
 #endif
     default:

--- a/tools/storage_update/storage_update.h
+++ b/tools/storage_update/storage_update.h
@@ -61,10 +61,11 @@ enum {
     BT_STORAGE_VERSION_5_0_0, // name_str:65 Bytes
     BT_STORAGE_VERSION_5_0_1, // add 80 Bytes UUIDs
     BT_STORAGE_VERSION_5_0_2, // version for dev-bluetooth/dev/openvela
+    BT_STORAGE_VERSION_5_0_3, // version for zblue
     BT_STORAGE_VERSION_MAX,
 };
 
-#define BT_STORAGE_VERISON_CURRENT BT_STORAGE_VERSION_5_0_2 /* need to change per version */
+#define BT_STORAGE_VERISON_CURRENT BT_STORAGE_VERSION_5_0_3 /* need to change per version */
 
 typedef bt_storage_update_properties_t* (*bt_storage_update_func_t)(bt_storage_update_properties_t* old_storage);
 

--- a/tools/storage_update/storage_version_5.c
+++ b/tools/storage_update/storage_version_5.c
@@ -66,6 +66,38 @@ bt_storage_update_properties_t* bt_storage_load_info_v5_0_2(void)
     return properties;
 }
 
+bt_storage_update_properties_t* bt_storage_load_info_v5_0_3(void)
+{
+    bt_storage_update_properties_t* properties;
+    adapter_storage_v5_0_3_t* adapter_info;
+    int ret, ret1;
+
+    /* load device information */
+    properties = bt_storage_load_info_kvdb(BT_STORAGE_VERSION_5_0_3);
+    if (!properties) {
+        return NULL;
+    }
+
+    /* load adapter information */
+    adapter_info = (adapter_storage_v5_0_2_t*)(properties->storage_info[BT_STORAGE_UPDATE_ADAPTER_INFO].value);
+    ret = property_get_binary(BT_KVDB_ADAPTERINFO_NAME, adapter_info->name, sizeof(adapter_info->name));
+    ret1 = property_get_binary(BT_KVDB_ADAPTERINFO_IRK, adapter_info->irk, sizeof(adapter_info->irk));
+    adapter_info->class_of_device = property_get_int32(BT_KVDB_ADAPTERINFO_COD, ERROR_ADAPTERINFO_VALUE);
+    adapter_info->io_capability = property_get_int32(BT_KVDB_ADAPTERINFO_IOCAP, ERROR_ADAPTERINFO_VALUE);
+    adapter_info->scan_mode = property_get_int32(BT_KVDB_ADAPTERINFO_SCAN, ERROR_ADAPTERINFO_VALUE);
+    adapter_info->bondable = property_get_int32(BT_KVDB_ADAPTERINFO_BOND, ERROR_ADAPTERINFO_VALUE);
+    if (ret < 0 || ret1 < 0 || adapter_info->class_of_device == ERROR_ADAPTERINFO_VALUE
+        || adapter_info->io_capability == ERROR_ADAPTERINFO_VALUE
+        || adapter_info->scan_mode == ERROR_ADAPTERINFO_VALUE
+        || adapter_info->bondable == ERROR_ADAPTERINFO_VALUE) {
+        syslog(LOG_ERR, "adapter info load failed");
+        bt_storage_update_properties_free(properties);
+        return NULL;
+    }
+
+    return properties;
+}
+
 bt_storage_update_properties_t* bt_storage_update_v4_0_0_to_v5_0_0(bt_storage_update_properties_t* old_storage)
 {
     bt_storage_update_properties_t* new_storage;
@@ -258,6 +290,85 @@ bt_storage_update_properties_t* bt_storage_update_v5_0_1_to_v5_0_2(bt_storage_up
         new_whitelist->addr_type = old_whitelist->addr_type;
         new_whitelist->device_type = old_whitelist->device_type;
         memcpy(new_whitelist->smp_key, old_whitelist->smp_key, 80);
+        new_whitelist++;
+        old_whitelist++;
+    }
+
+    return new_storage;
+}
+
+bt_storage_update_properties_t* bt_storage_update_v5_0_2_to_v5_0_3(bt_storage_update_properties_t* old_storage)
+{
+    bt_storage_update_properties_t* new_storage;
+    bt_storage_update_items_t prop_items = { 0 };
+    int i;
+    /* v5_0_3 storage structure */
+    adapter_storage_v5_0_3_t* new_adapter;
+    remote_device_properties_v5_0_3_t* new_btbond;
+    remote_device_le_properties_v5_0_3_t *new_lebond, *new_whitelist;
+    /* v5_0_2 storage structure */
+    adapter_storage_v5_0_2_t* old_adapter;
+    remote_device_properties_v5_0_2_t* old_btbond;
+    remote_device_le_properties_v5_0_2_t *old_lebond, *old_whitelist;
+
+    old_adapter = (adapter_storage_v5_0_2_t*)(old_storage->storage_info[BT_STORAGE_UPDATE_ADAPTER_INFO].value);
+    old_btbond = (remote_device_properties_v5_0_2_t*)(old_storage->storage_info[BT_STORAGE_UPDATE_BTBOND_INFO].value);
+    old_lebond = (remote_device_le_properties_v5_0_2_t*)(old_storage->storage_info[BT_STORAGE_UPDATE_BLEBOND_INFO].value);
+    old_whitelist = (remote_device_le_properties_v5_0_2_t*)(old_storage->storage_info[BT_STORAGE_UPDATE_WHITELIST_INFO].value);
+    for (i = 0; i < BT_STORAGE_UPDATE_ITEM_MAX; ++i) {
+        prop_items.items[i] = old_storage->storage_info[i].items;
+    }
+
+    /* properties init */
+    new_storage = bt_storage_update_properties_malloc(BT_STORAGE_VERSION_5_0_2, &prop_items);
+    if (!new_storage) {
+        return NULL;
+    }
+
+    /* transform adapter info */
+    new_adapter = (adapter_storage_v5_0_3_t*)(new_storage->storage_info[BT_STORAGE_UPDATE_ADAPTER_INFO].value);
+    new_adapter->bondable = old_adapter->bondable;
+    new_adapter->class_of_device = old_adapter->class_of_device;
+    new_adapter->io_capability = old_adapter->io_capability;
+    new_adapter->scan_mode = old_adapter->scan_mode;
+    strlcpy(new_adapter->name, old_adapter->name, sizeof(new_adapter->name));
+
+    /* transform btbond info */
+    new_btbond = (remote_device_properties_v5_0_3_t*)(new_storage->storage_info[BT_STORAGE_UPDATE_BTBOND_INFO].value);
+    for (i = 0; i < prop_items.items[BT_STORAGE_UPDATE_BTBOND_INFO]; ++i) {
+        memcpy(&new_btbond->addr, &old_btbond->addr, sizeof(bt_address_t));
+        new_btbond->addr_type = old_btbond->addr_type;
+        strlcpy(new_btbond->name, old_btbond->name, sizeof(new_btbond->name));
+        strlcpy(new_btbond->alias, old_btbond->alias, sizeof(new_btbond->alias));
+        new_btbond->class_of_device = old_btbond->class_of_device;
+        memcpy(new_btbond->link_key, old_btbond->link_key, 16);
+        new_btbond->link_key_type = old_btbond->link_key_type;
+        new_btbond->device_type = old_btbond->device_type;
+        memcpy(new_btbond->uuids, old_btbond->uuids, sizeof(old_btbond->uuids));
+        new_btbond++;
+        old_btbond++;
+    }
+
+    /* transform blebond info */
+    new_lebond = (remote_device_le_properties_v5_0_3_t*)(new_storage->storage_info[BT_STORAGE_UPDATE_BLEBOND_INFO].value);
+    for (i = 0; i < prop_items.items[BT_STORAGE_UPDATE_BLEBOND_INFO]; ++i) {
+        memcpy(&new_lebond->addr, &old_lebond->addr, sizeof(bt_address_t));
+        new_lebond->addr_type = old_lebond->addr_type;
+        new_lebond->device_type = old_lebond->device_type;
+        memcpy(new_lebond->smp_key, old_lebond->smp_key, 80);
+        /* alloc local_csrk */
+        new_lebond++;
+        old_lebond++;
+    }
+
+    /* transform whitelist info */
+    new_whitelist = (remote_device_le_properties_v5_0_2_t*)(new_storage->storage_info[BT_STORAGE_UPDATE_WHITELIST_INFO].value);
+    for (i = 0; i < prop_items.items[BT_STORAGE_UPDATE_WHITELIST_INFO]; ++i) {
+        memcpy(&new_whitelist->addr, &old_whitelist->addr, sizeof(bt_address_t));
+        new_whitelist->addr_type = old_whitelist->addr_type;
+        new_whitelist->device_type = old_whitelist->device_type;
+        memcpy(new_whitelist->smp_key, old_whitelist->smp_key, 80);
+        /* alloc local_csrk */
         new_whitelist++;
         old_whitelist++;
     }

--- a/tools/storage_update/storage_version_5.h
+++ b/tools/storage_update/storage_version_5.h
@@ -74,6 +74,38 @@ typedef adapter_storage_v5_0_0_t adapter_storage_v5_0_1_t;
 
 typedef remote_device_le_properties_v5_0_0_t remote_device_le_properties_v5_0_1_t;
 
+/* v5_0_2 storage structure */
+typedef struct {
+    bt_address_t addr;
+    uint8_t addr_type;
+    // only can add member after "addr_type" if needed, see function bt_storage_save_remote_device for reasons.
+    char name[BT_REM_NAME_MAX_LEN + 1];
+    char alias[BT_REM_NAME_MAX_LEN + 1];
+    uint8_t link_key_type;
+    uint8_t device_type;
+    uint8_t pad[1];
+    uint8_t link_key[16];
+    uint32_t class_of_device;
+    uint8_t uuids[CONFIG_BLUETOOTH_MAX_SAVED_REMOTE_UUIDS_LEN];
+} __attribute__((aligned(4))) remote_device_properties_v5_0_2_t;
+
+typedef struct {
+    bt_address_t addr;
+    uint8_t addr_type;
+    // only can add member after "addr_type" if needed, see function bt_storage_save_le_remote_device for reasons.
+    uint8_t device_type;
+    uint8_t smp_key[80];
+} __attribute__((aligned(4))) remote_device_le_properties_v5_0_2_t;
+
+typedef struct {
+    char name[BT_LOC_NAME_MAX_LEN + 1];
+    uint8_t pad[3];
+    uint32_t class_of_device;
+    uint32_t io_capability;
+    uint32_t scan_mode;
+    uint32_t bondable;
+} __attribute__((aligned(4))) adapter_storage_v5_0_2_t;
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -81,10 +113,12 @@ typedef remote_device_le_properties_v5_0_0_t remote_device_le_properties_v5_0_1_
 bt_storage_update_properties_t* bt_storage_load_info_v5_0_0(void);
 bt_storage_update_properties_t* bt_storage_load_info_v5_0_1(void);
 bt_storage_update_properties_t* bt_storage_load_info_v5_0_2(void);
+bt_storage_update_properties_t* bt_storage_load_info_v5_0_3(void);
 
 /* update function */
 bt_storage_update_properties_t* bt_storage_update_v4_0_0_to_v5_0_0(bt_storage_update_properties_t* old_storage);
 bt_storage_update_properties_t* bt_storage_update_v5_0_0_to_v5_0_1(bt_storage_update_properties_t* old_storage);
 bt_storage_update_properties_t* bt_storage_update_v5_0_1_to_v5_0_2(bt_storage_update_properties_t* old_storage);
+bt_storage_update_properties_t* bt_storage_update_v5_0_2_to_v5_0_3(bt_storage_update_properties_t* old_storage);
 
 #endif /* __STORAGE_VERSION_5_H__ */


### PR DESCRIPTION
bug: v/79370

When the object passed to `gatt_db_add` is a characteristic value, the `user_data` used is an element variable allocated by the `gatt_service` module's `malloc`. Since the memory allocated by the gatts_service module is contiguous memory of element * n, the free(start[i].user_data); executed during remove_service actually performs free(element[i]). This results in released memory being heap memory, but not the malloc memory header—instead, it releases the “body” of the memory block.
