### PR TITLE
Improve connection manager stability and profile lifecycle handling

### DIFF
--- a/service/stacks/zephyr/include/sal_connection_manager.h
+++ b/service/stacks/zephyr/include/sal_connection_manager.h
@@ -52,8 +52,10 @@ bt_status_t bt_sal_disconnect_internal(bt_controller_id_t id,
     bt_address_t* addr, uint8_t reason);
 
 cm_data_t* cm_data_new(bt_address_t* addr, uint8_t profile_id, uint16_t conn_id);
-void bt_sal_cm_profile_connected_callback(cm_data_t* data);
-void bt_sal_cm_profile_disconnected_callback(cm_data_t* data);
+void bt_sal_cm_profile_connected_callback(bt_address_t* addr, uint8_t profile_id,
+    uint16_t conn_id);
+void bt_sal_cm_profile_disconnected_callback(bt_address_t* addr, uint8_t profile_id,
+    uint16_t conn_id);
 void bt_sal_cm_acl_connected_callback(cm_data_t* data);
 void bt_sal_cm_acl_disconnected_callback(cm_data_t* data);
 

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -79,6 +79,7 @@ struct zblue_a2dp_info_t {
 static bt_list_t* bt_a2dp_conn = NULL;
 
 static void bt_list_remove_a2dp_info(struct zblue_a2dp_info_t* a2dp_info);
+static void bt_sal_a2dp_notify_connected(struct zblue_a2dp_info_t* a2dp_info);
 
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
 static bt_status_t a2dp_source_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data);
@@ -912,6 +913,8 @@ static void zblue_on_stream_established(struct bt_a2dp_stream* stream)
         bt_sal_a2dp_sink_event_callback(a2dp_event_new(CONNECTED_EVT, &a2dp_info->bd_addr));
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
     }
+
+    bt_sal_a2dp_notify_connected(a2dp_info);
 }
 
 static void bt_sal_a2dp_notify_connected(struct zblue_a2dp_info_t* a2dp_info)
@@ -1212,7 +1215,6 @@ static void zblue_on_connected(struct bt_a2dp* a2dp, int err)
     a2dp_info->selected_peer_endpoint = NULL;
 
     bt_list_add_tail(bt_a2dp_conn, a2dp_info);
-    bt_sal_a2dp_notify_connected(a2dp_info);
 }
 
 static void bt_list_remove_a2dp_info(struct zblue_a2dp_info_t* a2dp_info)
@@ -1449,6 +1451,8 @@ static void zblue_on_establish_rsp(struct bt_a2dp_stream* stream, uint8_t rsp_er
         bt_sal_a2dp_sink_event_callback(a2dp_event_new(DISCONNECTED_EVT, &a2dp_info->bd_addr));
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
     }
+
+    bt_sal_a2dp_notify_disconnected(a2dp_info);
 }
 
 static int zblue_on_release_req(struct bt_a2dp_stream* stream, uint8_t* rsp_err_code)

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -918,12 +918,12 @@ static void bt_sal_a2dp_notify_connected(struct zblue_a2dp_info_t* a2dp_info)
 {
     if (a2dp_info->role == SEP_SRC) {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP, CONN_ID_DEFAULT));
+        bt_sal_cm_profile_connected_callback(&a2dp_info->bd_addr, PROFILE_A2DP, CONN_ID_DEFAULT);
         bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP, CONN_ID_DEFAULT, PRIMARY_ADAPTER, a2dp_source_disconnect, NULL);
 #endif
     } else { /* SEP_SNK */
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-        bt_sal_cm_profile_connected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT));
+        bt_sal_cm_profile_connected_callback(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT);
         bt_sal_profile_disconnect_register(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT, PRIMARY_ADAPTER, a2dp_sink_disconnect, NULL);
 #endif
     }
