### PR TITLE
Bugfix/fix bluetooth hid device service module cb change to const

### DIFF
--- a/feature/feature_async/src/bluetooth_ble_impl.c
+++ b/feature/feature_async/src/bluetooth_ble_impl.c
@@ -299,7 +299,7 @@ static void on_advertising_stopped_cb(bt_advertiser_t* adv, uint8_t adv_id)
     adv_info->busy = false;
 }
 
-static advertiser_callback_t adv_callback = {
+static const advertiser_callback_t adv_callback = {
     sizeof(adv_callback),
     on_advertising_start_cb,
     on_advertising_stopped_cb
@@ -595,7 +595,7 @@ void system_bluetooth_ble_Advertiser_interface_adv_startAdvertising(FeatureInter
     adv_info->start_userdata = (void*)data;
 
     status = bt_le_start_advertising_async(adv_info->ins, &adv_params,
-        p_adv_data, adv_len, p_scan_rsp_data, scan_rsp_len, &adv_callback,
+        p_adv_data, adv_len, p_scan_rsp_data, scan_rsp_len, (advertiser_callback_t *)&adv_callback,
         start_adv_cb, (void*)data);
 
     if (status != BT_STATUS_SUCCESS) {
@@ -1563,7 +1563,7 @@ static void mtu_updated_callback(gattc_handle_t conn_handle, gatt_status_t statu
     bt_list_remove(gattc_info->userdata_list, data);
 }
 
-static bt_gattc_feature_callbacks_t gattc_cbs = {
+static const bt_gattc_feature_callbacks_t gattc_cbs = {
     sizeof(gattc_cbs),
     .on_connected = connect_callback,
     .on_disconnected = disconnect_callback,
@@ -1761,7 +1761,7 @@ void system_bluetooth_ble_GattClient_interface_gattc_connect(FeatureInterfaceHan
             gattc_info->gattc->addr_type, gattc_connect_cb, (void*)data);
     } else {
         status = bt_gattc_feature_create_client_async(gattc_info->ins, &gattc_info->gattc->remote_address, gattc_create_cb,
-            &gattc_cbs, (void*)data);
+            (bt_gattc_feature_callbacks_t *)&gattc_cbs, (void*)data);
     }
 
     if (status != BT_STATUS_SUCCESS) {

--- a/framework/btwrap/async/bt_gatt_feature.c
+++ b/framework/btwrap/async/bt_gatt_feature.c
@@ -716,7 +716,7 @@ static void feature_on_mtu_updated(void* conn_handle, gatt_status_t status, uint
         client->conn, status, mtu);
 }
 
-static gattc_callbacks_t s_feature_gattc_cbs = {
+static const gattc_callbacks_t s_feature_gattc_cbs = {
     sizeof(s_feature_gattc_cbs),
     feature_on_connected,
     feature_on_disconnected,
@@ -806,7 +806,7 @@ bt_status_t bt_gattc_feature_create_client_async(bt_instance_t* ins, bt_address_
     bt_list_add_tail(g_gatt_client_list, client);
 
     status = bt_gattc_create_connect_async(
-        ins, &client->conn, &s_feature_gattc_cbs, create_client_cb, client);
+        ins, &client->conn, (gattc_callbacks_t *)&s_feature_gattc_cbs, create_client_cb, client);
 
     if (status != BT_STATUS_SUCCESS) {
         bt_list_remove(g_gatt_client_list, client);

--- a/service/ipc/socket/src/bt_socket_advertiser.c
+++ b/service/ipc/socket/src/bt_socket_advertiser.c
@@ -82,7 +82,7 @@ static void on_advertising_stopped_cb(bt_advertiser_t* adv, uint8_t adv_id)
     free(adv);
 }
 
-static advertiser_callback_t g_advertiser_socket_cb = {
+static const advertiser_callback_t g_advertiser_socket_cb = {
     sizeof(g_advertiser_socket_cb),
     on_advertising_start_cb,
     on_advertising_stopped_cb,
@@ -106,7 +106,7 @@ void bt_socket_server_advertiser_process(service_poll_t* poll,
             packet->adv_pl._bt_le_start_advertising.adv_len,
             packet->adv_pl._bt_le_start_advertising.scan_rsp_data,
             packet->adv_pl._bt_le_start_advertising.scan_rsp_len,
-            &g_advertiser_socket_cb);
+            (advertiser_callback_t *)&g_advertiser_socket_cb);
 
         if (!packet->adv_r.remote)
             free(adver);

--- a/service/ipc/socket/src/bt_socket_scan.c
+++ b/service/ipc/socket/src/bt_socket_scan.c
@@ -201,7 +201,7 @@ static void on_scan_stopped_cb(bt_scanner_t* scanner)
     free(scanner);
 }
 
-static scanner_callbacks_t g_scanner_socket_cb = {
+static const scanner_callbacks_t g_scanner_socket_cb = {
     sizeof(g_scanner_socket_cb),
     on_scan_result_cb,
     on_scan_status_cb,
@@ -221,7 +221,7 @@ void bt_socket_server_scan_process(service_poll_t* poll,
 
         scan->ins = ins;
         scan->remote = packet->scan_pl._bt_le_start_scan.remote;
-        packet->scan_r.remote = PTR2INT(uint64_t) scanner_start_scan(scan, &g_scanner_socket_cb);
+        packet->scan_r.remote = PTR2INT(uint64_t) scanner_start_scan(scan, (scanner_callbacks_t *)&g_scanner_socket_cb);
         if (!packet->scan_r.remote)
             free(scan);
         break;

--- a/service/ipc/socket/src/bt_socket_spp.c
+++ b/service/ipc/socket/src/bt_socket_spp.c
@@ -95,7 +95,7 @@ static void spp_connection_state_cb(void* handle, bt_address_t* addr,
 
     bt_socket_server_send(ins, &packet, BT_SPP_CONNECTION_STATE_CB);
 }
-static spp_callbacks_t g_spp_socket_cb = {
+static const spp_callbacks_t g_spp_socket_cb = {
     .size = sizeof(g_spp_socket_cb),
     .connection_state_cb = spp_connection_state_cb,
     .proxy_state_cb = spp_proxy_state_cb,
@@ -113,7 +113,7 @@ void bt_socket_server_spp_process(service_poll_t* poll,
     switch (packet->code) {
     case BT_SPP_REGISTER_APP: {
         if (ins->spp_cookie == NULL) {
-            ins->spp_cookie = profile->register_app(ins, packet->spp_pl._bt_spp_register_app.name_len ? packet->spp_pl._bt_spp_register_app.name : NULL, &g_spp_socket_cb);
+            ins->spp_cookie = profile->register_app(ins, packet->spp_pl._bt_spp_register_app.name_len ? packet->spp_pl._bt_spp_register_app.name : NULL, (spp_callbacks_t *)&g_spp_socket_cb);
             packet->spp_r.handle = PTR2INT(uint64_t) ins->spp_cookie;
         } else {
             packet->spp_r.handle = 0;

--- a/service/profiles/hid/hid_device_service.c
+++ b/service/profiles/hid/hid_device_service.c
@@ -546,7 +546,7 @@ exit:
     return status;
 }
 
-static hid_device_interface_t deviceInterface = {
+static const hid_device_interface_t deviceInterface = {
     .size = sizeof(deviceInterface),
     .register_callbacks = hid_device_register_callbacks,
     .unregister_callbacks = hid_device_unregister_callbacks,


### PR DESCRIPTION
Memory Optimization: Change the bluetooth hid device service module to const for reduce the ram size.
    
bug:v/84946
    
Rootcause: To reduce RAM resource consumption, the `deviceInterface`
in the hid device service module must be marked with the `const` modifier.
This ensures it is compiled and linked into Flash memory instead of RAM.
