### PR TITLE
SPP: Fix `spp_device_cleanup` to handle device closure when bluetooth…

### DIFF
--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -437,6 +437,18 @@ static void spp_device_cleanup(spp_device_t* device, bool notify)
         spp_notify_connection_state(device, PROFILE_STATE_DISCONNECTED);
 
     BT_LOGD("%s, spp device conn_id: %" PRIu16 ", proxy_state: %d", __func__, device->conn_id, device->proxy_state);
+    if (!g_spp_handle.started) {
+        /* cleanup device directly */
+        if (device->handle) {
+            euv_pipe_close(device->handle);
+            device->handle = NULL;
+        }
+
+        spp_device_close(device);
+        remove_spp_device(device);
+        return;
+    }
+
     switch (device->proxy_state) {
     case SPP_PROXY_STATE_CONNECTING:
         /* wait for proxy connected and enter closing state */


### PR DESCRIPTION
… shutdown

bug: v/83593

Rootcause: Should an SPP disconnection occur whilst the SPP Service's Proxy remains unconnected, the SPP Service's connection instance (SPP device) shall mark the Proxy as closing. It shall await successful establishment of the SPP Proxy connection before executing the SPP device release procedure.

However, during this process, if the Bluetooth shutdown procedure is triggered before the Proxy connection succeeds, the SPP Service will enter its resource clean-up phase. Consequently, when the Proxy connection callback is invoked, attempting to locate the SPP device will yield a null pointer, resulting in a crash due to accessing a zero address.

