### PR TITLE
bluetooth: check remote address retrieval in HFP AG

### DIFF
--- a/service/stacks/zephyr/sal_hfp_ag_interface.c
+++ b/service/stacks/zephyr/sal_hfp_ag_interface.c
@@ -150,7 +150,14 @@ static bt_hfp_ag_connection_t* new_sal_connection(struct bt_conn* conn, struct b
         BT_LOGE("%s, malloc failed", __func__);
         return NULL;
     }
-    bt_sal_get_remote_address(conn, &sal_conn->addr);
+
+    bt_status_t status = bt_sal_get_remote_address(conn, &sal_conn->addr);
+    if (status != BT_STATUS_SUCCESS) {
+        BT_LOGE("%s, failed to get remote address", __func__);
+        free(sal_conn);
+        return NULL;
+    }
+
     sal_conn->context = conn;
     sal_conn->ag = ag;
     sal_conn->calls = bt_list_new(free_call);


### PR DESCRIPTION
bluetooth: check remote address retrieval in HFP AG

bug: v/83166

Check bt_sal_get_remote_address() return value when creating HFP AG connection to avoid using an uninitialized address on failure.

