### PR TITLE
gatts: Fix the issue of GATTs sending two write responses.

### DIFF
--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -446,7 +446,8 @@ static ssize_t bt_sal_on_ccc_written(struct bt_conn* conn, const struct bt_gatt_
     if_gatts_on_received_element_write_request(&addr, GATT_OPS_WRITE_REQUEST,
         element->handle, (uint8_t*)&value, 0, sizeof(value));
 
-    return ret;
+    // framework response
+    return -EINPROGRESS;
 }
 
 static int alloc_descriptor(const struct bt_gatt_attr* attr, struct add_descriptor* desc)


### PR DESCRIPTION
bug: v/83303

When the stack receives an att_write_req, it calls attr->write(). If the return value from SAL is -EINPROGRESS, the stack does not send a response, as the response will be handled by the service. Otherwise, the stack sends a response. In the SAL layer, bt_sal_on_ccc_written notifies the service, which then calls bt_sal_gatt_server_send_response. Since the return value from SAL is not -EINPROGRESS, the stack also sends a response, causing a conflict.

