### PR TITLE
Profile Connection Manager API Enhancement

### DIFF
--- a/service/stacks/zephyr/include/sal_connection_manager.h
+++ b/service/stacks/zephyr/include/sal_connection_manager.h
@@ -20,32 +20,36 @@
 typedef struct {
     bt_address_t addr;
     uint8_t profile_id;
+    uint16_t conn_id;
 } cm_data_t;
 
 typedef bt_status_t (*bt_profile_conn_handler_t)(
-    bt_controller_id_t id, bt_address_t* addr);
+    bt_controller_id_t id, bt_address_t* addr, void* user_data);
 
 typedef struct {
     bt_profile_conn_handler_t handler;
     uint8_t profile_id;
+    uint16_t conn_id;
+    bool is_busy;
     bt_controller_id_t id;
+    void* user_data;
 } bt_profile_conn_handler_node_t;
 
 bt_status_t bt_sal_profile_connect_request(bt_address_t* addr,
-    uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler);
+    uint8_t profile_id, uint16_t conn_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler, void* user_data);
 bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr,
-    uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler);
+    uint8_t profile_id, uint16_t conn_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler, void* user_data);
 bt_status_t bt_sal_profile_disconnect_request(bt_address_t* addr,
-    uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler);
+    uint8_t profile_id, uint16_t conn_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler, void* user_data);
 bt_status_t bt_sal_remove_bond_internal(bt_controller_id_t id,
     bt_address_t* addr);
 bt_status_t bt_sal_disconnect_internal(bt_controller_id_t id,
     bt_address_t* addr, uint8_t reason);
 
-cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id);
+cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id, uint16_t conn_id);
 void bt_sal_cm_profile_connected_callback(cm_data_t* data);
 void bt_sal_cm_profile_disconnected_callback(cm_data_t* data);
 void bt_sal_cm_acl_connected_callback(cm_data_t* data);

--- a/service/stacks/zephyr/include/sal_connection_manager.h
+++ b/service/stacks/zephyr/include/sal_connection_manager.h
@@ -17,6 +17,8 @@
 #include "bt_addr.h"
 #include "bt_profile.h"
 
+#define CONN_ID_DEFAULT 0x0001
+
 typedef struct {
     bt_address_t addr;
     uint8_t profile_id;

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -913,13 +913,13 @@ static void bt_sal_a2dp_notify_connected(struct zblue_a2dp_info_t* a2dp_info)
 {
     if (a2dp_info->role == SEP_SRC) {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP, 0));
-        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP, 0, PRIMARY_ADAPTER, a2dp_source_disconnect, NULL);
+        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP, CONN_ID_DEFAULT));
+        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP, CONN_ID_DEFAULT, PRIMARY_ADAPTER, a2dp_source_disconnect, NULL);
 #endif
     } else { /* SEP_SNK */
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, 0));
-        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, 0, PRIMARY_ADAPTER, a2dp_sink_disconnect, NULL);
+        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT));
+        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT, PRIMARY_ADAPTER, a2dp_sink_disconnect, NULL);
 #endif
     }
 }
@@ -928,11 +928,11 @@ static void bt_sal_a2dp_notify_disconnected(struct zblue_a2dp_info_t* a2dp_info)
 {
     if (a2dp_info->role == SEP_SRC) {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP, 0));
+        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP, CONN_ID_DEFAULT));
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
     } else { /* SEP_SNK */
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, 0));
+        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT));
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
     }
 }
@@ -1638,7 +1638,7 @@ error:
 bt_status_t bt_sal_a2dp_source_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-    return bt_sal_profile_connect_request(addr, PROFILE_A2DP, 0, id, a2dp_source_profile_connect, NULL);
+    return bt_sal_profile_connect_request(addr, PROFILE_A2DP, CONN_ID_DEFAULT, id, a2dp_source_profile_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
@@ -1700,7 +1700,7 @@ error:
 bt_status_t bt_sal_a2dp_sink_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    return bt_sal_profile_connect_request(addr, PROFILE_A2DP_SINK, 0, id, a2dp_sink_profile_connect, NULL);
+    return bt_sal_profile_connect_request(addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT, id, a2dp_sink_profile_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
@@ -1746,7 +1746,7 @@ static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* a
 bt_status_t bt_sal_a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP, 0, id, a2dp_source_disconnect, NULL);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP, CONN_ID_DEFAULT, id, a2dp_source_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
@@ -1770,7 +1770,7 @@ static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* add
 bt_status_t bt_sal_a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP_SINK, 0, id, a2dp_sink_disconnect, NULL);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT, id, a2dp_sink_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -81,11 +81,11 @@ static bt_list_t* bt_a2dp_conn = NULL;
 static void bt_list_remove_a2dp_info(struct zblue_a2dp_info_t* a2dp_info);
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr);
+static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data);
 #endif
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr);
+static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data);
 #endif
 
 static void flag_reset(struct zblue_a2dp_info_t* a2dp_info)
@@ -913,13 +913,13 @@ static void bt_sal_a2dp_notify_connected(struct zblue_a2dp_info_t* a2dp_info)
 {
     if (a2dp_info->role == SEP_SRC) {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP));
-        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP, PRIMARY_ADAPTER, a2dp_source_disconnect);
+        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP, 0));
+        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP, 0, PRIMARY_ADAPTER, a2dp_source_disconnect, NULL);
 #endif
     } else { /* SEP_SNK */
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK));
-        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, PRIMARY_ADAPTER, a2dp_sink_disconnect);
+        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, 0));
+        bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, 0, PRIMARY_ADAPTER, a2dp_sink_disconnect, NULL);
 #endif
     }
 }
@@ -928,11 +928,11 @@ static void bt_sal_a2dp_notify_disconnected(struct zblue_a2dp_info_t* a2dp_info)
 {
     if (a2dp_info->role == SEP_SRC) {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP));
+        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP, 0));
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
     } else { /* SEP_SNK */
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK));
+        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, 0));
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
     }
 }
@@ -1583,7 +1583,7 @@ bt_status_t bt_sal_a2dp_sink_init(uint8_t max_connections)
 }
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-static bt_status_t a2dp_source_profile_connect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t a2dp_source_profile_connect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     struct zblue_a2dp_info_t* a2dp_info;
@@ -1638,14 +1638,14 @@ error:
 bt_status_t bt_sal_a2dp_source_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-    return bt_sal_profile_connect_request(addr, PROFILE_A2DP, id, a2dp_source_profile_connect);
