### PR TITLE
L2CAP LE Credit-Based Flow Control Enhancement

### DIFF
--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -576,6 +576,19 @@ static bool prepare_data_path(l2cap_channel_t* channel)
     return true;
 }
 
+static void l2cap_abort_channel(l2cap_channel_t* channel)
+{
+    if (channel->pipe) {
+        euv_pipe_close(channel->pipe);
+        channel->proxy_connected = false;
+        channel->pipe = NULL;
+    }
+
+    if (channel->local_cid) {
+        bt_sal_l2cap_disconnect_channel(channel->local_cid);
+    }
+}
+
 static void l2cap_send_sdu_to_app_cb(euv_pipe_t* handle, uint8_t* buf, int status)
 {
 }
@@ -591,6 +604,7 @@ static void l2cap_send_sdu_to_app(l2cap_channel_t* channel)
         BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") write %" PRIu16 " bytes to app failed!",
             __func__, channel->id, channel->local_cid, sdu->len_total);
         free(sdu);
+        l2cap_abort_channel(channel);
     } else {
         list_add_tail(&channel->rx_list, &sdu->node);
     }
@@ -628,14 +642,15 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
     channel = find_l2cap_channel_by_conn_param(addr, param->psm, role, false);
     if (!channel) {
         BT_LOGE("%s, find L2CAP channel null, local cid: 0x%" PRIx16, __func__, param->local_cid);
-        bt_sal_l2cap_disconnect_channel(param->local_cid);
-
+        if (param->local_cid) {
+            bt_sal_l2cap_disconnect_channel(param->local_cid);
+        }
         return;
     }
 
     if (!channel->proxy_connected) {
         BT_LOGE("L2CAP channel(id:%" PRIu16 "/cid:0x %" PRIx16 ") data path is not prepared", channel->id, channel->local_cid);
-        bt_sal_l2cap_disconnect_channel(channel->local_cid);
+        l2cap_abort_channel(channel);
         return;
     }
 
@@ -673,14 +688,14 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
     ret = euv_pipe_read_stop(channel->pipe);
     if (ret != 0) {
         BT_LOGE("L2CAP channel(id: %" PRIu16 "/cid: 0x%" PRIx16 ") read stop failed!", channel->id, channel->local_cid);
-        bt_sal_l2cap_disconnect_channel(channel->local_cid);
+        l2cap_abort_channel(channel);
         return;
     }
 
     ret = euv_pipe_read_start(channel->pipe, channel->tx_mtu, l2cap_receive_data_from_app, NULL);
     if (ret != 0) {
         BT_LOGE("L2CAP channel(id: %" PRIu16 "/cid: 0x%" PRIx16 ") read start failed!", channel->id, channel->local_cid);
-        bt_sal_l2cap_disconnect_channel(channel->local_cid);
+        l2cap_abort_channel(channel);
         return;
     }
 
@@ -747,6 +762,7 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t
         BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") received sdu length %" PRIu16 " is larger than mtu %" PRIu16,
             __func__, channel->id, channel->local_cid, packet->len_total, channel->incoming.mtu);
         free(packet);
+        l2cap_abort_channel(channel);
         return;
     }
 
@@ -778,6 +794,7 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t
             free(channel->rx_sdu);
             channel->rx_sdu = NULL;
             free(packet);
+            l2cap_abort_channel(channel);
             return;
         }
 

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -602,6 +602,21 @@ static void l2cap_abort_channel(l2cap_channel_t* channel)
 
 static void l2cap_add_incoming_credits(l2cap_channel_t* channel)
 {
+    uint16_t remote_credits;
+    uint16_t additional_credits;
+
+    remote_credits = channel->rx_buf_size / channel->incoming.le_mps;
+    if (remote_credits <= channel->incoming.credits) {
+        return;
+    }
+
+    additional_credits = remote_credits - channel->incoming.credits;
+    if (bt_sal_l2cap_give_incoming_credits(&channel->addr, channel->local_cid, additional_credits) != BT_STATUS_SUCCESS) {
+        BT_LOGE("%s, give incoming credits failed", __func__);
+        return;
+    }
+
+    channel->incoming.credits = remote_credits;
 }
 
 static void l2cap_send_sdu_to_app_cb(euv_pipe_t* handle, uint8_t* buf, int status)
@@ -743,8 +758,8 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
     }
 
     BT_LOGI("L2CAP channel(id: %" PRIu16 "/cid: 0x%" PRIx16 ") connected", channel->id, channel->local_cid);
-    BT_LOGD("L2CAP channel(id: %" PRIu16 "/cid: 0x%" PRIx16 ") Tx mtu: %" PRIu16 ", Tx quota: %" PRIu16,
-        channel->id, channel->local_cid, channel->tx_mtu, channel->tx_quota);
+    BT_LOGD("L2CAP channel(id: %" PRIu16 "/cid: 0x%" PRIx16 ") Tx mtu: %" PRIu16 ", Tx quota: %" PRIu16 ", Rx buf size: %" PRIu16,
+        channel->id, channel->local_cid, channel->tx_mtu, channel->tx_quota, channel->rx_buf_size);
     channel->channel_connected = true;
 
     // notify app

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -458,6 +458,10 @@ static void free_l2cap_channel(void* context)
         free_le_dynamic_psm(psm);
     }
 
