### PR TITLE
SPP: Fix race condition crash by unifying thread context for resource cleanup

### DIFF
--- a/framework/common/uv_thread_loop.c
+++ b/framework/common/uv_thread_loop.c
@@ -223,10 +223,8 @@ void thread_loop_exit(uv_loop_t* loop)
         uv_sem_wait(&priv->exited);
         uv_sem_destroy(&priv->exited);
     } else {
-        if (!uv_loop_is_close(loop)) {
-            uv_run(loop, UV_RUN_ONCE);
-            (void)uv_loop_close(loop);
-        }
+        uv_run(loop, UV_RUN_ONCE);
+        (void)uv_loop_close(loop);
     }
 
     uv_mutex_lock(&priv->msg_lock);

--- a/service/common/service_loop.c
+++ b/service/common/service_loop.c
@@ -287,10 +287,8 @@ void service_loop_exit(void)
         uv_sem_wait(&loop->exited);
         uv_sem_destroy(&loop->exited);
     } else {
-        if (!uv_loop_is_close(handle)) {
-            uv_run(handle, UV_RUN_ONCE);
-            (void)uv_loop_close(handle);
-        }
+        uv_run(handle, UV_RUN_ONCE);
+        (void)uv_loop_close(handle);
     }
 
     uv_mutex_lock(&loop->msg_lock);

--- a/tools/async/gap.c
+++ b/tools/async/gap.c
@@ -259,6 +259,7 @@ static bool g_cmd_had_inited = false;
 extern bt_instance_t* g_bttool_ins;
 extern bool g_auto_accept_pair;
 extern bond_state_t g_bond_state;
