### PR TITLE
support bt/ble_sal_cleanup for zblue.

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -577,6 +577,17 @@ void bt_sal_cleanup(void)
 {
 #ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
     bt_sal_cm_conn_cleanup();
+
+    sal_adapter_req_t* req;
+
+    if (bt_is_ready()) {
+        req = sal_adapter_req(PRIMARY_ADAPTER, NULL, STACK_CALL(brder_disable));
+        if (!req) {
+            return BT_STATUS_NOMEM;
+        }
+        sal_send_req(req);
+    }
+
 #endif
 
     bt_sal_hci_transport_cleanup();

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -760,6 +760,19 @@ bt_status_t bt_sal_le_init(const bt_vhal_interface* vhal)
 
 void bt_sal_le_cleanup(void)
 {
+    sal_adapter_req_t* req;
+
+    if (!bt_is_ready()) {
+        return;
+    }
+
+    req = sal_adapter_req(PRIMARY_ADAPTER, NULL, STACK_CALL(le_disable));
+    if (!req) {
+        return BT_STATUS_NOMEM;
+    }
+    sal_send_req(req);
+
+    bt_sal_hci_transport_cleanup();
 }
 
 bt_status_t bt_sal_le_enable(bt_controller_id_t id)


### PR DESCRIPTION
bug: v/79141

kill bluetoothd or qemu reboot, we lost stack clean_up procedure, leading a mess hci receive procedure
buf for real equipment, reboot will reload all mem/ram space, so this problem will not occur.