### PR TITLE
Bluetooth: Prevent crash when calling uv_run after event loop closure.

### DIFF
--- a/framework/common/uv_thread_loop.c
+++ b/framework/common/uv_thread_loop.c
@@ -223,8 +223,10 @@ void thread_loop_exit(uv_loop_t* loop)
         uv_sem_wait(&priv->exited);
         uv_sem_destroy(&priv->exited);
     } else {
-        uv_run(loop, UV_RUN_ONCE);
-        (void)uv_loop_close(loop);
+        if (!uv_loop_is_close(loop)) {
+            uv_run(loop, UV_RUN_ONCE);
+            (void)uv_loop_close(loop);
+        }
     }
 
     uv_mutex_lock(&priv->msg_lock);

--- a/service/common/service_loop.c
+++ b/service/common/service_loop.c
@@ -287,8 +287,10 @@ void service_loop_exit(void)
         uv_sem_wait(&loop->exited);
         uv_sem_destroy(&loop->exited);
     } else {
-        uv_run(handle, UV_RUN_ONCE);
-        (void)uv_loop_close(handle);
+        if (!uv_loop_is_close(handle)) {
+            uv_run(handle, UV_RUN_ONCE);
+            (void)uv_loop_close(handle);
+        }
     }
 
     uv_mutex_lock(&loop->msg_lock);


### PR DESCRIPTION
bug: V/80385

Rootcause: uv_loop_close() marks internal data structures as invalid (e.g., set to -1), but pending callbacks in the queue still reference these invalidated structures. When uv_run() is called later, it processes the queue using corrupted pointers, leading to segmentation faults and crashes. Solution: Introduce a new flag in uv_loop_close() to mark the loop as closed and check it in uv_run() and other loop-related functions to prevent execution of callbacks after closure, ensuring memory safety and avoiding invalid pointer access.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

