### PR TITLE
Preserve UUID type, fix CCC write request_id, use real stack handles for async ops

### DIFF
--- a/service/profiles/gatt/gatts_service.c
+++ b/service/profiles/gatt/gatts_service.c
@@ -652,8 +652,7 @@ static bt_status_t if_gatts_add_attr_table(void* srv_handle, gatt_srv_db_t* srv_
             memcpy(elements->attr_data, attr_inst->attr_value, elements->attr_length);
         }
 
-        elements->uuid.type = BT_UUID128_TYPE;
-        bt_uuid_to_uuid128(&attr_inst->uuid, &elements->uuid);
+        memcpy(&elements->uuid, &attr_inst->uuid, sizeof(bt_uuid_t));
     }
     svc_table->start_handle = svc_table->elements[0].handle;
     svc_table->end_handle = svc_table->elements[svc_table->element_size - 1].handle;


### PR DESCRIPTION
**PR Description**

- Preserve the UUID type provided by the app (do not force-convert to 128-bit)
  - Root cause: The previous design converted all `bt_uuid` parameters to 128-bit unconditionally. When adding GATT services/attributes, `uuid_type` matters.
  - Impact: If a 16-bit UUID is registered as a 128-bit UUID, some GATT clients that only perform “discover by UUID” with 16-bit UUIDs may fail to find the service.
  - Change: Copy `bt_uuid_t` as-is into service table elements instead of converting everything to `BT_UUID128_TYPE`.

- Use `REQUEST_ID_NORSP` for CCC write callback
  - Rationale: `ccc_on_write` does not use a deferred response design, so it does not require a request type that implies a response.
  - Change: Report CCC writes with `REQUEST_ID_NORSP` instead of a write request opcode.

- Reply/track using real GATT handles from the protocol stack (not encoded service element handles)
  - Root cause: The stack uses the actual ATT handle value, while framework/service code uses a handle encoded with clientID. This can break request/response correlation for async operations.
  - Change: Build `request_id` using `attr->handle` (real stack handle) for async read/write request tracking.