### PR TITLE
Bluetooth: Sal: initlize device before using it.

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -540,7 +540,7 @@ static bool zblue_inquiry_eir_name(const uint8_t* eir, int len, char* name)
 
 static void zblue_on_discovery_recv_cb(const struct bt_br_discovery_result* results)
 {
-    bt_discovery_result_t device;
+    bt_discovery_result_t device = { 0 };
 
     memcpy(device.addr.addr, &results->addr, 6);
     device.rssi = results->rssi;


### PR DESCRIPTION
bug: v/74408

Rootcause: var device not initlized before using.
