### PR TITLE
Fix the issue where disabling fails when only BLE is enabled.

### DIFF
--- a/service/src/adapter_internel.h
+++ b/service/src/adapter_internel.h
@@ -213,6 +213,7 @@ enum adapter_event {
     BLE_DISABLE_TIMEOUT,
     BLE_ENABLE_PROFILE_TIMEOUT,
     BLE_DISABLE_PROFILE_TIMEOUT,
+    BLE_ACL_ALL_DISCONNECTED,
 };
 
 /* adapter state machine API functions*/
@@ -335,6 +336,7 @@ bt_status_t adapter_le_connect(bt_address_t* addr,
     ble_addr_type_t type,
     ble_connect_params_t* param);
 bt_status_t adapter_le_disconnect(bt_address_t* addr);
+bt_status_t adapter_le_disconnect_safe(void);
 bt_status_t adapter_connect_request_reply(bt_address_t* addr, bool accept);
 bt_status_t adapter_le_set_phy(bt_address_t* addr,
     ble_phy_type_t tx_phy,

--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -344,12 +344,12 @@ static void adapter_delete_device(void* data)
     device_delete(device);
 }
 
-static bool adapter_check_acl_all_disconnected(void)
+static bool adapter_check_acl_all_disconnected(bt_list_t* list)
 {
     bt_device_t* device;
     bt_list_node_t* node;
 
-    for (node = bt_list_head(g_adapter_service.devices); node != NULL; node = bt_list_next(g_adapter_service.devices, node)) {
+    for (node = bt_list_head(list); node != NULL; node = bt_list_next(list, node)) {
         device = (bt_device_t*)bt_list_node(node);
         if (device_is_connected(device)) {
             return false;
@@ -1124,8 +1124,26 @@ static void process_connection_state_changed_evt(bt_address_t* addr, acl_state_p
 
     /* check acls connection is all disconnected in safe disable mode */
     if (acl_params->connection_state == CONNECTION_STATE_DISCONNECTED) {
-        if (adapter_check_acl_all_disconnected()) {
-            send_to_state_machine((state_machine_t*)adapter->stm, BREDR_ACL_ALL_DISCONNECTED, NULL);
+        bt_list_t* list = NULL;
+        uint16_t event_id;
+#ifdef CONFIG_BLUETOOTH_BREDR_SUPPORT
+        if (acl_params->transport == BT_TRANSPORT_BREDR) {
+            list = g_adapter_service.devices;
+            event_id = BREDR_ACL_ALL_DISCONNECTED;
+        }
+#endif
+#ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
+        if (acl_params->transport == BT_TRANSPORT_BLE) {
+            list = g_adapter_service.le_devices;
+            event_id = BLE_ACL_ALL_DISCONNECTED;
+        }
+#endif
+
+        if (!list)
+            return;
+
+        if (adapter_check_acl_all_disconnected(list)) {
+            send_to_state_machine((state_machine_t*)adapter->stm, event_id, NULL);
         }
     }
 }
@@ -2993,7 +3011,7 @@ bt_status_t adapter_disconnect_safe(void)
     adapter_service_t* adapter = &g_adapter_service;
 
     /* check acls connection is all disconnected in safe disable mode */
-    if (adapter_check_acl_all_disconnected()) {
+    if (adapter_check_acl_all_disconnected(g_adapter_service.devices)) {
         send_to_state_machine((state_machine_t*)adapter->stm, BREDR_ACL_ALL_DISCONNECTED, NULL);
         return BT_STATUS_SUCCESS;
     }
@@ -3052,6 +3070,30 @@ bt_status_t adapter_le_disconnect(bt_address_t* addr)
 
     device_set_connection_state(device, CONNECTION_STATE_DISCONNECTING);
     adapter_unlock();
+    return BT_STATUS_SUCCESS;
+#else
+    return BT_STATUS_NOT_SUPPORTED;
+#endif
+}
+
+bt_status_t adapter_le_disconnect_safe(void)
+{
+#ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
+    bt_device_t* device;
+    bt_list_node_t* node;
+    adapter_service_t* adapter = &g_adapter_service;
+
+    /* check acls connection is all disconnected in safe disable mode */
+    if (adapter_check_acl_all_disconnected(g_adapter_service.le_devices)) {
+        send_to_state_machine((state_machine_t*)adapter->stm, BLE_ACL_ALL_DISCONNECTED, NULL);
+        return BT_STATUS_SUCCESS;
+    }
+
+    for (node = bt_list_head(g_adapter_service.le_devices); node != NULL; node = bt_list_next(g_adapter_service.le_devices, node)) {
+        device = (bt_device_t*)bt_list_node(node);
+        adapter_le_disconnect(device_get_address(device));
+    }
+
     return BT_STATUS_SUCCESS;
 #else
     return BT_STATUS_NOT_SUPPORTED;

--- a/service/src/adapter_state.c
+++ b/service/src/adapter_state.c
@@ -125,6 +125,7 @@ typedef struct adapter_state_machine {
     bool hfp_offloading;
     bool lea_offloading;
     bool turning_off_safe;
+    bool ble_turning_off_safe;
     service_timer_t* disable_safe_timer;
 } adapter_state_machine_t;
 
@@ -158,6 +159,7 @@ static const char* event_to_string(uint16_t event)
         CASE_RETURN_STR(BLE_DISABLE_TIMEOUT)
         CASE_RETURN_STR(BLE_ENABLE_PROFILE_TIMEOUT)
         CASE_RETURN_STR(BLE_DISABLE_PROFILE_TIMEOUT)
+        CASE_RETURN_STR(BLE_ACL_ALL_DISCONNECTED)
     default:
         return "unknown";
     }
@@ -330,6 +332,7 @@ static void ble_on_exit(state_machine_t* sm)
 
 static bool ble_on_process_event(state_machine_t* sm, uint32_t event, void* p_data)
 {
+    adapter_state_machine_t* stm = (adapter_state_machine_t*)sm;
     ADAPTER_DBG_EVENT(sm, event);
 
     switch (event) {
@@ -338,8 +341,21 @@ static bool ble_on_process_event(state_machine_t* sm, uint32_t event, void* p_da
         break;
     case SYS_TURN_OFF:
     case TURN_OFF_BLE:
-    case SYS_TURN_OFF_SAFE:
         hsm_transition_to(sm, &ble_turning_off_state);
+        break;
+    case SYS_TURN_OFF_SAFE:
+        stm->ble_turning_off_safe = true;
+
+        adapter_le_disconnect_safe();
+
+        stm->disable_safe_timer = service_loop_timer(DISABLE_SAFE_TIMEOUT, 0,
+            turning_off_safe_timeout_callback, (void*)sm);
+        break;
+    case SYS_TURN_OFF_SAFE_TIMEOUT:
+    case BLE_ACL_ALL_DISCONNECTED:
+        if (stm->ble_turning_off_safe)
+            hsm_transition_to(sm, &ble_turning_off_state);
+
         break;
     default:
         return false;
@@ -487,6 +503,9 @@ static void ble_turning_off_enter(state_machine_t* sm)
 {
     ADAPTER_DBG_ENTER(sm);
 #ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
+    adapter_state_machine_t* stm = (adapter_state_machine_t*)sm;
+    stm->ble_turning_off_safe = false;
+
     /* LE profile service shotdown */
     service_manager_shutdown(BT_TRANSPORT_BLE);
     adapter_on_le_disabled();

--- a/service/src/adapter_state.c
+++ b/service/src/adapter_state.c
@@ -338,6 +338,7 @@ static bool ble_on_process_event(state_machine_t* sm, uint32_t event, void* p_da
         break;
     case SYS_TURN_OFF:
     case TURN_OFF_BLE:
+    case SYS_TURN_OFF_SAFE:
         hsm_transition_to(sm, &ble_turning_off_state);
         break;
     default:


### PR DESCRIPTION
bug: v/84222

The bttool calls the disable API. While the SYS_TURN_OFF_SAFE event is received in ble_on_state, the ble_on_process_event handler fails to process this event, causing the disable operation to fail. Add handling for the SYS_TURN_OFF_SAFE event in ble_on_process_event and transition to the ble_turning_off_state.