+    if (channel->rx_sdu) {
+        free(channel->rx_sdu);
+    }
+
     list_for_every_safe(&channel->rx_list, node, next)
     {
         list_delete(node);

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -119,6 +119,8 @@ typedef struct {
     char proxy_name[16];
     bool proxy_connected;
     remote_callback_t* app_handle;
+    /* sdu receive */
+    l2cap_pkt_t* rx_sdu;
 } l2cap_channel_t;
 
 typedef struct {
@@ -690,6 +692,58 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t
     l2cap_channel_t* channel;
 
     channel = find_l2cap_channel_by_cid(cid);
+    if (!channel) {
+        BT_LOGE("%s, find L2CAP channel null, local cid: 0x%" PRIx16 ", lost %" PRIu16 " bytes data", __func__, cid, packet->len_received);
+        free(packet);
+        return;
+    }
+
+    if (packet->len_total > channel->incoming.mtu) {
+        BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") received sdu length %" PRIu16 " is larger than mtu %" PRIu16,
+            __func__, channel->id, channel->local_cid, packet->len_total, channel->incoming.mtu);
+        free(packet);
+        return;
+    }
+
+    if (!channel->proxy_connected || !channel->pipe) {
+        BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") data path is not prepared, lost %" PRIu16 " bytes data",
+            __func__, channel->id, channel->local_cid, packet->len_received);
+        free(packet);
+        return;
+    }
+
+    --channel->incoming.credits; /* TODO: different transport and mode may need different handling*/
+    if (!channel->rx_sdu) {
+        /* first segment */
+        if (packet->len_received == packet->len_total) {
+            /* single segment, send directly */
+            channel->rx_sdu = packet;
+            l2cap_send_sdu_to_app(channel);
+            return;
+        }
+
+        /* multi-segment, start reassembly */
+        channel->rx_sdu = packet;
+    } else {
+        /* append segment */
+        if (channel->rx_sdu->len_received + packet->len_received > channel->rx_sdu->len_total) {
+            BT_LOGE("%s, L2CAP channel (id:%" PRIu16 "/cid:0x%" PRIx16 ") append data overflow",
+                __func__, channel->id, channel->local_cid);
+            free(channel->rx_sdu);
+            channel->rx_sdu = NULL;
+            free(packet);
+            return;
+        }
+
+        memcpy(channel->rx_sdu->data + channel->rx_sdu->len_received, packet->data, packet->len_received);
+        channel->rx_sdu->len_received += packet->len_received;
+        free(packet);
+
+        if (channel->rx_sdu->len_received == channel->rx_sdu->len_total) {
+            /* reassembly complete */
+            l2cap_send_sdu_to_app(channel);
+        }
+    }
 }
 
 static void handle_packet_sent(bt_address_t* addr, uint16_t cid)

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -91,6 +91,17 @@
  */
 #define L2CAP_MAX_RX_BUF_SIZE 10240
 
+/**
+ * \def L2CAP LE credits low watermark for triggering refill mechanism
+ *
+ * \note When incoming credits drop below this watermark, the credits refill
+ * mechanism will be triggered to replenish credits and maintain flow control.
+ *
+ * TODO: Optimize this watermark based on performance testing and memory constraints
+ * to balance between flow control responsiveness and system overhead.
+ */
+#define L2CAP_LE_CREDITS_LOW_WATERMARK 10
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -589,8 +600,40 @@ static void l2cap_abort_channel(l2cap_channel_t* channel)
     }
 }
 
+static void l2cap_add_incoming_credits(l2cap_channel_t* channel)
+{
+}
+
 static void l2cap_send_sdu_to_app_cb(euv_pipe_t* handle, uint8_t* buf, int status)
 {
+    l2cap_channel_t* channel;
+    l2cap_pkt_t* sdu;
+
+    channel = find_l2cap_channel_by_pipe(handle);
+    if (!channel) {
+        BT_LOGE("%s, find null by pipe %p", __func__, handle);
+        return;
+    }
+
+    if (status != 0) {
+        BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") write failed with status %d", __func__, channel->id, channel->local_cid, status);
+        l2cap_abort_channel(channel); /* release SDU when free l2cap channel */
+        return;
+    }
+
+    sdu = (l2cap_pkt_t*)list_remove_head(&channel->rx_list);
+    if (!sdu) {
+        BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") rx_list is empty!", __func__, channel->id, channel->local_cid);
+        return;
+    }
+
+    assert(buf == sdu->data);
+    channel->rx_buf_size += sdu->len_total;
+    free(sdu);
+
+    if (channel->incoming.credits < L2CAP_LE_CREDITS_LOW_WATERMARK) {
+        l2cap_add_incoming_credits(channel);
+    }
 }
 
 static void l2cap_send_sdu_to_app(l2cap_channel_t* channel)
