### PR TITLE
Bluetooth: Fixed an issue where resources could not be released after…

### DIFF
--- a/framework/common/euv_pipe.c
+++ b/framework/common/euv_pipe.c
@@ -203,6 +203,16 @@ int euv_pipe_read_start(euv_pipe_t* handle, uint16_t read_size, euv_read_cb read
     euv_read_t* reader;
     int ret;
 
+    if (!handle) {
+        BT_LOGE("%s, handle null", __func__);
+        return -EINVAL;
+    }
+
+    if (uv_is_closing((uv_handle_t*)&handle->cli_pipe)) {
+        BT_LOGE("%s, handle %p is closing", __func__, handle);
+        return -EPERM;
+    }
+
     if (uv_is_active((uv_handle_t*)&handle->cli_pipe)) {
         BT_LOGE("%s, client is active", __func__);
         return 0;
@@ -236,6 +246,12 @@ int euv_pipe_read_stop(euv_pipe_t* handle)
         return -EINVAL;
     }
 
+    if (uv_is_closing((uv_handle_t*)&handle->cli_pipe)) {
+        /* uv_pipe is closing; cli_pipe.data has been set to handle for cleanup, so don't free it here */
+        BT_LOGE("%s, handle %p is closing", __func__, handle);
+        return -EPERM;
+    }
+
     if (handle->cli_pipe.data) {
         free(handle->cli_pipe.data);
         handle->cli_pipe.data = NULL;
@@ -243,11 +259,6 @@ int euv_pipe_read_stop(euv_pipe_t* handle)
 
     if (!uv_is_active((uv_handle_t*)&handle->cli_pipe)) {
         BT_LOGW("%s, cli_pipe is inactive", __func__);
-        return 0;
-    }
-
-    if (uv_is_closing((uv_handle_t*)&handle->cli_pipe)) {
-        BT_LOGE("%s, uv_is_closing", __func__);
         return 0;
     }
 


### PR DESCRIPTION
… closing uv_pipe in euv_pipe.

bug: v/83955

Rootcause: euv_pipe_close records the address of the euv_pipe in the data field of each uv_pipe instance to be closed, which is used to release the euv_pipe instance after the close operation completes.

A scenario exists where calling euv_pipe_close followed by euv_pipe_read_stop or euv_pipe_read_start causes the client pipe's data field to be reset to NULL or the reader's address. This prevents the euv_pipe instance from being released after close completes.

This occurs because `euv_pipe_read_stop` does not check the uv_pipe's state before directly freeing `cli_pipe.data`, while `euv_pipe_read_start` only verifies whether `cli_pipe` is active. Both functions lack a check for the closing state.