+    return bt_sal_profile_connect_request(addr, PROFILE_A2DP, 0, id, a2dp_source_profile_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
 }
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-static bt_status_t a2dp_sink_profile_connect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t a2dp_sink_profile_connect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     struct zblue_a2dp_info_t* a2dp_info;
@@ -1700,7 +1700,7 @@ error:
 bt_status_t bt_sal_a2dp_sink_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    return bt_sal_profile_connect_request(addr, PROFILE_A2DP_SINK, id, a2dp_sink_profile_connect);
+    return bt_sal_profile_connect_request(addr, PROFILE_A2DP_SINK, 0, id, a2dp_sink_profile_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
@@ -1729,7 +1729,7 @@ static bt_status_t bt_sal_a2dp_disconnect(struct zblue_a2dp_info_t* a2dp_info)
 }
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct zblue_a2dp_info_t* a2dp_info;
 
@@ -1746,14 +1746,14 @@ static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* a
 bt_status_t bt_sal_a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP, id, a2dp_source_disconnect);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP, 0, id, a2dp_source_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
 }
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct zblue_a2dp_info_t* a2dp_info;
 
@@ -1770,7 +1770,7 @@ static bt_status_t a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* add
 bt_status_t bt_sal_a2dp_sink_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP_SINK, id, a2dp_sink_disconnect);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_A2DP_SINK, 0, id, a2dp_sink_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */

--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -247,12 +247,12 @@ static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
     if (err) {
         state.connection_state = CONNECTION_STATE_DISCONNECTED;
         state.status = err;
-        bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN));
+        bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, 0));
         goto error;
     }
 
     bt_sal_get_remote_name(BT_TRANSPORT_BREDR, &state.addr);
-    bt_sal_cm_acl_connected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN));
+    bt_sal_cm_acl_connected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, 0));
 
 error:
     adapter_on_connection_state_changed(&state);
@@ -272,7 +272,7 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
 
     zblue_conn_get_addr(conn, &state.addr);
     adapter_on_connection_state_changed(&state);
-    bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN));
+    bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, 0));
 }
 
 static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,

--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -247,12 +247,12 @@ static void zblue_on_connected(struct bt_conn* conn, uint8_t err)
     if (err) {
         state.connection_state = CONNECTION_STATE_DISCONNECTED;
         state.status = err;
-        bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, 0));
+        bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, CONN_ID_DEFAULT));
         goto error;
     }
 
     bt_sal_get_remote_name(BT_TRANSPORT_BREDR, &state.addr);
-    bt_sal_cm_acl_connected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, 0));
+    bt_sal_cm_acl_connected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, CONN_ID_DEFAULT));
 
 error:
     adapter_on_connection_state_changed(&state);
@@ -272,7 +272,7 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason)
 
     zblue_conn_get_addr(conn, &state.addr);
     adapter_on_connection_state_changed(&state);
-    bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, 0));
+    bt_sal_cm_acl_disconnected_callback(cm_data_new(&state.addr, PROFILE_UNKOWN, CONN_ID_DEFAULT));
 }
 
 static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -88,7 +88,7 @@ static void zblue_on_ct_passthrough_rsp(struct bt_avrcp_ct* ct, uint8_t tid, bt_
 static void zblue_on_ct_notification_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, uint8_t event_id, struct bt_avrcp_event_data* data);
 static void zblue_on_ct_get_element_attrs_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, struct net_buf* buf);
 static void zblue_on_ct_get_play_status_rsp(struct bt_avrcp_ct* ct, uint8_t tid, uint8_t status, struct net_buf* buf);
-static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr);
+static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data);
 #endif
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_ABSOLUTE_VOLUME
@@ -727,8 +727,8 @@ static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
     msg->data.conn_state.conn_state = PROFILE_STATE_CONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
-    bt_sal_cm_profile_connected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT));
-    bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, PRIMARY_ADAPTER, avrcp_control_disconnect);
+    bt_sal_cm_profile_connected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, 0));
+    bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, 0, PRIMARY_ADAPTER, avrcp_control_disconnect, NULL);
 }
 
 static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
@@ -748,7 +748,7 @@ static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
     msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
-    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT));
+    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, 0));
 
     bt_list_remove_avrcp_info(avrcp_info);
 }
@@ -1068,7 +1068,7 @@ static void zblue_on_tg_disconnected(struct bt_avrcp_tg* tg)
     msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_target_event_callback(msg);
-    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_TG));
+    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_TG, 0));
 #endif
 
     bt_list_remove_avrcp_info(avrcp_info);
@@ -1388,7 +1388,7 @@ static void zblue_on_tg_get_play_status_req(struct bt_avrcp_tg* tg, uint8_t tid)
 #endif
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd_addr)
+static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data)
 {
     int err;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)bd_addr);
@@ -1412,14 +1412,14 @@ static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd
 bt_status_t bt_sal_avrcp_control_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-    return bt_sal_profile_connect_request(addr, PROFILE_AVRCP_CT, id, avrcp_control_connect);
+    return bt_sal_profile_connect_request(addr, PROFILE_AVRCP_CT, 0, id, avrcp_control_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif
 }
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr)
+static bt_status_t avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data)
 {
     zblue_avrcp_info_t* avrcp_info;
     int err;
@@ -1451,7 +1451,7 @@ failed:
 bt_status_t bt_sal_avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-    return bt_sal_profile_disconnect_request(addr, PROFILE_AVRCP_CT, id, avrcp_control_disconnect);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_AVRCP_CT, 0, id, avrcp_control_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -727,8 +727,8 @@ static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
     msg->data.conn_state.conn_state = PROFILE_STATE_CONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
-    bt_sal_cm_profile_connected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, 0));
-    bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, 0, PRIMARY_ADAPTER, avrcp_control_disconnect, NULL);
+    bt_sal_cm_profile_connected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT));
+    bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT, PRIMARY_ADAPTER, avrcp_control_disconnect, NULL);
 }
 
 static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
@@ -748,7 +748,7 @@ static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
     msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
-    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, 0));
+    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT));
 
     bt_list_remove_avrcp_info(avrcp_info);
 }
@@ -1068,7 +1068,7 @@ static void zblue_on_tg_disconnected(struct bt_avrcp_tg* tg)
     msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_target_event_callback(msg);
-    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_TG, 0));
+    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_TG, CONN_ID_DEFAULT));
 #endif
 
     bt_list_remove_avrcp_info(avrcp_info);
@@ -1412,7 +1412,7 @@ static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd
 bt_status_t bt_sal_avrcp_control_connect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-    return bt_sal_profile_connect_request(addr, PROFILE_AVRCP_CT, 0, id, avrcp_control_connect, NULL);