+extern uv_loop_t* g_bttool_loop;
 
 static void status_cb(bt_instance_t* ins, bt_status_t status, void* userdata)
 {
@@ -1627,7 +1628,12 @@ static void ipc_disconnected(bt_instance_t* ins, void* userdata, int status)
 
 int bttool_async_ins_init(bttool_t* bttool)
 {
-    g_bttool_ins = bluetooth_create_async_instance(&bttool->loop, ipc_connected, ipc_disconnected, (void*)bttool);
+    if (g_bttool_loop == NULL) {
+        PRINT("%s: g_bttool_loop is not initialized", __func__);
+        return -1;
+    }
+
+    g_bttool_ins = bluetooth_create_async_instance(g_bttool_loop, ipc_connected, ipc_disconnected, (void*)bttool);
     if (g_bttool_ins == NULL) {
         PRINT("create instance error\n");
         return -1;

--- a/tools/bt_tools.c
+++ b/tools/bt_tools.c
@@ -81,12 +81,14 @@ static int stop_service_cmd(void* handle, int argc, char** argv);
 static int set_phy_cmd(void* handle, int argc, char** argv);
 static int dump_cmd(void* handle, int argc, char** argv);
 static int quit_cmd(void* handle, int argc, char** argv);
+static void bttool_ins_uninit(bttool_t* bttool);
 
 bt_instance_t* g_bttool_ins = NULL;
 static void* adapter_callback = NULL;
 static bool g_cmd_had_inited = false;
 bool g_auto_accept_pair = true;
 bond_state_t g_bond_state = BOND_STATE_NONE;
+uv_loop_t* g_bttool_loop = NULL;
 
 static struct {
     int cmd_err_code;
@@ -1595,6 +1597,17 @@ static int execute_command(void* handle, int argc, char* argv[])
     return CMD_UNKNOWN;
 }
 
+static void bt_tool_uninit_cb(void* data)
+{
+    bttool_ins_uninit(NULL);
+
+    if (g_bttool_loop) {
+        uv_loop_close(g_bttool_loop);
+        free(g_bttool_loop);
+        g_bttool_loop = NULL;
+    }
+}
+
 static void on_adapter_state_changed_cb(void* cookie, bt_adapter_state_t state)
 {
     PRINT("Context:%p, Adapter state changed: %d", cookie, state);
@@ -1616,7 +1629,9 @@ static void on_adapter_state_changed_cb(void* cookie, bt_adapter_state_t state)
         PRINT("Adapter Name: %s, Cap: %d, Class: 0x%08" PRIX32 ", Mode:%d", name, cap, class, mode);
     } else if (state == BT_ADAPTER_STATE_TURNING_OFF) {
         /* code */
-        bt_tool_uninit(g_bttool_ins);
+        if (g_bttool_loop && g_bttool_loop->data && !uv_loop_is_close(g_bttool_loop)) {
+            do_in_thread_loop(g_bttool_loop, bt_tool_uninit_cb, NULL);
+        }
     } else if (state == BT_ADAPTER_STATE_OFF) {
         /* do something */
     }
@@ -1878,10 +1893,12 @@ static void bttool_command_uvloop_run(bttool_t* bttool)
     int ret;
 
     /* This code is used to initialize the async queue. */
-    ret = uv_async_queue_init(&bttool->loop, &bttool->async, bttool_execute_command_cb);
+    ret = uv_async_queue_init(g_bttool_loop, &bttool->async, bttool_execute_command_cb);
     if (ret != 0) {
         PRINT("%s async error: %d", __func__, ret);
-        uv_loop_close(&bttool->loop);
+        uv_loop_close(g_bttool_loop);
+        free(g_bttool_loop);
+        g_bttool_loop = NULL;
         return;
     }
 
@@ -1889,23 +1906,30 @@ static void bttool_command_uvloop_run(bttool_t* bttool)
     uv_sem_post(&bttool->ready);
 
     /* This code is used to start the event loop until there are no more events to process. */
-    uv_run(&bttool->loop, UV_RUN_DEFAULT);
+    uv_run(g_bttool_loop, UV_RUN_DEFAULT);
 
     /* The assert() function is used to check the return value of uv_loop_close().
        If the return value is 0, it means that the loop is closed successfully,
        otherwise it means an error occurs.
     */
-    assert(uv_loop_close(&bttool->loop) == 0);
+    if (g_bttool_loop) {
+        assert(uv_loop_close(g_bttool_loop) == 0);
+        free(g_bttool_loop);
+        g_bttool_loop = NULL;
+    }
 }
 
 static void bttool_thread(void* data)
 {
     bttool_t* bttool = data;
 
-    /* Initialize the event loop, the loop is available
-       before the asynchronous instance is created.
+    /* g_bttool_loop is now initialized in main() function
+       before the thread starts, so it's already available here.
     */
-    uv_loop_init(&bttool->loop);
+    if (!g_bttool_loop) {
+        PRINT("%s: g_bttool_loop is not initialized", __func__);
+        return;
+    }
 
     /* initialize synchronous or asynchronous instance.
        and register callbacks.
@@ -1987,11 +2011,29 @@ int main(int argc, char** argv)
         }
     }
 
+    g_bttool_loop = zalloc(sizeof(uv_loop_t));
+    if (!g_bttool_loop) {
+        PRINT("%s: Failed to allocate uv_loop_t", __func__);
+        return -1;
+    }
+
+    ret = uv_loop_init(g_bttool_loop);
+    if (ret != 0) {
+        PRINT("%s: Failed to init uv_loop: %d", __func__, ret);
+        free(g_bttool_loop);
+        g_bttool_loop = NULL;
+        return -1;
+    }
+
     // Call the bttool_create_thread function to create a new thread
     // If thread creation fails, the return value is non-zero
     ret = bttool_create_thread(&bttool);
-    if (ret != 0)
+    if (ret != 0) {
+        uv_loop_close(g_bttool_loop);
+        free(g_bttool_loop);
+        g_bttool_loop = NULL;
         return ret;
+    }
 
     while (1) {
         printf("bttool> ");
@@ -2025,6 +2067,12 @@ int main(int argc, char** argv)
     }
 
     uv_thread_join(&bttool.thread);
+
+    if (g_bttool_loop) {
+        uv_loop_close(g_bttool_loop);
+        free(g_bttool_loop);
+        g_bttool_loop = NULL;
+    }
 
     return 0;
 }

--- a/tools/bt_tools.h
+++ b/tools/bt_tools.h
@@ -78,7 +78,6 @@
  * Public Types
  ****************************************************************************/
 typedef struct {
-    uv_loop_t loop;
     uv_async_queue_t async;
     uv_thread_t thread;
     uv_sem_t ready;


### PR DESCRIPTION
… access

bug : v/80850

Rootcause: uv_loop_close() marks internal data structures as invalid, but pending callbacks in the queue still reference these invalidated structures. When uv_run() is called later, it processes the queue using corrupted pointers, leading to segmentation faults and crashes.

Solution:To address the issues described above, the solution removes uv_loop_t from the bttool_t struct and changes it to dynamic allocation, introducing a global pointer g_bttool_loop to centrally manage its lifecycle. Specific modifications include: dynamically allocating and initializing the uv_loop_t instance within the bttool_thread function and assigning it to the global pointer; modifying the bttool_command_uvloop_run function to operate using the global g_bttool_loop pointer; and adjusting the asynchronous API initialization logic in async/gap.c to ensure it uses the global pointer instead of a local pointer. Furthermore, the solution enhances error handling, ensuring proper resource cleanup if memory allocation fails, and optimizes the bt_tool_uninit_cb function to prevent premature clearing of the global pointer, which could lead to access exceptions.
