### PR TITLE
drop stack api access in defered service worker when bt adapter is offline.

### DIFF
--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -178,6 +178,11 @@ static void sal_invoke_async(service_work_t* work, void* userdata)
 
     SAL_ASSERT(req);
 
+    if (!bt_is_ready()) {
+        free(req);
+        return;
+    }
+
     if (!req->manager_list) {
         /* !req->user_data means a direct profile "disconnection" */
         req->handler(req->id, &req->device_addr, req->user_data);


### PR DESCRIPTION
drop stack api access in defered service worker when bt adapter is offline.

bug: v/83903

rootcause: 
During shutdown, the stack disable is executed synchronously, while some API execute asynchronously. This can cause asynchronous handler func access 'hdev' resources that have already been memset to zero, resulting in null pointer exceptions. Therefore, service_work is not allowed to make stack interface calls during the bt_disable phase.