### PR TITLE
Adapt legacy adv

### DIFF
--- a/service/stacks/zephyr/sal_le_advertise_interface.c
+++ b/service/stacks/zephyr/sal_le_advertise_interface.c
@@ -74,6 +74,32 @@ static struct bt_le_ext_adv_cb g_adv_cb = {
     .connected = ext_adv_connected,
 };
 
+static bt_status_t parse_bt_adv_data(uint8_t* raw, uint16_t raw_len,
+    struct bt_data* out, size_t out_max, size_t* out_size)
+{
+    size_t index;
+
+    if (!out || !out_size) {
+        return BT_STATUS_PARM_INVALID;
+    }
+
+    *out_size = 0;
+
+    if (!raw || raw_len == 0) {
+        return BT_STATUS_SUCCESS;
+    }
+
+    for (index = 0; index < raw_len;) {
+        out[*out_size].data_len = raw[index] - 1;
+        out[*out_size].type = raw[index + 1];
+        out[*out_size].data = &raw[index + 2];
+        index += out[*out_size].data_len + 2;
+        (*out_size)++;
+    }
+
+    return BT_STATUS_SUCCESS;
+}
+
 static void ext_adv_terminated_cb(struct bt_le_ext_adv* adv)
 {
     int index;
@@ -273,41 +299,6 @@ static struct bt_le_adv_set* zblue_le_ext_find_adv(uint8_t adv_id)
     return NULL;
 }
 
