### PR TITLE
fix wrong return branch in zblue_inquiry_eir_name.

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -482,22 +482,26 @@ static bool zblue_inquiry_eir_name(const uint8_t* eir, int len, char* name)
 {
     while (len) {
         if (len < 2) {
-            false;
+            return false;
         }
 
         /* Look for early termination */
         if (!eir[0]) {
-            false;
+            return false;
         }
 
         /* Check if field length is correct */
         if (eir[0] > len - 1) {
-            false;
+            return false;
         }
 
         switch (eir[1]) {
         case BT_DATA_NAME_SHORTENED:
         case BT_DATA_NAME_COMPLETE:
+            if (eir[0] <= 1) {
+                return false;
+            }
+
             memset(name, 0, BT_REM_NAME_MAX_LEN);
             if (eir[0] > BT_REM_NAME_MAX_LEN - 1) {
                 memcpy(name, &eir[2], BT_REM_NAME_MAX_LEN - 1);


### PR DESCRIPTION
bug: v/79125

use correct 'return false;' instead of 'false', and if eir[0] <= 1, means there is no valid name field, need return false.
