### PR TITLE
bluetooth: Fix the bluetoothd hang issue.

### DIFF
--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -1830,7 +1830,7 @@ bt_status_t bt_sal_a2dp_source_send_data(bt_controller_id_t id, bt_address_t* re
         return BT_STATUS_PARM_INVALID;
     }
 
-    media_packet_buf = bt_a2dp_stream_create_pdu(&bt_a2dp_tx_pool, K_FOREVER);
+    media_packet_buf = bt_a2dp_stream_create_pdu(&bt_a2dp_tx_pool, K_NO_WAIT);
     if (!media_packet_buf) {
         BT_LOGI("%s, fail to allocate buffer", __func__);
         return BT_STATUS_NOMEM;


### PR DESCRIPTION
bug: v/79594

During music playback, the SAL (Stream Abstraction Layer) sends audio data to the protocol stack depending on the number of buffers available in the pool (CONFIG_BT_MAX_CONN). When no buffers are available, bluetoothd gets stuck due to the K_FOREVER setting used during buffer allocation. Changing K_FOREVER to K_NO_WAIT ensures the bluetoothd thread will not be blocked.



