### PR TITLE
add conn null check after bt_conn_lookup_addr_br.

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -40,8 +40,8 @@
 #include "sal_adapter_le_interface.h"
 #include "sal_connection_manager.h"
 #include "sal_interface.h"
-#include "sal_zephyr_interface.h"
 #include "sal_zblue.h"
+#include "sal_zephyr_interface.h"
 
 #include <settings_zblue.h>
 #include <zephyr/settings/settings.h>
@@ -1168,6 +1168,11 @@ static void STACK_CALL(acl_connection_reply)(void* args)
     sal_adapter_req_t* req = args;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)&req->addr);
 
+    if (!conn) {
+        BT_LOGE("%s, conn null", __func__);
+        return;
+    }
+
     if (req->adpt.accept) {
         SAL_CHECK(bt_conn_accept_acl_conn(conn), 0);
     } else {
@@ -1207,6 +1212,11 @@ static void STACK_CALL(ssp_reply)(void* args)
 {
     sal_adapter_req_t* req = args;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)&req->addr);
+
+    if (!conn) {
+        BT_LOGE("%s, conn null", __func__);
+        return;
+    }
 
     if (req->adpt.ssp.accept) {
         switch (req->adpt.ssp.type) {
@@ -1255,6 +1265,11 @@ static void STACK_CALL(pin_reply)(void* args)
     sal_adapter_req_t* req = args;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)&req->addr);
 
+    if (!conn) {
+        BT_LOGE("%s, conn null", __func__);
+        return;
+    }
+
     if (req->adpt.pin.accept) {
         SAL_CHECK(bt_conn_auth_pincode_entry(conn, req->adpt.pin.pincode), 0);
     } else {
@@ -1295,6 +1310,11 @@ connection_state_t bt_sal_get_connection_state(bt_controller_id_t id, bt_address
     struct bt_conn_info info;
     connection_state_t state = CONNECTION_STATE_DISCONNECTED;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
+
+    if (!conn) {
+        BT_LOGE("%s, conn null", __func__);
+        return CONNECTION_STATE_DISCONNECTED;
+    }
 
     bt_conn_get_info(conn, &info);
     switch (info.state) {
@@ -1527,6 +1547,11 @@ static void STACK_CALL(cancel_bond)(void* args)
 {
     sal_adapter_req_t* req = args;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)&req->addr);
+
+    if (!conn) {
+        BT_LOGE("%s, conn null", __func__);
+        return;
+    }
 
     SAL_CHECK(bt_conn_auth_cancel(conn), 0);
     SAL_CHECK(bt_br_unpair((bt_addr_t*)&req->addr), 0);
@@ -1775,6 +1800,11 @@ static void STACK_CALL(set_power_mode)(void* args)
     bt_pm_mode_t* pm = &req->adpt.mode;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)&req->addr);
 
+    if (!conn) {
+        BT_LOGE("%s, conn null", __func__);
+        return;
+    }
+
     if (pm->mode == BT_LINK_MODE_ACTIVE) {
         SAL_CHECK(bt_conn_exit_sniff_mode(conn), 0);
     } else {
@@ -1819,6 +1849,11 @@ static void STACK_CALL(set_link_role)(void* args)
     sal_adapter_req_t* req = args;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)&req->addr);
 
+    if (!conn) {
+        BT_LOGE("%s, conn null", __func__);
+        return;
+    }
+
     SAL_CHECK(bt_conn_switch_role(conn, req->adpt.role), 0);
     bt_conn_unref(conn);
 }
@@ -1847,6 +1882,12 @@ static void STACK_CALL(set_link_policy)(void* args)
 {
     sal_adapter_req_t* req = args;
     struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)&req->addr);
+
+    if (!conn) {
+        BT_LOGE("%s, conn null", __func__);
+        return;
+    }
+
     uint16_t policy = 0;
 
     switch (req->adpt.policy) {


### PR DESCRIPTION
bug: v/85073

rootcause:
For example, an ACL connection might suddenly drop, due to issues such as controller problems or remote device problems. Therefore, we might get an empty `conn`. We must perform a null check here to avoid operations like `conn->hdev` when calling the API.