### PR TITLE
bluetooth: Fix resource leak issues when initializing the client with…

### DIFF
--- a/service/ipc/socket/src/bt_socket_client.c
+++ b/service/ipc/socket/src/bt_socket_client.c
@@ -724,6 +724,7 @@ int bt_socket_async_client_init(bt_instance_t* ins, uv_loop_t* loop, int family,
     if (priv == NULL)
         return BT_STATUS_NOMEM;
 
+    ins->priv = priv;
     priv->user_data = user_data;
     priv->loop = loop;
     priv->ins = ins;
@@ -762,8 +763,6 @@ int bt_socket_async_client_init(bt_instance_t* ins, uv_loop_t* loop, int family,
             goto fail;
         }
     }
-
-    ins->priv = priv;
 
     return BT_STATUS_SUCCESS;
 fail:


### PR DESCRIPTION
… an asynchronous API.

bug: v/81682

When priv dynamically allocates memory successfully but fails later due to other reasons before reaching the assignment ins->priv = priv;, the memory allocated to priv cannot be freed in bt_socket_async_client_deinit, leading to a resource leak.