### PR TITLE
remove connection state check in security changed callback

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -305,11 +305,6 @@ static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,
         return;
     }
 
-    if (info.state != BT_CONN_STATE_CONNECTED) {
-        BT_LOGD("%s, not CONNECTED", __func__);
-        return;
-    }
-
     bt_addr_set(&addr, info.br.dst->val);
 
     BT_LOGD("%s, level: %d, required level: %d, err: %d", __func__, level, g_security_level, err);


### PR DESCRIPTION
bug: v/78493

rootcause:
ACL state changes can occur before security changes, causing the BT_CONN_STATE_CONNECTED check to incorrectly skip bond key removal when authentication fails.

Remove the state guard to ensure failed bond keys are always cleaned up via bt_br_unpair() and bond state changes are properly reported, regardless of current connection state.