@@ -933,11 +933,11 @@ static void bt_sal_a2dp_notify_disconnected(struct zblue_a2dp_info_t* a2dp_info)
 {
     if (a2dp_info->role == SEP_SRC) {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
-        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP, CONN_ID_DEFAULT));
+        bt_sal_cm_profile_disconnected_callback(&a2dp_info->bd_addr, PROFILE_A2DP, CONN_ID_DEFAULT);
 #endif /* CONFIG_BLUETOOTH_A2DP_SOURCE */
     } else { /* SEP_SNK */
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
-        bt_sal_cm_profile_disconnected_callback(cm_data_new(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT));
+        bt_sal_cm_profile_disconnected_callback(&a2dp_info->bd_addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT);
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
     }
 }

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -1068,7 +1068,6 @@ static void zblue_on_tg_disconnected(struct bt_avrcp_tg* tg)
     msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_target_event_callback(msg);
-    bt_sal_cm_profile_disconnected_callback(&avrcp_info->bd_addr, PROFILE_AVRCP_TG, CONN_ID_DEFAULT);
 #endif
 
     bt_list_remove_avrcp_info(avrcp_info);

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -727,7 +727,7 @@ static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
     msg->data.conn_state.conn_state = PROFILE_STATE_CONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
-    bt_sal_cm_profile_connected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT));
+    bt_sal_cm_profile_connected_callback(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT);
     bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT, PRIMARY_ADAPTER, avrcp_control_disconnect, NULL);
 }
 
@@ -748,7 +748,7 @@ static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
     msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_control_event_callback(msg);
-    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT));
+    bt_sal_cm_profile_disconnected_callback(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT);
 
     bt_list_remove_avrcp_info(avrcp_info);
 }
@@ -1068,7 +1068,7 @@ static void zblue_on_tg_disconnected(struct bt_avrcp_tg* tg)
     msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
     msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
     bt_sal_avrcp_target_event_callback(msg);
-    bt_sal_cm_profile_disconnected_callback(cm_data_new(&avrcp_info->bd_addr, PROFILE_AVRCP_TG, CONN_ID_DEFAULT));
+    bt_sal_cm_profile_disconnected_callback(&avrcp_info->bd_addr, PROFILE_AVRCP_TG, CONN_ID_DEFAULT);
 #endif
 
     bt_list_remove_avrcp_info(avrcp_info);

--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -107,22 +107,11 @@ static void profile_entry_destroy(void* data)
     }
 }
 
-static bt_profile_connection_manager_t* find_or_create_connection_manager(bt_list_t* list, bt_address_t* addr)
+static bt_profile_connection_manager_t* create_connection_manager(bt_address_t* addr)
 {
     bt_profile_connection_manager_t* manager;
 
-    if (!addr || !list) {
-        return NULL;
-    }
-
-    manager = (bt_profile_connection_manager_t*)bt_list_find(list, bt_connection_manager_find, addr);
-
-    if (manager != NULL) {
-        return manager;
-    }
-
-    manager = (bt_profile_connection_manager_t*)zalloc(sizeof(*manager));
-
+    manager = zalloc(sizeof(*manager));
     if (!manager) {
         return NULL;
     }
@@ -132,6 +121,27 @@ static bt_profile_connection_manager_t* find_or_create_connection_manager(bt_lis
     manager->profile_conn_handler_list = bt_list_new(profile_entry_destroy);
     if (!manager->profile_conn_handler_list) {
         free(manager);
+        return NULL;
+    }
+
+    return manager;
+}
+
+static bt_profile_connection_manager_t* find_or_create_connection_manager(bt_list_t* list, bt_address_t* addr)
+{
+    bt_profile_connection_manager_t* manager;
+
+    if (!addr || !list) {
+        return NULL;
+    }
+
+    manager = bt_list_find(list, bt_connection_manager_find, addr);
+    if (manager) {
+        return manager;
+    }
+
+    manager = create_connection_manager(addr);
+    if (!manager) {
         return NULL;
     }
 
@@ -467,13 +477,12 @@ bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair
         return bt_sal_trigger_profile_conn_act(manager, bt_sal_disconnecting_list);
     }
 
-    manager = (bt_profile_connection_manager_t*)zalloc(sizeof(bt_profile_connection_manager_t));
+    manager = create_connection_manager(addr);
     if (!manager) {
         BT_LOGE("%s, malloc failed", __func__);
         return BT_STATUS_NOMEM;
     }
 
-    memcpy(&manager->device_addr, addr, sizeof(bt_address_t));
     manager->is_unpair = is_unpair;
     bt_list_add_tail(bt_sal_disconnecting_list, manager);
 

--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -318,29 +318,6 @@ static void remove_from_connection_manager_list(bt_list_t* list, bt_address_t* a
     }
 }
 