@@ -766,6 +809,14 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t
         return;
     }
 
+    if (channel->incoming.credits == 0) {
+        BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") has no incoming credits",
+            __func__, channel->id, channel->local_cid, packet->len_received);
+        free(packet);
+        l2cap_abort_channel(channel);
+        return;
+    }
+
     if (!channel->proxy_connected || !channel->pipe) {
         BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") data path is not prepared, lost %" PRIu16 " bytes data",
             __func__, channel->id, channel->local_cid, packet->len_received);
@@ -775,6 +826,10 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t
 
     --channel->incoming.credits; /* TODO: different transport and mode may need different handling*/
     channel->rx_buf_size -= packet->len_received;
+    if (channel->incoming.credits < L2CAP_LE_CREDITS_LOW_WATERMARK) {
+        l2cap_add_incoming_credits(channel);
+    }
+
     if (!channel->rx_sdu) {
         /* first segment */
         if (packet->len_received == packet->len_total) {

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -604,6 +604,42 @@ static void l2cap_abort_channel(l2cap_channel_t* channel)
     }
 }
 
+static bool l2cap_config_param(l2cap_config_option_t* option)
+{
+    uint16_t min_credits;
+    uint16_t max_credits;
+
+    if (option->mtu > L2CAP_MAX_RX_BUF_SIZE) {
+        BT_LOGE("%s, MTU (%" PRIu16 ") exceeds maximum buffer size (%d)", __func__, option->mtu, L2CAP_MAX_RX_BUF_SIZE);
+        return false;
+    }
+
+    if (option->transport == BT_TRANSPORT_BLE) {
+        if (option->le_mps == 0) {
+            BT_LOGE("%s, invalid MPS value (0)", __func__);
+            return false;
+        }
+
+        if (option->mtu < option->le_mps) {
+            BT_LOGE("%s, MTU (%" PRIu16 ") must be >= MPS (%" PRIu16 ")", __func__, option->mtu, option->le_mps);
+            return false;
+        }
+
+        min_credits = (option->mtu + option->le_mps - 1) / option->le_mps;
+        max_credits = L2CAP_MAX_RX_BUF_SIZE / option->le_mps;
+
+        if (option->init_credits < min_credits) {
+            BT_LOGW("%s, initial credits (%" PRIu16 ") adjusted to minimum (%" PRIu16 ")", __func__, option->init_credits, min_credits);
+            option->init_credits = min_credits;
+        } else if (option->init_credits > max_credits) {
+            BT_LOGW("%s, initial credits (%" PRIu16 ") adjusted to maximum (%" PRIu16 ")", __func__, option->init_credits, max_credits);
+            option->init_credits = max_credits;
+        }
+    }
+
+    return true;
+}
+
 static void l2cap_add_incoming_credits(l2cap_channel_t* channel)
 {
     uint16_t remote_credits;
@@ -648,8 +684,13 @@ static void l2cap_send_sdu_to_app_cb(euv_pipe_t* handle, uint8_t* buf, int statu
 
     assert(buf == sdu->data);
     channel->rx_buf_size += sdu->len_total;
-    free(sdu);
+    if (channel->rx_buf_size > L2CAP_MAX_RX_BUF_SIZE) {
+        BT_LOGW("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") rx_buf_size exceeds max, clamping to %d",
+            __func__, channel->id, channel->local_cid, L2CAP_MAX_RX_BUF_SIZE);
+        channel->rx_buf_size = L2CAP_MAX_RX_BUF_SIZE;
+    }
 
+    free(sdu);
     if (channel->incoming.credits < L2CAP_LE_CREDITS_LOW_WATERMARK) {
         l2cap_add_incoming_credits(channel);
     }
@@ -1119,6 +1160,10 @@ bt_status_t l2cap_listen_channel(void* handle, l2cap_config_option_t* option)
         return BT_STATUS_UNSUPPORTED;
     }
 