+    return bt_sal_profile_connect_request(addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT, id, avrcp_control_connect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif
@@ -1451,7 +1451,7 @@ failed:
 bt_status_t bt_sal_avrcp_control_disconnect(bt_controller_id_t id, bt_address_t* addr)
 {
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
-    return bt_sal_profile_disconnect_request(addr, PROFILE_AVRCP_CT, 0, id, avrcp_control_disconnect, NULL);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT, id, avrcp_control_disconnect, NULL);
 #else
     return BT_STATUS_NOT_SUPPORTED;
 #endif

--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -22,15 +22,8 @@
 
 #include "utils/log.h"
 
-#define FLAG_NONE (0)
-#define FLAG_A2DP_SINK (1ULL << (PROFILE_A2DP_SINK))
-#define FLAG_A2DP_SOURCE (1ULL << (PROFILE_A2DP))
-#define FLAG_AVRCP_TARGET (1ULL << (PROFILE_AVRCP_TG))
-#define FLAG_AVRCP_CONTROL (1ULL << (PROFILE_AVRCP_CT))
-
 typedef struct {
     bt_address_t device_addr;
-    uint64_t profile_flags;
     bool is_unpair;
     bt_list_t* profile_conn_handler_list;
 } bt_profile_connection_manager_t;
@@ -38,8 +31,10 @@ typedef struct {
 typedef struct {
     bt_address_t device_addr;
     uint8_t profile_id;
+    uint16_t conn_id;
     bt_profile_conn_handler_t handler;
     bt_controller_id_t id;
+    bt_list_t* manager_list;
     void* user_data;
 } sal_async_profile_req_t;
 
@@ -47,46 +42,39 @@ static bt_list_t* bt_sal_connecting_list = NULL;
 static bt_list_t* bt_sal_disconnecting_list = NULL;
 
 static bt_status_t bt_sal_trigger_profile_conn_act(bt_profile_connection_manager_t* manager, bt_list_t* manager_list);
+static void remove_from_connection_manager_list(bt_list_t* list, bt_address_t* addr, uint8_t profile_id,
+    uint16_t conn_id, bool try_acl_disconnect);
 
-static void flags_set(uint64_t* profile_flags, uint64_t flags)
-{
-    *profile_flags |= flags;
-}
-
-static void flags_clear(uint64_t* profile_flags, uint64_t flags)
-{
-    *profile_flags &= ~flags;
-}
-
-static inline uint64_t profile_id_to_flag(uint8_t profile_id)
-{
-    SAL_ASSERT(profile_id <= PROFILE_MAX);
-
-    return (1ULL << (profile_id));
-}
-
-static bool match_profile_func(void* data, void* context)
+static bool match_profile_id_and_conn_id(void* data, void* context)
 {
     bt_profile_conn_handler_node_t* handler_node = (bt_profile_conn_handler_node_t*)data;
-    bt_profile_conn_handler_t* target_func = (bt_profile_conn_handler_t*)context;
+    uint32_t key = (uint32_t)(uintptr_t)context;
+    uint8_t profile_id = (key >> 16) & 0xFF;
+    uint16_t conn_id = key & 0xFFFF;
 
-    if (!handler_node || !target_func) {
+    if (!handler_node) {
         return false;
     }
 
-    return handler_node->handler == *target_func;
+    return handler_node->profile_id == profile_id && handler_node->conn_id == conn_id;
 }
 
-static bool match_profile_id(void* data, void* context)
+static bt_profile_conn_handler_node_t* find_handler_node(
+    bt_profile_connection_manager_t* manager,
+    uint8_t profile_id,
+    uint16_t conn_id)
 {
-    bt_profile_conn_handler_node_t* handler_node = (bt_profile_conn_handler_node_t*)data;
-    uint8_t* profile_id = (uint8_t*)context;
+    uint32_t key;
 
-    if (!handler_node || !profile_id) {
-        return false;
+    if (!manager || !manager->profile_conn_handler_list) {
+        return NULL;
     }
 
-    return handler_node->profile_id == *profile_id;
+    key = (((uint32_t)profile_id) << 16) | (uint32_t)conn_id;
+
+    return bt_list_find(manager->profile_conn_handler_list,
+        match_profile_id_and_conn_id,
+        (void*)(uintptr_t)key);
 }
 
 static void bt_connection_manager_destory(void* data)
@@ -152,14 +140,16 @@ static bt_profile_connection_manager_t* find_or_create_connection_manager(bt_lis
 }
 
 static sal_async_profile_req_t* sal_async_profile_req(bt_address_t* addr, bt_profile_conn_handler_t handler,
-    uint8_t profile_id, bt_controller_id_t id, void* user_data)
+    uint8_t profile_id, uint16_t conn_id, bt_controller_id_t id, bt_list_t* manager_list, void* user_data)
 {
     sal_async_profile_req_t* req = calloc(sizeof(sal_async_profile_req_t), 1);
 
     if (req) {
         req->profile_id = profile_id;
+        req->conn_id = conn_id;
         req->id = id;
         req->handler = handler;
+        req->manager_list = manager_list;
         req->user_data = user_data;
         if (addr)
             memcpy(&req->device_addr, addr, sizeof(bt_address_t));
@@ -178,14 +168,14 @@ static void sal_invoke_async(service_work_t* work, void* userdata)
 
     SAL_ASSERT(req);
 
-    if (!req->user_data) {
+    if (!req->manager_list) {
         /* !req->user_data means a direct profile "disconnection" */
-        req->handler(req->id, &req->device_addr);
+        req->handler(req->id, &req->device_addr, req->user_data);
         free(req);
         return;
     }
 
-    manager_list = (bt_list_t*)req->user_data;
+    manager_list = (bt_list_t*)req->manager_list;
 
     manager = (bt_profile_connection_manager_t*)bt_list_find(manager_list,
         bt_connection_manager_find, &req->device_addr);
@@ -196,26 +186,18 @@ static void sal_invoke_async(service_work_t* work, void* userdata)
         return;
     }
 
-    if (!bt_list_find(manager->profile_conn_handler_list, match_profile_func, (void*)&req->handler)) {
-        BT_LOGW("%s, handler_node handler not found.", __func__);
-        flags_clear(&manager->profile_flags, profile_id_to_flag(req->profile_id));
-        free(req);
-        return;
-    }
-
-    handler_node = bt_list_find(manager->profile_conn_handler_list, match_profile_id, (void*)&req->profile_id);
+    handler_node = find_handler_node(manager, req->profile_id, req->conn_id);
 
     if (!handler_node) {
         BT_LOGW("%s, handler_node not found.", __func__);
-        flags_clear(&manager->profile_flags, profile_id_to_flag(req->profile_id));
         free(req);
         return;
     }
 
-    status = req->handler(req->id, &req->device_addr);
+    status = req->handler(req->id, &req->device_addr, req->user_data);
 
     if (status != BT_STATUS_SUCCESS) {
-        flags_clear(&manager->profile_flags, profile_id_to_flag(req->profile_id));
+        remove_from_connection_manager_list(manager_list, &req->device_addr, req->profile_id, req->conn_id, false);
     }
 
     free(req);
@@ -227,13 +209,14 @@ static bt_status_t sal_send_async_req(sal_async_profile_req_t* req)
         return BT_STATUS_PARM_INVALID;
 
     if (!service_loop_work((void*)req, sal_invoke_async, NULL)) {
+        free(req);
         return BT_STATUS_FAIL;
     }
 
     return BT_STATUS_SUCCESS;
 }
 
-cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id)
+cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id, uint16_t conn_id)
 {
     cm_data_t* data = (cm_data_t*)zalloc(sizeof(cm_data_t));
     if (!data)
@@ -243,6 +226,7 @@ cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id)
         memcpy(&data->addr, addr, sizeof(bt_address_t));
 
     data->profile_id = profile_id;
+    data->conn_id = conn_id;
     return data;
 }
 
@@ -260,8 +244,7 @@ void cm_data_destory(cm_data_t* data)
 static bt_status_t bt_sal_trigger_profile_conn_act(bt_profile_connection_manager_t* manager, bt_list_t* manager_list)
 {
     bt_list_node_t* node;
-    bt_profile_conn_handler_node_t* entry_node;
-    uint64_t bit_flag;
+    bt_profile_conn_handler_node_t* handler_node;
     bt_address_t* addr;
     bt_list_t* list;
     sal_async_profile_req_t* req;
@@ -279,43 +262,33 @@ static bt_status_t bt_sal_trigger_profile_conn_act(bt_profile_connection_manager
     addr = &manager->device_addr;
 
     for (node = bt_list_head(list); node != NULL; node = bt_list_next(list, node)) {
-        entry_node = (bt_profile_conn_handler_node_t*)bt_list_node(node);
+        handler_node = (bt_profile_conn_handler_node_t*)bt_list_node(node);
 
-        if (!entry_node || !entry_node->handler)
+        if (!handler_node || !handler_node->handler)
             continue;
 
-        bit_flag = profile_id_to_flag(entry_node->profile_id);
-        if (bit_flag && (manager->profile_flags & bit_flag)) {
+        if (handler_node->is_busy) {
             continue;
         }
 
         /* async invoke to service_worker thread */
-        req = sal_async_profile_req(addr, entry_node->handler, entry_node->profile_id, entry_node->id, manager_list);
+        req = sal_async_profile_req(addr, handler_node->handler, handler_node->profile_id, handler_node->conn_id,
+            handler_node->id, manager_list, handler_node->user_data);
 
         if (sal_send_async_req(req) != BT_STATUS_SUCCESS) {
-            BT_LOGE("%s, profile_id: %u", __func__, entry_node->profile_id);
+            BT_LOGE("%s, profile_id: %u", __func__, handler_node->profile_id);
             free(req);
             continue;
         }
 
-        flags_set(&manager->profile_flags, profile_id_to_flag(entry_node->profile_id));
+        handler_node->is_busy = true;
     }
 
     return BT_STATUS_SUCCESS;
 }
 
-static bt_status_t bt_try_disconnect_acl(bt_profile_connection_manager_t* manager)
-{
-    if (manager->profile_flags != FLAG_NONE) {
-        BT_LOGD("%s, Disconnecting profile.", __func__);
-        return BT_STATUS_BUSY;
-    }
-
-    return bt_sal_disconnect_internal(PRIMARY_ADAPTER, &manager->device_addr, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-}
-
 static void remove_from_connection_manager_list(bt_list_t* list, bt_address_t* addr, uint8_t profile_id,
-    bool try_acl_disconnect)
+    uint16_t conn_id, bool try_acl_disconnect)
 {
     if (list == NULL) {
         return;
@@ -329,21 +302,16 @@ static void remove_from_connection_manager_list(bt_list_t* list, bt_address_t* a
         return;
     }
 
-    flags_clear(&manager->profile_flags, profile_id_to_flag(profile_id));
-    handler_node = bt_list_find(manager->profile_conn_handler_list, match_profile_id,
-        (void*)&profile_id);
+    handler_node = find_handler_node(manager, profile_id, conn_id);
 
-    if (handler_node == NULL) {
-        BT_LOGW("%s, handler_node not found.", __func__);
-        return;
+    if (handler_node) {
+        bt_list_remove(manager->profile_conn_handler_list, handler_node);
     }
-
-    bt_list_remove(manager->profile_conn_handler_list, handler_node);
 
     if (bt_list_is_empty(manager->profile_conn_handler_list)) {
 
         if (try_acl_disconnect) {
-            bt_try_disconnect_acl(manager);
+            bt_sal_disconnect_internal(PRIMARY_ADAPTER, addr, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
         } else {
             bt_list_remove(list, manager);
         }
@@ -361,11 +329,13 @@ static void bt_sal_cm_profile_disconnected(void* data)
     remove_from_connection_manager_list(bt_sal_connecting_list,
         &cm_data->addr,
         cm_data->profile_id,
+        cm_data->conn_id,
         false);
 
     remove_from_connection_manager_list(bt_sal_disconnecting_list,
         &cm_data->addr,
         cm_data->profile_id,
+        cm_data->conn_id,
         true);
 
     cm_data_destory(cm_data);
@@ -513,7 +483,7 @@ bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair
         }
 
         if (bt_list_is_empty(manager->profile_conn_handler_list)) {
-            return bt_try_disconnect_acl(manager);
+            return bt_sal_disconnect_internal(PRIMARY_ADAPTER, addr, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
         }
 
         return bt_sal_trigger_profile_conn_act(manager, bt_sal_disconnecting_list);
@@ -529,7 +499,7 @@ bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair
     manager->is_unpair = is_unpair;
     bt_list_add_tail(bt_sal_disconnecting_list, manager);
 
-    return bt_try_disconnect_acl(manager);
+    return bt_sal_disconnect_internal(PRIMARY_ADAPTER, addr, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 }
 
 static bt_status_t bt_sal_try_profile_connect(bt_address_t* addr)
@@ -571,11 +541,11 @@ static bt_status_t bt_sal_try_profile_connect(bt_address_t* addr)
     return bt_sal_trigger_profile_conn_act(manager, bt_sal_connecting_list);
 }
 
-bt_status_t bt_sal_profile_connect_request(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler)
+bt_status_t bt_sal_profile_connect_request(bt_address_t* addr, uint8_t profile_id, uint16_t conn_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler, void* user_data)
 {
     bt_profile_connection_manager_t* manager;
-    bt_profile_conn_handler_node_t* entry_node;
+    bt_profile_conn_handler_node_t* handler_node;
 
     if (!addr || !handler)
         return BT_STATUS_PARM_INVALID;
@@ -585,28 +555,30 @@ bt_status_t bt_sal_profile_connect_request(bt_address_t* addr, uint8_t profile_i
         return BT_STATUS_NOMEM;
     }
 
-    if (bt_list_find(manager->profile_conn_handler_list, match_profile_func, (void*)&handler)) {
+    if (find_handler_node(manager, profile_id, conn_id)) {
         return BT_STATUS_SUCCESS;
     }
 
-    entry_node = (bt_profile_conn_handler_node_t*)zalloc(sizeof(bt_profile_conn_handler_node_t));
-    if (!entry_node) {
+    handler_node = (bt_profile_conn_handler_node_t*)zalloc(sizeof(bt_profile_conn_handler_node_t));
+    if (!handler_node) {
         return BT_STATUS_NOMEM;
     }
 
-    entry_node->handler = handler;
-    entry_node->profile_id = profile_id;
-    entry_node->id = id;
-    bt_list_add_tail(manager->profile_conn_handler_list, entry_node);
+    handler_node->handler = handler;
+    handler_node->profile_id = profile_id;
+    handler_node->conn_id = conn_id;
+    handler_node->id = id;
+    handler_node->user_data = user_data;
+    bt_list_add_tail(manager->profile_conn_handler_list, handler_node);
 
     return bt_sal_try_profile_connect(addr);
 }
 
-bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler)
+bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr, uint8_t profile_id, uint16_t conn_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler, void* user_data)
 {
     bt_profile_connection_manager_t* manager;
-    bt_profile_conn_handler_node_t* entry_node;
+    bt_profile_conn_handler_node_t* handler_node;
 
     if (!addr || !handler)
         return BT_STATUS_PARM_INVALID;
@@ -616,30 +588,32 @@ bt_status_t bt_sal_profile_disconnect_register(bt_address_t* addr, uint8_t profi
         return BT_STATUS_NOMEM;
     }
 
-    if (bt_list_find(manager->profile_conn_handler_list, match_profile_func, (void*)&handler)) {
+    if (find_handler_node(manager, profile_id, conn_id)) {
         return BT_STATUS_SUCCESS;
     }
 
-    entry_node = (bt_profile_conn_handler_node_t*)zalloc(sizeof(bt_profile_conn_handler_node_t));
-    if (!entry_node) {
+    handler_node = (bt_profile_conn_handler_node_t*)zalloc(sizeof(bt_profile_conn_handler_node_t));
+    if (!handler_node) {
         return BT_STATUS_NOMEM;
     }
 
-    entry_node->handler = handler;
-    entry_node->profile_id = profile_id;
-    entry_node->id = id;
-    bt_list_add_tail(manager->profile_conn_handler_list, entry_node);
+    handler_node->handler = handler;
+    handler_node->profile_id = profile_id;
+    handler_node->conn_id = conn_id;
+    handler_node->id = id;
+    handler_node->user_data = user_data;
+    bt_list_add_tail(manager->profile_conn_handler_list, handler_node);
 
     return BT_STATUS_SUCCESS;
 }
 
-bt_status_t bt_sal_profile_disconnect_request(bt_address_t* addr, uint8_t profile_id, bt_controller_id_t id,
-    bt_profile_conn_handler_t handler)
+bt_status_t bt_sal_profile_disconnect_request(bt_address_t* addr, uint8_t profile_id, uint16_t conn_id, bt_controller_id_t id,
+    bt_profile_conn_handler_t handler, void* user_data)
 {
     sal_async_profile_req_t* req;
 
     /* async invoke to service_worker thread */
-    req = sal_async_profile_req(addr, handler, profile_id, id, NULL);
+    req = sal_async_profile_req(addr, handler, profile_id, conn_id, id, NULL, user_data);
 
     if (sal_send_async_req(req) != BT_STATUS_SUCCESS) {
         BT_LOGE("%s, profile_id: %u", __func__, profile_id);

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -301,7 +301,7 @@ static void set_call_state(
     sal_call->state = state;
 }
 
-static bt_status_t do_hf_connect(bt_controller_id_t id, bt_address_t* addr)
+static bt_status_t do_hf_connect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     struct bt_hfp_hf* hf = NULL;
     uint8_t channel;
@@ -358,7 +358,7 @@ static bt_status_t do_hf_connect(bt_controller_id_t id, bt_address_t* addr)
     return BT_STATUS_SUCCESS;
 }
 
-bt_status_t do_hf_disconnect(bt_controller_id_t id, bt_address_t* addr)
+bt_status_t do_hf_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
@@ -419,7 +419,7 @@ static uint8_t zblue_on_sdp_done(struct bt_conn* conn, struct bt_sdp_client_resu
 
     g_conn_params->channel = (uint8_t)port;
 
-    if (do_hf_connect(0 /* bt_controller_id_t */, &bd_addr) != BT_STATUS_SUCCESS) {
+    if (do_hf_connect(0 /* bt_controller_id_t */, &bd_addr, NULL) != BT_STATUS_SUCCESS) {
         free(g_conn_params);
         g_conn_params = NULL;
         goto error;
@@ -449,8 +449,8 @@ static void zblue_on_connected(struct bt_conn* conn, struct bt_hfp_hf* hf)
 
         hfp_hf_on_connection_state_changed(&bd_addr, PROFILE_STATE_CONNECTING, 0, 0);
     }
-    bt_sal_cm_profile_connected_callback(cm_data_new(&bd_addr, PROFILE_HFP_HF));
-    bt_sal_profile_disconnect_register(&bd_addr, PROFILE_HFP_HF, PRIMARY_ADAPTER, do_hf_disconnect);
+    bt_sal_cm_profile_connected_callback(cm_data_new(&bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT));
+    bt_sal_profile_disconnect_register(&bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT, PRIMARY_ADAPTER, do_hf_disconnect, NULL);
 
     hfp_hf_on_connection_state_changed(&bd_addr, PROFILE_STATE_CONNECTED, 0, 0);
 }
@@ -952,7 +952,7 @@ bt_status_t bt_sal_hfp_hf_connect(bt_address_t* addr)
         return BT_STATUS_BUSY;
     }
 
-    return bt_sal_profile_connect_request(addr, PROFILE_HFP_HF, 0, do_hf_connect);
+    return bt_sal_profile_connect_request(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT, 0, do_hf_connect, NULL);
 }
 
 bt_status_t bt_sal_hfp_hf_disconnect(bt_address_t* addr)
@@ -968,7 +968,7 @@ bt_status_t bt_sal_hfp_hf_disconnect(bt_address_t* addr)
         return BT_STATUS_FAIL;
     }
 
-    return bt_sal_profile_disconnect_request(addr, PROFILE_HFP_HF, 0, do_hf_disconnect);
+    return bt_sal_profile_disconnect_request(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT, 0, do_hf_disconnect, NULL);
 }
 
 bt_status_t bt_sal_hfp_hf_connect_audio(bt_address_t* addr)

--- a/service/stacks/zephyr/sal_hid_device_interface.c
+++ b/service/stacks/zephyr/sal_hid_device_interface.c
@@ -25,6 +25,7 @@
 #include "hid_device_service.h"
 #include "utils/log.h"
 
+#include "sal_connection_manager.h"
 #include "sal_hid_device_interface.h"
 #include "sal_interface.h"
 #include "sal_zblue.h"
@@ -173,6 +174,8 @@ static sal_bt_hid_device_mgr_t g_hid_device_mgr = {
     .mutex = PTHREAD_MUTEX_INITIALIZER,
     .connections = NULL
 };
+
+static bt_status_t hid_disconnect_handler(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data);
 
 static inline void hid_conn_lock(void)
 {
@@ -422,6 +425,9 @@ static void hid_connect_callback(struct bt_hid_device* hid)
 
     hid_conn_unlock();
     hid_device_on_connection_state_changed(&hid_conn->addr, false, PROFILE_STATE_CONNECTED);
+
+    bt_sal_cm_profile_connected_callback(cm_data_new(&hid_conn->addr, PROFILE_HID_DEV, CONN_ID_DEFAULT));
+    bt_sal_profile_disconnect_register(&hid_conn->addr, PROFILE_HID_DEV, CONN_ID_DEFAULT, PRIMARY_ADAPTER, hid_disconnect_handler, hid_conn);
 }
 
 static void hid_disconnected_callback(struct bt_hid_device* hid)
@@ -610,31 +616,20 @@ bt_status_t bt_sal_hid_device_unregister_app(void)
     return BT_STATUS_SUCCESS;
 }
 
-bt_status_t bt_sal_hid_device_connect(bt_address_t* addr)
+static bt_status_t hid_connect_handler(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     sal_bt_hid_device_mgr_t* hid_mgr = &g_hid_device_mgr;
+    struct bt_conn* conn;
     sal_hid_connection_t* hid_conn;
     struct bt_hid_device* hid_device;
-    struct bt_conn* conn;
-    char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
+    bt_status_t status;
 
-    bt_addr_ba2str(addr, addr_str);
-    BT_LOGD("%s, addr:%s", __func__, addr_str);
-
-    hid_conn_lock();
-    hid_conn = hid_find_connection_by_address(addr);
-    if (hid_conn) {
-        BT_LOGE("HID connection already exists for addr: %s", addr_str);
-        hid_conn_unlock();
-        return BT_STATUS_FAIL;
-    }
-
-    hid_conn_unlock();
+    hid_device_on_connection_state_changed(addr, false, PROFILE_STATE_CONNECTING);
 
     conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     if (!conn) {
-        BT_LOGD("No existing connection for address: %s", addr_str);
-        return BT_STATUS_FAIL;
+        status = BT_STATUS_FAIL;
+        goto out;
     }
 
     hid_conn = hid_connection_new(addr, conn);
@@ -642,14 +637,16 @@ bt_status_t bt_sal_hid_device_connect(bt_address_t* addr)
 
     if (!hid_conn) {
         BT_LOGE("Failed to allocate memory for HID connection");
-        return BT_STATUS_NOMEM;
+        status = BT_STATUS_NOMEM;
+        goto out;
     }
 
-    hid_device = Z_API(bt_hid_device_connect)(conn);
+    BT_LOGD("HID device Connecting, addr:%s", bt_addr_bastr(addr));
+    hid_device = Z_API(bt_hid_device_connect)(hid_conn->conn);
     if (!hid_device) {
         BT_LOGE("Failed to connect HID device");
-        hid_connection_free(hid_conn);
-        return BT_STATUS_FAIL;
+        status = BT_STATUS_FAIL;
+        goto out_con;
     }
 
     hid_conn->hid_device = hid_device;
@@ -658,14 +655,69 @@ bt_status_t bt_sal_hid_device_connect(bt_address_t* addr)
     bt_list_add_tail(hid_mgr->connections, hid_conn);
     hid_conn_unlock();
 
-    hid_device_on_connection_state_changed(&hid_conn->addr, false, PROFILE_STATE_CONNECTING);
+    return BT_STATUS_SUCCESS;
+
+out_con:
+    hid_connection_free(hid_conn);
+
+out:
+    hid_device_on_connection_state_changed(addr, false, PROFILE_STATE_DISCONNECTED);
+    return status;
+}
+
+bt_status_t bt_sal_hid_device_connect(bt_address_t* addr)
+{
+    sal_hid_connection_t* hid_conn;
+    bt_status_t status;
+    char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
+
+    bt_addr_ba2str(addr, addr_str);
+    BT_LOGD("%s, addr:%s", __func__, addr_str);
+
+    hid_conn_lock();
+    hid_conn = hid_find_connection_by_address(addr);
+    if (hid_conn) {
+        hid_conn_unlock();
+        BT_LOGE("HID connection already exists for addr: %s", addr_str);
+        return BT_STATUS_FAIL;
+    }
+
+    hid_conn_unlock();
+
+    status = bt_sal_profile_connect_request(addr, PROFILE_HID_DEV, CONN_ID_DEFAULT, PRIMARY_ADAPTER, hid_connect_handler, NULL);
+    if (status != BT_STATUS_SUCCESS) {
+        BT_LOGE("Failed to connect HID profile: %d", status);
+        return BT_STATUS_FAIL;
+    }
+
+    return BT_STATUS_SUCCESS;
+}
+
+static bt_status_t hid_disconnect_handler(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data)
+{
+    sal_hid_connection_t* hid_conn;
+    int ret;
+
+    hid_conn = hid_find_connection_by_address(bd_addr);
+    if (!hid_conn) {
+        BT_LOGE("No HID connection found for addr");
+        return BT_STATUS_FAIL;
+    }
+
+    BT_LOGD("HID disconnect handler, addr:%s", bt_addr_bastr(bd_addr));
+
+    ret = Z_API(bt_hid_device_disconnect)(hid_conn->hid_device);
+    if (ret < 0) {
+        BT_LOGE("Failed to disconnect HID device: %d", ret);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
 bt_status_t bt_sal_hid_device_disconnect(bt_address_t* addr)
 {
     sal_hid_connection_t* hid_conn;
-    int ret;
 
     hid_conn_lock();
     hid_conn = hid_find_connection_by_address(addr);
@@ -677,14 +729,7 @@ bt_status_t bt_sal_hid_device_disconnect(bt_address_t* addr)
 
     hid_conn_unlock();
 
-    /* Disconnect the HID device */
-    ret = Z_API(bt_hid_device_disconnect)(hid_conn->hid_device);
-    if (ret < 0) {
-        BT_LOGE("Failed to disconnect HID device: %d", ret);
-        return BT_STATUS_FAIL;
-    }
-
-    return BT_STATUS_SUCCESS;
+    return bt_sal_profile_disconnect_request(&hid_conn->addr, PROFILE_HID_DEV, CONN_ID_DEFAULT, PRIMARY_ADAPTER, hid_disconnect_handler, NULL);
 }
 
 void bt_sal_hid_device_cleanup()

--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -29,6 +29,7 @@
 #include "spp_service.h"
 #include "utils/log.h"
 
+#include "sal_connection_manager.h"
 #include "sal_interface.h"
 #include "sal_spp_interface.h"
 #include "sal_zblue.h"
@@ -66,6 +67,7 @@ typedef struct {
     bt_address_t addr;
     uint16_t scn;
     uint16_t conn_port;
+    bt_uuid_t uuid;
     bt_list_t* tx_list;
     bt_list_t* rx_list;
 } sal_spp_connection_t;
@@ -137,6 +139,8 @@ sal_spp_manager_t g_spp_manager = {
     .connections = NULL,
     .mutex = PTHREAD_MUTEX_INITIALIZER,
 };
+
+static bt_status_t spp_disconnect_handler(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data);
 
 static inline void spp_conn_lock(void)
 {
@@ -330,6 +334,10 @@ static void spp_rfcomm_connected(struct bt_rfcomm_dlc* rfcomm_dlc)
 
     spp_on_connection_state_changed(&spp_conn->addr, spp_conn->conn_port, PROFILE_STATE_CONNECTED);
     spp_on_connection_mfs_update(spp_conn->conn_port, rfcomm_dlc->mtu);
+
+    bt_sal_cm_profile_connected_callback(cm_data_new(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port));
+    bt_sal_profile_disconnect_register(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port, PRIMARY_ADAPTER, spp_disconnect_handler, spp_conn);
+
     spp_conn_unlock();
 }
 
@@ -367,6 +375,8 @@ static void spp_rfcomm_disconnected(struct bt_rfcomm_dlc* rfcomm_dlc)
     }
 
     spp_on_connection_state_changed(&spp_conn->addr, spp_conn->conn_port, PROFILE_STATE_DISCONNECTED);
+    bt_sal_cm_profile_disconnected_callback(cm_data_new(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port));
+
     do_in_service_loop_deffered(spp_disconnected_defer_handler, rfcomm_dlc, false);
     spp_conn_unlock();
 }
@@ -776,16 +786,74 @@ static bt_status_t spp_connect_with_uuid(sal_spp_connection_t* spp_conn, bt_uuid
     return 0;
 }
 
-bt_status_t bt_sal_spp_connect(bt_address_t* addr, uint16_t conn_port, bt_uuid_t* uuid)
+static bt_status_t spp_connect_handler(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     sal_spp_manager_t* spp_mgr = &g_spp_manager;
+    struct bt_rfcomm_dlc* rfcomm_dlc = (struct bt_rfcomm_dlc*)user_data;
     sal_spp_connection_t* spp_conn;
     struct bt_conn* conn;
+
+    BT_LOGD("%s, rfcomm_dlc: %p", __func__, rfcomm_dlc);
+
+    spp_conn_lock();
+    spp_conn = spp_find_connection_by_dlc(rfcomm_dlc);
+    if (!spp_conn) {
+        spp_conn_unlock();
+        BT_LOGE("SPP connection not found for rfcomm_dlc");
+        return BT_STATUS_FAIL;
+    }
+
+    spp_conn_unlock();
+
+    BT_LOGD("Initiating SPP connection to addr:%s", bt_addr_str(addr));
+    spp_on_connection_state_changed(addr, spp_conn->conn_port, PROFILE_STATE_CONNECTING);
+
+    conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
+    if (!conn) {
+        BT_LOGE("No ACL connection found for address: %s", bt_addr_str(addr));
+        goto fail;
+    }
+
+    spp_conn->conn = conn;
+
+    if (spp_conn->conn_port & 0x3F) {
+        int err;
+
+        err = spp_connect_with_channel(spp_conn, spp_conn->scn);
+        if (err < 0) {
+            BT_LOGE("Failed to connect with scn: %d", err);
+            goto fail;
+        }
+    } else {
+        int err;
+
+        err = spp_connect_with_uuid(spp_conn, &spp_conn->uuid);
+        if (err < 0) {
+            BT_LOGE("Failed to connect with uuid, err: %d", err);
+            goto fail;
+        }
+    }
+
+    spp_conn_lock();
+    bt_list_add_tail(spp_mgr->connections, spp_conn);
+    spp_conn_unlock();
+
+    return BT_STATUS_SUCCESS;
+
+fail:
+    spp_on_connection_state_changed(addr, spp_conn->conn_port, PROFILE_STATE_DISCONNECTED);
+    spp_connection_free(spp_conn);
+    return BT_STATUS_FAIL;
+}
+
+bt_status_t bt_sal_spp_connect(bt_address_t* addr, uint16_t conn_port, bt_uuid_t* uuid)
+{
+    sal_spp_connection_t* spp_conn;
     uint16_t scn = PORT2SCN(conn_port);
     char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
     char uuid_str[40] = { 0 };
     sal_spp_client_t* spp_client;
-    int err;
+    bt_status_t status;
 
     if (!addr || scn > 30) {
         BT_LOGE("Invalid parameters: addr=%p, scn=%d", addr, scn);
@@ -825,57 +893,33 @@ bt_status_t bt_sal_spp_connect(bt_address_t* addr, uint16_t conn_port, bt_uuid_t
         return BT_STATUS_NOMEM;
     }
 
-    conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
-    if (!conn) {
-        BT_LOGE("No ACL connection found for address: %s", addr_str);
-        free(spp_client);
+    spp_conn->spp_client = spp_client;
+    memcpy(&spp_conn->uuid, uuid, sizeof(bt_uuid_t));
+
+    status = bt_sal_profile_connect_request(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port, PRIMARY_ADAPTER, spp_connect_handler, &spp_conn->rfcomm_dlc);
+    if (status != BT_STATUS_SUCCESS) {
+        BT_LOGE("Failed to connect SPP, status: %d", status);
         spp_connection_free(spp_conn);
         return BT_STATUS_FAIL;
     }
 
-    spp_conn->spp_client = spp_client;
-    spp_conn->conn = conn;
-    bt_conn_ref(spp_conn->conn);
-
-    spp_on_connection_state_changed((bt_address_t*)addr, conn_port, PROFILE_STATE_CONNECTING);
-
-    if (conn_port & 0x3F) {
-        err = spp_connect_with_channel(spp_conn, scn);
-        if (err < 0) {
-            BT_LOGE("Failed to connect with scn: %d", err);
-            goto fail;
-        }
-    } else {
-        err = spp_connect_with_uuid(spp_conn, uuid);
-        if (err < 0) {
-            BT_LOGE("Failed to connect with uuid, err: %d", err);
-            goto fail;
-        }
-    }
-
-    spp_conn_lock();
-    bt_list_add_tail(spp_mgr->connections, spp_conn);
-    spp_conn_unlock();
-
     return BT_STATUS_SUCCESS;
-
-fail:
-    spp_on_connection_state_changed((bt_address_t*)addr, conn_port, PROFILE_STATE_DISCONNECTED);
-    spp_connection_free(spp_conn);
-    return BT_STATUS_FAIL;
 }
 
-bt_status_t bt_sal_spp_disconnect(uint16_t conn_port)
+static bt_status_t spp_disconnect_handler(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data)
 {
+    struct bt_rfcomm_dlc* rfcomm_dlc = (struct bt_rfcomm_dlc*)user_data;
     sal_spp_connection_t* spp_conn;
     int ret;
 
+    BT_LOGD("%s, rfcomm_dlc: %p", __func__, rfcomm_dlc);
+
     spp_conn_lock();
-    spp_conn = spp_find_connection_by_port(conn_port);
+    spp_conn = spp_find_connection_by_dlc(rfcomm_dlc);
     if (!spp_conn) {
         spp_conn_unlock();
-        BT_LOGE("No SPP connection found for port %d", conn_port);
-        return BT_STATUS_PARM_INVALID;
+        BT_LOGE("SPP connection not found for rfcomm_dlc");
+        return BT_STATUS_FAIL;
     }
 
     spp_conn_unlock();
@@ -887,8 +931,24 @@ bt_status_t bt_sal_spp_disconnect(uint16_t conn_port)
         return BT_STATUS_FAIL;
     }
 
-    BT_LOGD("SPP connection on port %d disconnecting", conn_port);
     return BT_STATUS_SUCCESS;
+}
+
+bt_status_t bt_sal_spp_disconnect(uint16_t conn_port)
+{
+    sal_spp_connection_t* spp_conn;
+
+    spp_conn_lock();
+    spp_conn = spp_find_connection_by_port(conn_port);
+    if (!spp_conn) {
+        spp_conn_unlock();
+        BT_LOGE("No SPP connection found for port %d", conn_port);
+        return BT_STATUS_PARM_INVALID;
+    }
+
+    spp_conn_unlock();
+
+    return bt_sal_profile_disconnect_request(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port, PRIMARY_ADAPTER, spp_disconnect_handler, &spp_conn->rfcomm_dlc);
 }
 
 bt_status_t bt_sal_spp_data_received_response(uint16_t conn_port, uint8_t* buf)


### PR DESCRIPTION
## Profile Connection Manager API Enhancement

### Summary
This PR refactors the profile connection manager to support multi-connection instances per profile and adds user_data field for better connection context management.

### Key Changes

#### 1. Core API Enhancement (`6fb6d78`, `a4df9ed`)
- **Added `conn_id` parameter**: Enables multiple connection instances per profile
- **Added `user_data` parameter**: Allows passing connection-specific context through callbacks
- **Removed flag-based state tracking**: Replaced with `is_busy` state per connection node
- **Updated handler signature**: `bt_profile_conn_handler_t` now accepts `void* user_data`

```c
// Before
bt_status_t (*bt_profile_conn_handler_t)(bt_controller_id_t id, bt_address_t* addr);

// After
bt_status_t (*bt_profile_conn_handler_t)(bt_controller_id_t id, bt_address_t* addr, void* user_data);
```

#### 2. Profile Adaptations
- **A2DP** (`ebad02c`): Adapted source and sink profiles to new API
- **Adapter** (`7d6eb45`): Updated ACL connection callbacks with conn_id
- **AVRCP** (`1f50220`): Updated controller and target profiles
- **HID Device** (`abf8cca`): Added multi-connection support and user_data handling
- **SPP** (`75ef118`): Added conn_id field and integrated with connection manager

#### 3. Implementation Details

**Connection Manager (`a4df9ed`)**:
- Each handler node now represents a unique connection instance
- Connection identified by `(profile_id, conn_id)` tuple
- Handler lookup optimized with composite key matching
- Automatic ACL disconnect when all profiles are closed

**Profile Integration Pattern**:
```c
// Connection
bt_sal_cm_profile_connected_callback(cm_data_new(&addr, PROFILE_XXX, conn_id));
bt_sal_profile_disconnect_register(&addr, PROFILE_XXX, conn_id, PRIMARY_ADAPTER, 
                                   disconnect_handler, conn_context);

// Disconnection  
bt_sal_cm_profile_disconnected_callback(cm_data_new(&addr, PROFILE_XXX, conn_id));
```

### Benefits
1. **Multiple Connections**: Supports multiple connections per profile (e.g., multiple SPP channels)
2. **Better Context Management**: User data eliminates need for global state lookup
3. **Cleaner Code**: Removed complex flag-based state machine
4. **Type Safety**: Proper connection instance identification

### Testing
- All adapted profiles maintain backward compatibility
- Connection/disconnection flows tested with multi-instance scenarios

---

**Signed-off-by:** zhongzhijie1 <zhongzhijie1@xiaomi.com>