-static void bt_sal_cm_profile_disconnected(void* data)
-{
-    if (data == NULL) {
-        return;
-    }
-
-    cm_data_t* cm_data = data;
-
-    remove_from_connection_manager_list(bt_sal_connecting_list,
-        &cm_data->addr,
-        cm_data->profile_id,
-        cm_data->conn_id,
-        false);
-
-    remove_from_connection_manager_list(bt_sal_disconnecting_list,
-        &cm_data->addr,
-        cm_data->profile_id,
-        cm_data->conn_id,
-        true);
-
-    cm_data_destory(cm_data);
-}
-
 static void bt_sal_cm_acl_connected(void* data)
 {
     if (data == NULL)
@@ -356,21 +333,6 @@ static void bt_sal_cm_acl_connected(void* data)
     if (manager != NULL) {
         bt_sal_trigger_profile_conn_act(manager, bt_sal_connecting_list);
     }
-
-    cm_data_destory(cm_data);
-}
-
-static void bt_sal_cm_profile_connected(void* data)
-{
-    if (data == NULL)
-        return;
-
-    cm_data_t* cm_data = data;
-
-    /*
-     * To avoid generating duplicate profile connect requests for an
-     * already-connected profile, we do not change the manager state.
-     */
 
     cm_data_destory(cm_data);
 }
@@ -408,20 +370,36 @@ static void bt_sal_cm_acl_disconnected(void* data)
     cm_data_destory(cm_data);
 }
 
-void bt_sal_cm_profile_connected_callback(cm_data_t* data)
+void bt_sal_cm_profile_connected_callback(bt_address_t* addr, uint8_t profile_id,
+    uint16_t conn_id)
 {
-    if (data == NULL)
-        return;
-
-    do_in_service_loop(bt_sal_cm_profile_connected, data);
+    /*
+     * To avoid generating duplicate profile connect requests for an
+     * already-connected profile, we do not change the manager state.
+     */
+    return;
 }
 
-void bt_sal_cm_profile_disconnected_callback(cm_data_t* data)
+void bt_sal_cm_profile_disconnected_callback(bt_address_t* addr, uint8_t profile_id,
+    uint16_t conn_id)
 {
-    if (data == NULL)
+    if (!addr) {
         return;
+    }
 
-    do_in_service_loop(bt_sal_cm_profile_disconnected, data);
+    remove_from_connection_manager_list(
+        bt_sal_connecting_list,
+        addr,
+        profile_id,
+        conn_id,
+        false);
+
+    remove_from_connection_manager_list(
+        bt_sal_disconnecting_list,
+        addr,
+        profile_id,
+        conn_id,
+        true);
 }
 
 void bt_sal_cm_acl_connected_callback(cm_data_t* data)

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -453,7 +453,7 @@ static void zblue_on_connected(struct bt_conn* conn, struct bt_hfp_hf* hf)
 
         hfp_hf_on_connection_state_changed(&bd_addr, PROFILE_STATE_CONNECTING, 0, 0);
     }
