### PR TITLE
Supports user confirmation during Just Work pairing in the app.

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -850,7 +850,11 @@ bt_status_t bt_sal_set_io_capability(bt_controller_id_t id, bt_io_capability_t c
     default:
         g_conn_auth_cbs.passkey_display = NULL;
         g_conn_auth_cbs.passkey_entry = NULL;
+#ifdef CONFIG_HCI_AUTO_REPLY_IN_JUST_WORK
         g_conn_auth_cbs.passkey_confirm = NULL;
+#else
+        g_conn_auth_cbs.passkey_confirm = zblue_on_passkey_confirm;
+#endif
         g_conn_auth_cbs.pairing_confirm = NULL;
         break;
     }


### PR DESCRIPTION
depends-on: [open-vela/external_zblue/pull/140]

bug: v/81924

By default, just working (no I/O) should automatically accept user confirmation, but for compatibility with the watch app, app confirmation is required.