-static bt_status_t zblue_le_ext_adv_set_data(struct bt_le_ext_adv* adv, uint8_t* adv_data, uint16_t adv_len, uint8_t* scan_rsp_data, uint16_t scan_rsp_len)
-{
-    size_t index;
-    struct bt_data ad[CONFIG_BT_EXT_ADV_MAX_ADV_SEGMENT] = { 0 };
-    struct bt_data sd[CONFIG_BT_EXT_ADV_MAX_ADV_SEGMENT] = { 0 };
-    size_t ad_size = 0;
-    size_t sd_size = 0;
-    int ret;
-
-    for (index = 0; index < adv_len;) {
-        ad[ad_size].data_len = adv_data[index] - 1;
-        ad[ad_size].type = adv_data[index + 1];
-        ad[ad_size].data = &adv_data[index + 2];
-        index += ad[ad_size].data_len + 2;
-        ad_size++;
-    }
-
-    for (index = 0; index < scan_rsp_len;) {
-        sd[sd_size].data_len = scan_rsp_data[index] - 1;
-        sd[sd_size].type = scan_rsp_data[index + 1];
-        sd[sd_size].data = &scan_rsp_data[index + 2];
-        index += sd[sd_size].data_len + 2;
-        sd_size++;
-    }
-
-    ret = bt_le_ext_adv_set_data(adv, ad_size > 0 ? ad : NULL, ad_size,
-        sd_size > 0 ? sd : NULL, sd_size);
-    if (ret) {
-        BT_LOGE("%s, le ext adv set data fail, err:%d", __func__, ret);
-        return BT_STATUS_FAIL;
-    }
-
-    return BT_STATUS_SUCCESS;
-}
-
 static sal_adapter_req_t* sal_adapter_req(bt_controller_id_t id, uint8_t adv_id, sal_func_t func)
 {
     sal_adapter_req_t* req = calloc(sizeof(sal_adapter_req_t), 1);
@@ -351,6 +342,10 @@ static void STACK_CALL(start_adv)(void* args)
     sal_adapter_req_t* req = args;
     struct bt_le_ext_adv* adv;
     int ret;
+    struct bt_data ad[CONFIG_BT_EXT_ADV_MAX_ADV_SEGMENT] = { 0 };
+    struct bt_data sd[CONFIG_BT_EXT_ADV_MAX_ADV_SEGMENT] = { 0 };
+    size_t ad_size = 0;
+    size_t sd_size = 0;
 
     ret = zblue_le_ext_create(&req->adpt.start_adv.param, &adv, req->adv_id);
     if (ret) {
@@ -359,8 +354,22 @@ static void STACK_CALL(start_adv)(void* args)
         goto done;
     }
 
-    ret = zblue_le_ext_adv_set_data(adv, req->adpt.start_adv.adv_data, req->adpt.start_adv.adv_len,
-        req->adpt.start_adv.scan_rsp_data, req->adpt.start_adv.scan_rsp_len);
+    ret = parse_bt_adv_data(req->adpt.start_adv.adv_data, req->adpt.start_adv.adv_len,
+        ad, ARRAY_SIZE(ad), &ad_size);
+    if (ret) {
+        BT_LOGE("%s, parse adv_data fail, err:%d", __func__, ret);
+        goto done;
+    }
+
+    ret = parse_bt_adv_data(req->adpt.start_adv.scan_rsp_data, req->adpt.start_adv.scan_rsp_len,
+        sd, ARRAY_SIZE(sd), &sd_size);
+    if (ret) {
+        BT_LOGE("%s, parse scan_rsp_data fail, ret:%d", __func__, ret);
+        goto done;
+    }
+
+    ret = bt_le_ext_adv_set_data(adv, ad_size > 0 ? ad : NULL, ad_size,
+        sd_size > 0 ? sd : NULL, sd_size);
     if (ret) {
         BT_LOGE("%s, le ext adv set fail, err:%d", __func__, ret);
         ret = BT_STATUS_FAIL;

--- a/service/stacks/zephyr/sal_le_advertise_interface.c
+++ b/service/stacks/zephyr/sal_le_advertise_interface.c
@@ -346,13 +346,7 @@ static void STACK_CALL(start_adv)(void* args)
     struct bt_data sd[CONFIG_BT_EXT_ADV_MAX_ADV_SEGMENT] = { 0 };
     size_t ad_size = 0;
     size_t sd_size = 0;
-
-    ret = zblue_le_ext_create(&req->adpt.start_adv.param, &adv, req->adv_id);
-    if (ret) {
-        BT_LOGE("%s, zblue le ext adv create fail, err:%d", __func__, ret);
-        ret = BT_STATUS_FAIL;
-        goto done;
-    }
+    bool ext_supported = bt_le_ext_adv_is_supported();
 
     ret = parse_bt_adv_data(req->adpt.start_adv.adv_data, req->adpt.start_adv.adv_len,
         ad, ARRAY_SIZE(ad), &ad_size);
@@ -368,19 +362,36 @@ static void STACK_CALL(start_adv)(void* args)
         goto done;
     }
 
-    ret = bt_le_ext_adv_set_data(adv, ad_size > 0 ? ad : NULL, ad_size,
-        sd_size > 0 ? sd : NULL, sd_size);
-    if (ret) {
-        BT_LOGE("%s, le ext adv set fail, err:%d", __func__, ret);
-        ret = BT_STATUS_FAIL;
-        goto done;
-    }
+    if (ext_supported) {
+        ret = zblue_le_ext_create(&req->adpt.start_adv.param, &adv, req->adv_id);
+        if (ret) {
+            BT_LOGE("%s, zblue le ext adv create fail, err:%d", __func__, ret);
+            ret = BT_STATUS_FAIL;
+            goto done;
+        }
 
-    ret = bt_le_ext_adv_start(adv, &req->adpt.start_adv.ext_param);
-    if (ret) {
-        BT_LOGE("%s, le ext adv start fail, err:%d", __func__, ret);
-        ret = BT_STATUS_FAIL;
-        goto done;
+        ret = bt_le_ext_adv_set_data(adv, ad_size > 0 ? ad : NULL, ad_size,
+            sd_size > 0 ? sd : NULL, sd_size);
+        if (ret) {
+            BT_LOGE("%s, le ext adv set fail, err:%d", __func__, ret);
+            ret = BT_STATUS_FAIL;
+            goto done;
+        }
+
+        ret = bt_le_ext_adv_start(adv, &req->adpt.start_adv.ext_param);
+        if (ret) {
+            BT_LOGE("%s, le ext adv start fail, err:%d", __func__, ret);
+            ret = BT_STATUS_FAIL;
+            goto done;
+        }
+    } else {
+        ret = bt_le_adv_start(&req->adpt.start_adv.param, ad_size > 0 ? ad : NULL, ad_size,
+            sd_size > 0 ? sd : NULL, sd_size);
+        if (ret) {
+            BT_LOGE("%s, legacy adv start fail, err:%d", __func__, ret);
+            ret = BT_STATUS_FAIL;
+            goto done;
+        }
     }
 
     advertising_on_state_changed(req->adv_id, LE_ADVERTISING_STARTED);
@@ -398,6 +409,7 @@ bt_status_t bt_sal_le_start_adv(bt_controller_id_t id, uint8_t adv_id, ble_adv_p
     sal_adapter_req_t* req;
     int ret;
     bool ext_adv;
+    bool ext_supported;
 
     req = sal_adapter_req(id, adv_id, STACK_CALL(start_adv));
     if (!req) {
@@ -412,7 +424,14 @@ bt_status_t bt_sal_le_start_adv(bt_controller_id_t id, uint8_t adv_id, ble_adv_p
         goto error;
     }
 
+    ext_supported = bt_le_ext_adv_is_supported();
     ext_adv = (req->adpt.start_adv.param.options & BT_LE_ADV_OPT_EXT_ADV) ? true : false;
+
+    if (ext_adv && !ext_supported) {
+        BT_LOGE("%s, controller not support ext adv", __func__);
+        ret = BT_STATUS_UNSUPPORTED;
+        goto error;
+    }
 
     if ((!(req->adpt.start_adv.param.options & BT_LE_ADV_OPT_SCANNABLE) && ext_adv)
         || !ext_adv) {
@@ -466,6 +485,19 @@ static void STACK_CALL(stop_adv)(void* args)
     sal_adapter_req_t* req = args;
     struct bt_le_adv_set* adv_set;
     int ret;
+    bool ext_supported;
+
+    ext_supported = bt_le_ext_adv_is_supported();
+
+    if (!ext_supported) {
+        ret = bt_le_adv_stop();
+        if (ret) {
+            BT_LOGE("%s, legacy adv stop fail", __func__);
+            return;
+        } else {
+            goto stopped;
+        }
+    }
 
     adv_set = zblue_le_ext_find_adv(req->adv_id);
     if (!adv_set) {
@@ -485,6 +517,7 @@ static void STACK_CALL(stop_adv)(void* args)
         return;
     }
 
+stopped:
     advertising_on_state_changed(req->adv_id, LE_ADVERTISING_STOPPED);
 }
 

--- a/service/stacks/zephyr/sal_le_advertise_interface.c
+++ b/service/stacks/zephyr/sal_le_advertise_interface.c
@@ -176,6 +176,22 @@ static bt_status_t zblue_le_ext_convert_param(ble_adv_params_t* params, struct b
         return BT_STATUS_PARM_INVALID;
     }
 
+    switch (params->filter_policy) {
+    case BT_LE_ADV_FILTER_WHITE_LIST_FOR_SCAN:
+        param->options |= BT_LE_ADV_OPT_FILTER_SCAN_REQ;
+        break;
+    case BT_LE_ADV_FILTER_WHITE_LIST_FOR_CONNECTION:
+        param->options |= BT_LE_ADV_OPT_FILTER_CONN;
+        break;
+    case BT_LE_ADV_FILTER_WHITE_LIST_FOR_ALL:
+        param->options |= BT_LE_ADV_OPT_FILTER_SCAN_REQ;
+        param->options |= BT_LE_ADV_OPT_FILTER_CONN;
+        break;
+    case BT_LE_ADV_FILTER_WHITE_LIST_FOR_NONE:
+    default:
+        param->options |= BT_LE_ADV_OPT_NONE;
+    }
+
     param->interval_min = params->interval;
     param->interval_max = params->interval;
 


### PR DESCRIPTION
depends-on: [open-vela/external_zblue/pull/151]

## PR Title
BLE Advertising: honor `filter_policy`, refactor AD parsing, and fallback to legacy when Ext Adv is unsupported

## Summary
This PR fixes whitelist filtering for LE advertising, removes duplicated AD/ScanRsp parsing logic, and improves compatibility on controllers that do not support Extended Advertising by falling back to legacy advertising APIs.

## Changes
- **Honor `filter_policy` (bug: v/82052)**
  - Map `ble_adv_params_t.filter_policy` to Zephyr `bt_le_adv_param.options`:
    - `BT_LE_ADV_OPT_FILTER_SCAN_REQ`
    - `BT_LE_ADV_OPT_FILTER_CONN`
- **Refactor AD/ScanRsp parsing**
  - Introduce `parse_bt_adv_data()` to convert raw payload into `struct bt_data[]`
  - Replace duplicated parsing code paths with the shared helper
- **Ext Adv capability handling**
  - Use `bt_le_ext_adv_is_supported()` to determine controller capability
  - If Ext Adv is **unsupported**:
    - Start/stop advertising via `bt_le_adv_start()` / `bt_le_adv_stop()` (legacy)
  - If caller requests Ext Adv but controller doesn’t support it:
    - Return `BT_STATUS_UNSUPPORTED` (fail fast and explicit)

## Files Touched
- sal_le_advertise_interface.c

## Behavior Impact
- Whitelist filtering now works as configured via `filter_policy`
- Advertising works on both Ext-Adv-capable and legacy-only controllers
- Explicit error returned when Ext Adv is requested on unsupported controllers

## Testing Notes
- Ext-Adv controller: verify start/set_data/start and stop/delete flows, plus whitelist behavior.
- Legacy-only controller: verify start/stop succeeds via legacy APIs; Ext-Adv request returns `BT_STATUS_UNSUPPORTED`.