-    bt_sal_cm_profile_connected_callback(cm_data_new(&bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT));
+    bt_sal_cm_profile_connected_callback(&bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
     bt_sal_profile_disconnect_register(&bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT, PRIMARY_ADAPTER, do_hf_disconnect, NULL);
 
     hfp_hf_on_connection_state_changed(&bd_addr, PROFILE_STATE_CONNECTED, 0, 0);

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -431,6 +431,7 @@ static uint8_t zblue_on_sdp_done(struct bt_conn* conn, struct bt_sdp_client_resu
 
 error:
     hfp_hf_on_connection_state_changed(&bd_addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+    bt_sal_cm_profile_disconnected_callback(&bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
     return BT_SDP_DISCOVER_UUID_STOP;
 }
 
@@ -470,6 +471,7 @@ static void zblue_hf_disconnected(struct bt_hfp_hf* hf)
 
     hfp_hf_on_connection_state_changed(bd_addr, PROFILE_STATE_DISCONNECTING, 0, 0);
     hfp_hf_on_connection_state_changed(bd_addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+    bt_sal_cm_profile_disconnected_callback(bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
 
     bt_list_remove(g_sal_hf_conn_list, conn);
 }

--- a/service/stacks/zephyr/sal_hid_device_interface.c
+++ b/service/stacks/zephyr/sal_hid_device_interface.c
@@ -426,7 +426,7 @@ static void hid_connect_callback(struct bt_hid_device* hid)
     hid_conn_unlock();
     hid_device_on_connection_state_changed(&hid_conn->addr, false, PROFILE_STATE_CONNECTED);
 
-    bt_sal_cm_profile_connected_callback(cm_data_new(&hid_conn->addr, PROFILE_HID_DEV, CONN_ID_DEFAULT));
+    bt_sal_cm_profile_connected_callback(&hid_conn->addr, PROFILE_HID_DEV, CONN_ID_DEFAULT);
     bt_sal_profile_disconnect_register(&hid_conn->addr, PROFILE_HID_DEV, CONN_ID_DEFAULT, PRIMARY_ADAPTER, hid_disconnect_handler, hid_conn);
 }
 

--- a/service/stacks/zephyr/sal_hid_device_interface.c
+++ b/service/stacks/zephyr/sal_hid_device_interface.c
@@ -445,6 +445,7 @@ static void hid_disconnected_callback(struct bt_hid_device* hid)
     }
 
     hid_device_on_connection_state_changed(&hid_conn->addr, false, PROFILE_STATE_DISCONNECTED);
+    bt_sal_cm_profile_disconnected_callback(&hid_conn->addr, PROFILE_HID_DEV, CONN_ID_DEFAULT);
     bt_list_remove(g_hid_device_mgr.connections, hid_conn);
     hid_conn_unlock();
 }
@@ -662,6 +663,7 @@ out_con:
 
 out:
     hid_device_on_connection_state_changed(addr, false, PROFILE_STATE_DISCONNECTED);
+    bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HID_DEV, CONN_ID_DEFAULT);
     return status;
 }
 

--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -829,6 +829,7 @@ static bt_status_t spp_connect_handler(bt_controller_id_t id, bt_address_t* addr
 
 fail:
     spp_on_connection_state_changed(addr, spp_conn->conn_port, PROFILE_STATE_DISCONNECTED);
+    bt_sal_cm_profile_disconnected_callback(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port);
     spp_connection_free(spp_conn);
     return BT_STATUS_FAIL;
 }

--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -335,7 +335,7 @@ static void spp_rfcomm_connected(struct bt_rfcomm_dlc* rfcomm_dlc)
     spp_on_connection_state_changed(&spp_conn->addr, spp_conn->conn_port, PROFILE_STATE_CONNECTED);
     spp_on_connection_mfs_update(spp_conn->conn_port, rfcomm_dlc->mtu);
 
-    bt_sal_cm_profile_connected_callback(cm_data_new(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port));
+    bt_sal_cm_profile_connected_callback(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port);
     bt_sal_profile_disconnect_register(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port, PRIMARY_ADAPTER, spp_disconnect_handler, spp_conn);
 
     spp_conn_unlock();
@@ -375,7 +375,7 @@ static void spp_rfcomm_disconnected(struct bt_rfcomm_dlc* rfcomm_dlc)
     }
 
     spp_on_connection_state_changed(&spp_conn->addr, spp_conn->conn_port, PROFILE_STATE_DISCONNECTED);
-    bt_sal_cm_profile_disconnected_callback(cm_data_new(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port));
+    bt_sal_cm_profile_disconnected_callback(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port);
 
     do_in_service_loop_deffered(spp_disconnected_defer_handler, rfcomm_dlc, false);
     spp_conn_unlock();

