### PR TITLE
avrcp: Fix the issue where the AVRCP CT cannot control the TG to swit…

### DIFF
--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -1299,8 +1299,8 @@ static void zblue_on_tg_passthrough_req(struct bt_avrcp_tg* tg, uint8_t tid, str
     case PASSTHROUGH_CMD_ID_PLAY:
     case PASSTHROUGH_CMD_ID_STOP:
     case PASSTHROUGH_CMD_ID_PAUSE:
-    case PASSTHROUGH_CMD_ID_RECORD:
-    case PASSTHROUGH_CMD_ID_REWIND:
+    case PASSTHROUGH_CMD_ID_FORWARD:
+    case PASSTHROUGH_CMD_ID_BACKWARD:
         break;
     default:
         BT_LOGW("%s, operation 0x%x not recognized", __func__, opid);


### PR DESCRIPTION
…ch songs.

bug: v/83779

When handling the handle_avrcp_passthrough_cmd function, the AVRCP Target (TG) does not report the PASSTHROUGH_CMD_ID_FORWARD and PASSTHROUGH_CMD_ID_BACKWARD events to the service. Instead, it directly responds to the peer device with BT_AVRCP_RSP_NOT_IMPLEMENTED, causing the peer device’s track switching control to fail.