+    if (l2cap_config_param(option) == false) {
+        return BT_STATUS_PARM_INVALID;
+    }
+
     pthread_mutex_lock(&g_l2cap_manager.l2cap_lock);
     if (option->psm == 0) {
         option->psm = alloc_le_dynamic_psm();
@@ -1175,6 +1220,10 @@ bt_status_t l2cap_connect_channel(void* handle, bt_address_t* addr, l2cap_config
     }
 
     CHECK_ADAPTER_ENABLED(BT_STATUS_NOT_ENABLED);
+
+    if (l2cap_config_param(option) == false) {
+        return BT_STATUS_PARM_INVALID;
+    }
 
     pthread_mutex_lock(&g_l2cap_manager.l2cap_lock);
     channel = alloc_free_channel(handle, addr, option->psm, L2CAP_CHANNEL_ROLE_CLIENT);

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -86,6 +86,11 @@
  */
 #define L2CAP_CID_DYNAMIC_MIN 0x0040
 
+/**
+ * \def L2CAP maximum receive buffer size per channel
+ */
+#define L2CAP_MAX_RX_BUF_SIZE 10240
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -121,6 +126,8 @@ typedef struct {
     remote_callback_t* app_handle;
     /* sdu receive */
     l2cap_pkt_t* rx_sdu;
+    struct list_node rx_list;
+    uint16_t rx_buf_size;
 } l2cap_channel_t;
 
 typedef struct {
@@ -261,6 +268,7 @@ static l2cap_channel_t* alloc_free_channel(void* handle, bt_address_t* addr, uin
     channel->role = role;
     channel->channel_connected = false;
     channel->proxy_connected = false;
+    list_initialize(&channel->rx_list);
 
     bt_list_add_tail(g_l2cap_manager.channel_list, (void*)channel);
 
@@ -418,6 +426,8 @@ static void free_l2cap_channel(void* context)
 {
     uint16_t psm;
     l2cap_channel_t* channel = (l2cap_channel_t*)context;
+    struct list_node* node;
+    struct list_node* next;
 
     BT_LOGD("%s, channel id: %" PRIu16, __func__, channel->id);
     if (!channel) {
@@ -435,6 +445,12 @@ static void free_l2cap_channel(void* context)
         channel->psm = 0; // remove this channel's psm
         BT_LOGD("%s, try to free le dynamic psm 0x%" PRIx16, __func__, psm);
         free_le_dynamic_psm(psm);
+    }
+
+    list_for_every_safe(&channel->rx_list, node, next)
+    {
+        list_delete(node);
+        free(list_entry(node, l2cap_pkt_t, node));
     }
 
     free(channel);
@@ -560,6 +576,26 @@ static bool prepare_data_path(l2cap_channel_t* channel)
     return true;
 }
 
+static void l2cap_send_sdu_to_app_cb(euv_pipe_t* handle, uint8_t* buf, int status)
+{
+}
+
+static void l2cap_send_sdu_to_app(l2cap_channel_t* channel)
+{
+    int ret;
+    l2cap_pkt_t* sdu = channel->rx_sdu;
+
+    channel->rx_sdu = NULL;
+    ret = euv_pipe_write(channel->pipe, sdu->data, sdu->len_total, l2cap_send_sdu_to_app_cb);
+    if (ret != 0) {
+        BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") write %" PRIu16 " bytes to app failed!",
+            __func__, channel->id, channel->local_cid, sdu->len_total);
+        free(sdu);
+    } else {
+        list_add_tail(&channel->rx_list, &sdu->node);
+    }
+}
+
 static void handle_cid_allocated(bt_address_t* addr, uint16_t psm, uint16_t cid)
 {
     l2cap_channel_t* channel;
@@ -577,6 +613,7 @@ static void handle_cid_allocated(bt_address_t* addr, uint16_t psm, uint16_t cid)
 static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* param)
 {
     int ret;
+    uint32_t rx_buf_size;
     l2cap_channel_t* channel;
     l2cap_channel_t* new_listen_channel = NULL;
     l2cap_connect_params_t conn_param = { .listen_id = INVALID_L2CAP_LISTEN_ID };
@@ -623,6 +660,14 @@ static void handle_channel_conneted(bt_address_t* addr, l2cap_channel_param_t* p
     memcpy(&channel->outgoing, &param->outgoing, sizeof(channel->outgoing));
     channel->tx_mtu = MIN(param->outgoing.mtu, CONFIG_BLUETOOTH_L2CAP_OUTGOING_MTU);
     channel->tx_quota = L2CAP_TX_QUOTA; // TODO: need to adjust quota according to mtu and memory
+    rx_buf_size = (uint32_t)channel->incoming.credits * channel->incoming.le_mps;
+    if (rx_buf_size > L2CAP_MAX_RX_BUF_SIZE) {
+        BT_LOGW("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") rx_buf_size %" PRIu32 " exceeds max, clamping to %d",
+            __func__, channel->id, channel->local_cid, rx_buf_size, L2CAP_MAX_RX_BUF_SIZE);
+        channel->rx_buf_size = L2CAP_MAX_RX_BUF_SIZE;
+    } else {
+        channel->rx_buf_size = (uint16_t)rx_buf_size;
+    }
 
     // restart read pipe to adjust mtu
     ret = euv_pipe_read_stop(channel->pipe);
@@ -713,6 +758,7 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t
     }
 
     --channel->incoming.credits; /* TODO: different transport and mode may need different handling*/
+    channel->rx_buf_size -= packet->len_received;
     if (!channel->rx_sdu) {
         /* first segment */
         if (packet->len_received == packet->len_total) {

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -79,6 +79,13 @@
  */
 #define L2CAP_TX_QUOTA 16
 
+/**
+ * \def L2CAP dynamic CID minimum value per Bluetooth Core Spec
+ *
+ * \note CID 0x0001-0x003F are reserved for fixed channels
+ */
+#define L2CAP_CID_DYNAMIC_MIN 0x0040
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -87,6 +94,13 @@ typedef enum {
     L2CAP_CHANNEL_ROLE_SERVER_ACCEPT,
     L2CAP_CHANNEL_ROLE_CLIENT,
 } l2cap_channel_role_t;
+
+typedef struct {
+    struct list_node node;
+    uint16_t len_total; /* SDU total length */
+    uint16_t len_received; /* current length received */
+    uint8_t data[]; /* flexible array for SDU */
+} l2cap_pkt_t;
 
 typedef struct {
     bt_address_t addr;
@@ -121,7 +135,7 @@ typedef struct {
         CID_ALLOCATED_EVT,
         CHANNEL_CONNECTED_EVT,
         CHANNEL_DISCONNECTED_EVT,
-        PACKET_RECEVIED_EVT,
+        PACKET_RECEIVED_EVT,
         PACKET_SENT_EVT,
     } event;
 
@@ -152,13 +166,12 @@ typedef struct {
         } channel_disconnected;
 
         /**
-         * @brief PACKET_RECEVIED_EVT
+         * @brief PACKET_RECEIVED_EVT
          */
         struct packet_received_evt_param {
             bt_address_t addr;
             uint16_t cid;
-            uint16_t size;
-            uint8_t* data;
+            l2cap_pkt_t* packet;
         } packet_received;
 
         /**
@@ -545,11 +558,6 @@ static bool prepare_data_path(l2cap_channel_t* channel)
     return true;
 }
 
-static void euv_write_complete(euv_pipe_t* handle, uint8_t* buf, int status)
-{
-    free(buf);
-}
-
 static void handle_cid_allocated(bt_address_t* addr, uint16_t psm, uint16_t cid)
 {
     l2cap_channel_t* channel;
@@ -677,21 +685,11 @@ static void handle_channel_disconneted(bt_address_t* addr, uint16_t cid, uint32_
     bt_list_remove(g_l2cap_manager.channel_list, (void*)channel);
 }
 
-static void handle_packet_received(bt_address_t* addr, uint16_t cid, uint8_t* packet_data, uint16_t packet_size)
+static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t* packet)
 {
     l2cap_channel_t* channel;
 
     channel = find_l2cap_channel_by_cid(cid);
-    if (channel && channel->pipe) {
-        int ret = euv_pipe_write(channel->pipe, packet_data, packet_size, euv_write_complete);
-        if (ret != 0) {
-            BT_LOGE("L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") write failed!", channel->id, channel->local_cid);
-            euv_pipe_close(channel->pipe);
-            channel->proxy_connected = false;
-            channel->pipe = NULL;
-            bt_sal_l2cap_disconnect_channel(channel->local_cid);
-        }
-    }
 }
 
 static void handle_packet_sent(bt_address_t* addr, uint16_t cid)
@@ -734,11 +732,10 @@ static void handle_l2cap_event(void* data)
             msg->channel_disconnected.cid,
             msg->channel_disconnected.reason);
         break;
-    case PACKET_RECEVIED_EVT:
+    case PACKET_RECEIVED_EVT:
         handle_packet_received(&msg->packet_received.addr,
             msg->packet_received.cid,
-            msg->packet_received.data,
-            msg->packet_received.size);
+            msg->packet_received.packet);
         break;
     case PACKET_SENT_EVT:
         handle_packet_sent(&msg->packet_sent.addr,
@@ -804,17 +801,18 @@ void l2cap_on_packet_received(bt_address_t* addr, uint16_t cid, uint8_t* packet_
         return;
     }
 
-    msg->packet_received.data = malloc(packet_size);
-    if (!msg->packet_received.data) {
+    msg->packet_received.packet = malloc(sizeof(l2cap_pkt_t) + packet_size);
+    if (!msg->packet_received.packet) {
         free(msg);
         return;
     }
 
-    msg->event = PACKET_RECEVIED_EVT;
+    msg->event = PACKET_RECEIVED_EVT;
     memcpy(&msg->packet_received.addr, addr, sizeof(msg->packet_received.addr));
     msg->packet_received.cid = cid;
-    msg->packet_received.size = packet_size;
-    memcpy(msg->packet_received.data, packet_data, packet_size);
+    msg->packet_received.packet->len_total = packet_size;
+    msg->packet_received.packet->len_received = packet_size;
+    memcpy(msg->packet_received.packet->data, packet_data, packet_size);
     do_in_service_loop(handle_l2cap_event, msg);
 }
 
@@ -829,6 +827,61 @@ void l2cap_on_packet_sent(bt_address_t* addr, uint16_t cid)
     memcpy(&msg->packet_sent.addr, addr, sizeof(msg->packet_sent.addr));
     msg->packet_sent.cid = cid;
     do_in_service_loop(handle_l2cap_event, msg);
+}
+
+bool l2cap_on_segment_received(bt_address_t* addr, uint16_t cid, uint8_t* seg, uint16_t seg_len, uint16_t sdu_len, uint16_t seg_off)
+{
+    uint16_t data_len;
+    l2cap_msg_t* msg;
+    char addr_str[BT_ADDR_STR_LENGTH];
+
+    if (!addr) {
+        BT_LOGE("%s, addr is NULL, cid: 0x%" PRIx16, __func__, cid);
+        return false;
+    }
+
+    if (!seg || seg_len == 0) {
+        bt_addr_ba2str(addr, addr_str);
+        BT_LOGE("%s, invalid seg (seg: %p, len: %" PRIu16 "), addr: %s, cid: 0x%" PRIx16,
+            __func__, seg, seg_len, addr_str, cid);
+        return false;
+    }
+
+    if (cid < L2CAP_CID_DYNAMIC_MIN) {
+        bt_addr_ba2str(addr, addr_str);
+        BT_LOGE("%s, invalid cid: 0x%" PRIx16 ", addr: %s", __func__, cid, addr_str);
+        return false;
+    }
+
+    if (sdu_len > 0 && seg_len > sdu_len) {
+        bt_addr_ba2str(addr, addr_str);
+        BT_LOGE("%s, seg_len (%" PRIu16 ") > sdu_len (%" PRIu16 "), addr: %s, cid: 0x%" PRIx16,
+            __func__, seg_len, sdu_len, addr_str, cid);
+        return false;
+    }
+
+    msg = malloc(sizeof(l2cap_msg_t));
+    if (!msg) {
+        BT_LOGE("%s, malloc failed", __func__);
+        return false;
+    }
+
+    data_len = seg_off ? seg_len : sdu_len; // first segment malloc sdu_len, otherwise seg_len
+    msg->packet_received.packet = malloc(sizeof(l2cap_pkt_t) + data_len);
+    if (!msg->packet_received.packet) {
+        BT_LOGE("%s, malloc packet failed", __func__);
+        free(msg);
+        return false;
+    }
+
+    msg->event = PACKET_RECEIVED_EVT;
+    memcpy(&msg->packet_received.addr, addr, sizeof(msg->packet_received.addr));
+    msg->packet_received.cid = cid;
+    msg->packet_received.packet->len_total = sdu_len;
+    msg->packet_received.packet->len_received = seg_len;
+    memcpy(msg->packet_received.packet->data, seg, seg_len);
+    do_in_service_loop(handle_l2cap_event, msg);
+    return true;
 }
 
 void* l2cap_register_callbacks(void* remote, const l2cap_callbacks_t* callbacks)

--- a/service/src/l2cap_service.h
+++ b/service/src/l2cap_service.h
@@ -23,7 +23,7 @@
 typedef struct {
     uint16_t mtu;
     uint16_t le_mps;
-    uint16_t init_credits;
+    uint16_t credits;
 } l2cap_endpoint_param_t;
 
 typedef struct {

--- a/service/src/l2cap_service.h
+++ b/service/src/l2cap_service.h
@@ -41,6 +41,7 @@ void l2cap_on_channel_connected(bt_address_t* addr, l2cap_channel_param_t* param
 void l2cap_on_channel_disconnected(bt_address_t* addr, uint16_t cid, uint32_t reason);
 void l2cap_on_packet_received(bt_address_t* addr, uint16_t cid, uint8_t* packet_data, uint16_t packet_size);
 void l2cap_on_packet_sent(bt_address_t* addr, uint16_t cid);
+bool l2cap_on_segment_received(bt_address_t* addr, uint16_t cid, uint8_t* seg, uint16_t seg_len, uint16_t sdu_len, uint16_t seg_off);
 
 void* l2cap_register_callbacks(void* remote, const l2cap_callbacks_t* callbacks);
 bool l2cap_unregister_callbacks(void** remote, void* cookie);

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -26,6 +26,11 @@
 #define L2CAP_TRANS_MPS_CFG 251
 #define L2CAP_TRANS_CREDIT_CFG 30
 
+#define L2CAP_LE_MTU_MIN 23
+#define L2CAP_LE_MPS_MIN 23
+#define L2CAP_LE_MPS_MAX 65533
+#define L2CAP_LE_CREDIT_MIN 1
+
 typedef struct {
     struct list_node node;
     euv_pipe_t* pipe;
@@ -513,6 +518,31 @@ static l2cap_callbacks_t l2cap_callback = {
     .on_disconnected = on_disconnected,
 };
 
+static int validate_l2cap_params(uint16_t mtu, uint16_t mps, uint16_t credits)
+{
+    if (mtu < L2CAP_LE_MTU_MIN) {
+        PRINT("invalid mtu:%" PRIu16 ", min:%d", mtu, L2CAP_LE_MTU_MIN);
+        return -1;
+    }
+
+    if (mps < L2CAP_LE_MPS_MIN || mps > L2CAP_LE_MPS_MAX) {
+        PRINT("invalid mps:%" PRIu16 ", range:%d~%d", mps, L2CAP_LE_MPS_MIN, L2CAP_LE_MPS_MAX);
+        return -1;
+    }
+
+    if (credits < L2CAP_LE_CREDIT_MIN) {
+        PRINT("invalid credits:%" PRIu16 ", min:%d", credits, L2CAP_LE_CREDIT_MIN);
+        return -1;
+    }
+
+    if (mps > mtu) {
+        PRINT("invalid params: mps(%" PRIu16 ") > mtu(%" PRIu16 ")", mps, mtu);
+        return -1;
+    }
+
+    return 0;
+}
+
 static int connect_cmd(void* handle, int argc, char* argv[])
 {
     bt_address_t addr;
@@ -537,12 +567,16 @@ static int connect_cmd(void* handle, int argc, char* argv[])
     }
 
     conn_option.psm = strtoul(argv[1], NULL, 0);
-    // defaule param
     conn_option.transport = BT_TRANSPORT_BLE;
     conn_option.mode = L2CAP_CHANNEL_MODE_LE_CREDIT_BASED_FLOW_CONTROL;
-    conn_option.mtu = L2CAP_TRANS_MTU_CFG;
-    conn_option.le_mps = L2CAP_TRANS_MPS_CFG;
-    conn_option.init_credits = L2CAP_TRANS_CREDIT_CFG;
+    conn_option.mtu = (argc > 2) ? strtoul(argv[2], NULL, 0) : L2CAP_TRANS_MTU_CFG;
+    conn_option.le_mps = (argc > 3) ? strtoul(argv[3], NULL, 0) : L2CAP_TRANS_MPS_CFG;
+    conn_option.init_credits = (argc > 4) ? strtoul(argv[4], NULL, 0) : L2CAP_TRANS_CREDIT_CFG;
+    if (validate_l2cap_params(conn_option.mtu, conn_option.le_mps, conn_option.init_credits) < 0) {
+        free(msg);
+        return CMD_INVALID_PARAM;
+    }
+
     if (bt_l2cap_connect(handle, g_l2cap_handle, &addr, &conn_option) != BT_STATUS_SUCCESS) {
         PRINT("connect %s failed", argv[0]);
         free(msg);
@@ -582,12 +616,16 @@ static int listen_cmd(void* handle, int argc, char* argv[])
         return CMD_ERROR;
     }
 
-    // default param
     conn_option.transport = BT_TRANSPORT_BLE;
     conn_option.mode = L2CAP_CHANNEL_MODE_LE_CREDIT_BASED_FLOW_CONTROL;
-    conn_option.mtu = L2CAP_TRANS_MTU_CFG;
-    conn_option.le_mps = L2CAP_TRANS_MPS_CFG;
-    conn_option.init_credits = L2CAP_TRANS_CREDIT_CFG;
+    conn_option.mtu = (argc > 1) ? strtoul(argv[1], NULL, 0) : L2CAP_TRANS_MTU_CFG;
+    conn_option.le_mps = (argc > 2) ? strtoul(argv[2], NULL, 0) : L2CAP_TRANS_MPS_CFG;
+    conn_option.init_credits = (argc > 3) ? strtoul(argv[3], NULL, 0) : L2CAP_TRANS_CREDIT_CFG;
+    if (validate_l2cap_params(conn_option.mtu, conn_option.le_mps, conn_option.init_credits) < 0) {
+        free(msg);
+        return CMD_INVALID_PARAM;
+    }
+
     if (bt_l2cap_listen(handle, g_l2cap_handle, &conn_option) != BT_STATUS_SUCCESS) {
         PRINT("listen 0x%" PRIx16 " failed", conn_option.psm);
         free(msg);
@@ -786,8 +824,8 @@ static int start_receive_cmd(void* handle, int argc, char* argv[])
 }
 
 static bt_command_t g_l2cap_commands[] = {
-    { "connect", connect_cmd, 0, "\"connect l2cap channel      param: <address> <psm>\"" },
-    { "listen", listen_cmd, 0, "\"listen l2cap channel        param: <psm>\"" },
+    { "connect", connect_cmd, 0, "\"connect l2cap channel      param: <address> <psm> [mtu] [mps] [credits]\"" },
+    { "listen", listen_cmd, 0, "\"listen l2cap channel        param: <psm> [mtu] [mps] [credits]\"" },
     { "disconnect", disconnect_cmd, 0, "\"disconnect l2cap channel  param: <id>\"" },
     { "stoplisten", stop_listen_cmd, 0, "\"stop listen l2cap channel  param: <psm>\"" },
     { "write", write_cmd, 0, "\"write data to peer   param: <id> <data>\"" },

--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -427,6 +427,28 @@ static void do_l2cap_speed_test(void* data)
     PRINT("transmit start, waiting for %" PRIu32 " bytes transmit done", trans_ctx->trans_total_size);
 }
 
+static void do_l2cap_flow_control(void* data)
+{
+    l2cap_msg_t* msg = (l2cap_msg_t*)data;
+    l2cap_chnl_t* channel;
+    int err;
+    uint16_t id = msg->id;
+    bool start_recv = msg->is_listening;
+    const char* action;
+
+    free(msg);
+    channel = find_channel_by_id(id);
+    if (channel == NULL || channel->pipe == NULL) {
+        PRINT("L2CAP channel(id: %" PRIu16 ") not found or pipe disconnected", id);
+        return;
+    }
+
+    action = start_recv ? "start" : "stop";
+    err = start_recv ? euv_pipe_read_start(channel->pipe, 2048, read_complete_cb, NULL)
+                     : euv_pipe_read_stop(channel->pipe);
+    PRINT("%s L2CAP channel(id: %" PRIu16 ") receive %s", action, id, err ? "failed" : "success");
+}
+
 static void on_connected(void* handle, l2cap_connect_params_t* params)
 {
     l2cap_msg_t* msg;
@@ -711,6 +733,58 @@ static int speed_test_cmd(void* handle, int argc, char* argv[])
     return CMD_OK;
 }
 
+static int stop_receive_cmd(void* handle, int argc, char* argv[])
+{
+    l2cap_msg_t* msg;
+
+    if (!handle || !g_l2cap_handle) {
+        PRINT("L2CAP tool not ready!");
+        return CMD_ERROR;
+    }
+
+    if (argc < 1) {
+        return CMD_PARAM_NOT_ENOUGH;
+    }
+
+    msg = (l2cap_msg_t*)malloc(sizeof(l2cap_msg_t));
+    if (!msg) {
+        PRINT("allocate msg failed");
+        return CMD_ERROR;
+    }
+
+    msg->id = strtoul(argv[0], NULL, 10);
+    msg->is_listening = false; /* stop receive*/
+    do_in_thread_loop(&g_l2cap_thread, do_l2cap_flow_control, msg);
+
+    return CMD_OK;
+}
+
+static int start_receive_cmd(void* handle, int argc, char* argv[])
+{
+    l2cap_msg_t* msg;
+
+    if (!handle || !g_l2cap_handle) {
+        PRINT("L2CAP tool not ready!");
+        return CMD_ERROR;
+    }
+
+    if (argc < 1) {
+        return CMD_PARAM_NOT_ENOUGH;
+    }
+
+    msg = (l2cap_msg_t*)malloc(sizeof(l2cap_msg_t));
+    if (!msg) {
+        PRINT("allocate msg failed");
+        return CMD_ERROR;
+    }
+
+    msg->id = strtoul(argv[0], NULL, 10);
+    msg->is_listening = true; /* start receive*/
+    do_in_thread_loop(&g_l2cap_thread, do_l2cap_flow_control, msg);
+
+    return CMD_OK;
+}
+
 static bt_command_t g_l2cap_commands[] = {
     { "connect", connect_cmd, 0, "\"connect l2cap channel      param: <address> <psm>\"" },
     { "listen", listen_cmd, 0, "\"listen l2cap channel        param: <psm>\"" },
@@ -718,6 +792,8 @@ static bt_command_t g_l2cap_commands[] = {
     { "stoplisten", stop_listen_cmd, 0, "\"stop listen l2cap channel  param: <psm>\"" },
     { "write", write_cmd, 0, "\"write data to peer   param: <id> <data>\"" },
     { "speed", speed_test_cmd, 0, "\"speed test l2cap channel    param: <id> <iteration>\"" },
+    { "stoprecv", stop_receive_cmd, 0, "\"stop receive data from specified L2CAP channel  param: <id>\"" },
+    { "startrecv", start_receive_cmd, 0, "\"start receive data from specified L2CAP channel  param: <id>\"" },
 };
 
 static void usage(void)


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

This PR implements comprehensive LE credit-based flow control management for L2CAP channels, including dynamic credit tracking, automatic refill mechanism, parameter validation, and testing capabilities.

### Key Changes

#### 1. Core Infrastructure
- **Rename field for dynamic tracking** (`init_credits` → `credits`)
  - Changed field name in `l2cap_endpoint_param_t` to better reflect its purpose of tracking credit changes dynamically rather than just storing initial values

#### 2. Credit Management
- **Add credit threshold monitoring**
  - Defined `L2CAP_LE_CREDITS_THRESHOLD` (10) for low credit detection
  - Implemented callback `l2cap_send_sdu_to_app_cb` to handle SDU delivery completion
  - Trigger credit refill when incoming credits drop below threshold

- **Implement credit refill mechanism**
  - Calculate additional credits based on available rx buffer space
  - Call `bt_sal_l2cap_add_incoming_credits` to refill credits to remote peer
  - Update channel incoming credits after successful refill
  - Initialize `rx_buf_size` on channel connection using `credits * MPS` formula

#### 3. Parameter Validation
- **Add configuration validation with auto-adjustment**
  - Defined `L2CAP_MAX_RX_BUF_SIZE` (10240) for receive buffer limit
  - Implemented `l2cap_config_param` to validate MTU, MPS and credits
  - Validate MTU does not exceed maximum buffer size
  - Validate MPS is non-zero and MTU >= MPS for BLE transport
  - Auto-adjust `init_credits` to valid range `[min_credits, max_credits]`
  - Apply validation in both listen and connect operations

#### 4. Testing Support
- **Add flow control test commands**
  - Implemented `do_l2cap_flow_contral` to start/stop pipe reading
  - Added `stoprecv` command to stop receiving data from channel
  - Added `startrecv` command to resume receiving data from channel
  - Enable manual flow control testing for L2CAP channels