--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -789,21 +789,8 @@ static bt_status_t spp_connect_with_uuid(sal_spp_connection_t* spp_conn, bt_uuid
 static bt_status_t spp_connect_handler(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
     sal_spp_manager_t* spp_mgr = &g_spp_manager;
-    struct bt_rfcomm_dlc* rfcomm_dlc = (struct bt_rfcomm_dlc*)user_data;
-    sal_spp_connection_t* spp_conn;
+    sal_spp_connection_t* spp_conn = (sal_spp_connection_t*)user_data;
     struct bt_conn* conn;
-
-    BT_LOGD("%s, rfcomm_dlc: %p", __func__, rfcomm_dlc);
-
-    spp_conn_lock();
-    spp_conn = spp_find_connection_by_dlc(rfcomm_dlc);
-    if (!spp_conn) {
-        spp_conn_unlock();
-        BT_LOGE("SPP connection not found for rfcomm_dlc");
-        return BT_STATUS_FAIL;
-    }
-
-    spp_conn_unlock();
 
     BT_LOGD("Initiating SPP connection to addr:%s", bt_addr_str(addr));
     spp_on_connection_state_changed(addr, spp_conn->conn_port, PROFILE_STATE_CONNECTING);
@@ -896,7 +883,7 @@ bt_status_t bt_sal_spp_connect(bt_address_t* addr, uint16_t conn_port, bt_uuid_t
     spp_conn->spp_client = spp_client;
     memcpy(&spp_conn->uuid, uuid, sizeof(bt_uuid_t));
 
-    status = bt_sal_profile_connect_request(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port, PRIMARY_ADAPTER, spp_connect_handler, &spp_conn->rfcomm_dlc);
+    status = bt_sal_profile_connect_request(&spp_conn->addr, PROFILE_SPP, spp_conn->conn_port, PRIMARY_ADAPTER, spp_connect_handler, spp_conn);
     if (status != BT_STATUS_SUCCESS) {
         BT_LOGE("Failed to connect SPP, status: %d", status);
         spp_connection_free(spp_conn);


### PR DESCRIPTION
This PR addresses several connection manager and profile lifecycle issues discovered through crash analysis and connection flow testing.

**Issue 1: Uninitialized profile handler list in CM manager (v/79367)**

Root Cause:
In bt_sal_cm_try_disconnect_profiles(), a connection manager was directly allocated 
and added to the disconnecting list without initializing profile_conn_handler_list.
When bt_connection_manager_find() successfully matched this manager by device address,
subsequent operations like bt_list_is_empty() would access the NULL handler list,
causing assertion failures and use-after-free crashes.

Fix:
Extract create_connection_manager() to ensure profile_conn_handler_list is always 
initialized before adding manager to any list.

**Issue 2: Missing disconnect callbacks breaking CM state tracking (v/79519)**

Root Cause:
Profile stack callbacks (A2DP/AVRCP/HFP/HID/SPP) were not consistently invoking
bt_sal_cm_profile_disconnected_callback() on disconnection events. This violated
the service callback pattern and left stale entries in the connection manager,
preventing proper cleanup and causing state inconsistencies.

Fix:
Add missing disconnect callbacks to all profile disconnect paths to properly
notify connection manager and trigger cleanup.

**Issue 3: SPP connection lookup failure (v/79519)**

Root Cause:
spp_connect_handler() attempted to lookup SPP connection by rfcomm_dlc before
the connection object was added to the global connection list, causing
spp_find_connection_by_dlc() to always fail with "connection not found" error.

Fix:
Pass spp_conn pointer directly as user_data to avoid premature lookup, and add
connection to list only after successful initialization.

**Issue 4: Race condition in async CM callbacks (v/80258)**

Root Cause:
CM profile callbacks were dispatched asynchronously via service_worker, but the
cm_data_t* parameter lifetime was not properly managed. The data could be freed
before the async callback executed, leading to use-after-free issues.

Fix:
Make CM profile connected/disconnected callbacks synchronous by removing async
dispatch and accessing manager state directly in calling context.

Signed-off-by: zhongzhijie1 <zhongzhijie1@xiaomi.com>
Signed-off-by: Kai Cheng <chengkai@xiaomi.com>