### PR TITLE
always report BONDED on pairing_complete callbacks

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -137,6 +137,7 @@ static void zblue_on_cancel(struct bt_conn* conn);
 static void zblue_on_pairing_confirm(struct bt_conn* conn);
 static void zblue_on_pincode_entry(struct bt_conn* conn, bool highsec);
 static void zblue_on_br_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_key);
+static void zblue_on_br_pairing_complete(struct bt_conn* conn, bool bonding_flag);
 static void zblue_on_br_pairing_failed(struct bt_conn* conn, enum bt_security_err reason);
 static void zblue_on_br_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
 static void zblue_register_callback(void);
@@ -172,6 +173,7 @@ static struct bt_settings_zblue_cb g_setting_cbs = {
 #endif
 
 static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
+    .pairing_complete = zblue_on_br_pairing_complete,
     .pairing_complete_ctkd = zblue_on_br_pairing_complete_ctkd,
     .pairing_failed = zblue_on_br_pairing_failed,
     .bond_deleted = zblue_on_br_bond_deleted,
@@ -462,7 +464,6 @@ static int zblue_on_link_key_notify(uint8_t dev_id, bt_addr_le_t* addr, const ch
     key_type = link_key->key_type;
     free(link_key);
 
-    adapter_on_bond_state_changed(&br_addr, BOND_STATE_BONDED, BT_TRANSPORT_BREDR, BT_STATUS_SUCCESS, false);
     adapter_on_link_key_update(&br_addr, key, key_type);
     return 0;
 }
@@ -508,6 +509,20 @@ static int zblue_on_link_key_load(bt_addr_le_t* addr, uint8_t* key_value, uint8_
     return value_len;
 }
 #endif
+
+static void zblue_on_br_pairing_complete(struct bt_conn* conn, bool bonding_flag)
+{
+    bt_address_t addr;
+
+    if (!bt_conn_get_dst_br(conn)) {
+        return;
+    }
+
+    BT_LOGD("%s bonding_flag: %s", __func__, bonding_flag ? "true" : "false");
+
+    zblue_conn_get_addr(conn, &addr);
+    adapter_on_bond_state_changed(&addr, BOND_STATE_BONDED, BT_TRANSPORT_BREDR, BT_STATUS_SUCCESS, false);
+}
 
 static void zblue_on_br_pairing_failed(struct bt_conn* conn, enum bt_security_err reason)
 {

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -83,7 +83,7 @@ static void zblue_on_disconnected(struct bt_conn* conn, uint8_t reason);
 static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level, enum bt_security_err err);
 static void zblue_on_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_key);
 #endif
-static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded);
+static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonding_flag);
 static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err reason);
 static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
 static void zblue_convert_le_addr(bt_address_t* addr, ble_addr_type_t type, bt_addr_le_t* le_addr);
@@ -708,25 +708,22 @@ static void zblue_on_pairing_complete_ctkd(struct bt_conn* conn, bool is_link_ke
 #endif
 }
 
-static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonded)
+static void zblue_on_pairing_complete(struct bt_conn* conn, bool bonding_flag)
 {
     bt_address_t addr;
-    bond_state_t state;
 
-    BT_LOGD("%s", __func__);
+    if (!bt_conn_get_dst(conn)) {
+        return;
+    }
 
     if (get_le_addr_from_conn(conn, &addr) != BT_STATUS_SUCCESS) {
         BT_LOGE("%s, get_le_addr_from_conn failed", __func__);
         return;
     }
 
-    if (bonded) {
-        state = BOND_STATE_BONDED;
-    } else {
-        state = BOND_STATE_NONE;
-    }
+    BT_LOGD("%s bonding_flag: %s", __func__, bonding_flag ? "true" : "false");
 
-    adapter_on_bond_state_changed(&addr, state, BT_TRANSPORT_BLE, BT_STATUS_SUCCESS, false);
+    adapter_on_bond_state_changed(&addr, BOND_STATE_BONDED, BT_TRANSPORT_BLE, BT_STATUS_SUCCESS, false);
 }
 
 static void zblue_on_pairing_failed(struct bt_conn* conn, enum bt_security_err reason)


### PR DESCRIPTION
bug: v/80684

Treat pairing_complete as a successful bonding result and always report BOND_STATE_BONDED to upper layers for both BR/EDR and BLE.

The business logic doesn't need to distinguish the no_bonding state. This behavior is consistent with the legacy Bluetooth stack.

Also remove bond state reporting from link_key_notify and rely on pairing_complete to deliver bond state updates.