### PR TITLE
Add dynamic log control for SPP data transmission

### DIFF
--- a/framework/api/bt_spp.c
+++ b/framework/api/bt_spp.c
@@ -80,3 +80,23 @@ bt_status_t BTSYMBOLS(bt_spp_disconnect)(bt_instance_t* ins, void* handle, bt_ad
 
     return profile->disconnect(handle, addr, port);
 }
+
+bt_status_t BTSYMBOLS(bt_spp_enable_dump)(bt_instance_t* ins, void* handle)
+{
+    spp_interface_t* profile = get_profile_service();
+
+    if (profile->enable_dump) {
+        return profile->enable_dump(handle);
+    }
+    return BT_STATUS_UNSUPPORTED;
+}
+
+bt_status_t BTSYMBOLS(bt_spp_disable_dump)(bt_instance_t* ins, void* handle)
+{
+    spp_interface_t* profile = get_profile_service();
+
+    if (profile->disable_dump) {
+        return profile->disable_dump(handle);
+    }
+    return BT_STATUS_UNSUPPORTED;
+}

--- a/framework/include/bt_spp.h
+++ b/framework/include/bt_spp.h
@@ -456,6 +456,58 @@ void app_disconnect_spp_server(bt_instance_t* ins, void* handle)
  */
 bt_status_t BTSYMBOLS(bt_spp_disconnect)(bt_instance_t* ins, void* handle, bt_address_t* addr, uint16_t port);
 
+/**
+ * @brief Enable SPP data dump for debugging
+ *
+ * This function enables SPP data dump for debugging purposes. When enabled,
+ * SPP will dump transmission data (first 16 bytes) with detailed information
+ * including function name, SPP port, proxy handle, and transmission byte count.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param handle - SPP APP handle.
+ * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ *
+ * **Example:**
+ * @code
+void app_enable_spp_dump(bt_instance_t* ins, void* handle)
+{
+    bt_status_t status;
+
+    status = bt_spp_enable_dump(ins, handle);
+    if(status != BT_STATUS_SUCCESS)
+        printf("enable spp dump failed\n");
+    else
+        printf("enable spp dump success\n");
+}
+ * @endcode
+ */
+bt_status_t BTSYMBOLS(bt_spp_enable_dump)(bt_instance_t* ins, void* handle);
+
+/**
+ * @brief Disable SPP data dump for debugging
+ *
+ * This function disables SPP data dump for debugging purposes.
+ *
+ * @param ins - Bluetooth client instance.
+ * @param handle - SPP APP handle.
+ * @return bt_status_t - BT_STATUS_SUCCESS on success, a negated errno value on failure.
+ *
+ * **Example:**
+ * @code
+void app_disable_spp_dump(bt_instance_t* ins, void* handle)
+{
+    bt_status_t status;
+
+    status = bt_spp_disable_dump(ins, handle);
+    if(status != BT_STATUS_SUCCESS)
+        printf("disable spp dump failed\n");
+    else
+        printf("disable spp dump success\n");
+}
+ * @endcode
+ */
+bt_status_t BTSYMBOLS(bt_spp_disable_dump)(bt_instance_t* ins, void* handle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/service/profiles/include/spp_service.h
+++ b/service/profiles/include/spp_service.h
@@ -30,6 +30,8 @@ typedef struct spp_interface {
     bt_status_t (*server_stop)(void* handle, uint16_t scn);
     bt_status_t (*connect)(void* handle, bt_address_t* addr, int16_t scn, bt_uuid_t* uuid, uint16_t* port);
     bt_status_t (*disconnect)(void* handle, bt_address_t* addr, uint16_t port);
+    bt_status_t (*enable_dump)(void* handle);
+    bt_status_t (*disable_dump)(void* handle);
 } spp_interface_t;
 
 void spp_on_connection_state_changed(bt_address_t* addr, uint16_t conn_port,

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -54,6 +54,15 @@
 #define spp_dumpbuffer(m, a, n)
 #endif
 
+#define spp_dump_trans_data(device, buffer, length)                                   \
+    do {                                                                              \
+        if (g_spp_handle.dump_enabled) {                                              \
+            BT_LOGD("%s, dump spp port %d, proxy %p transmission %d bytes data",      \
+                __func__, (int)device->conn_id, device->handle, (int)(length));       \
+            lib_dumpbuffer("data:", buffer, (size_t)((length) > 16 ? 16 : (length))); \
+        }                                                                             \
+    } while (0)
+
 #define STACK_SVR_PORT(scn) (((scn << 1) & 0x3E) + 1)
 #define STACK_CONN_PORT(scn, conn_id, accept) \
     ((conn_id << 6) + (accept ? STACK_SVR_PORT(scn) : ((scn << 1) & 0x3E)))
@@ -77,6 +86,7 @@ struct spp_service_global {
     struct list_node devices;
     struct list_node servers;
     struct list_node apps;
+    uint8_t dump_enabled;
 };
 
 typedef struct spp_handle {
@@ -157,6 +167,8 @@ static void spp_proxy_connection_callback(euv_pipe_t* handle, int status, void* 
 static bt_status_t spp_unregister_app(void** remote, void* handle);
 static bool spp_rx_buffer_empty(spp_device_t* device);
 static void euv_close_complete(euv_pipe_t* handle);
+static bt_status_t spp_enable_dump(void* handle);
+static bt_status_t spp_disable_dump(void* handle);
 
 /****************************************************************************
  * Private Data
@@ -574,6 +586,7 @@ static void euv_read_complete(euv_pipe_t* handle, const uint8_t* buf, ssize_t si
     }
 
     spp_dumpbuffer("master read:", buf, size);
+    spp_dump_trans_data(device, (uint8_t*)buf, size);
     do_spp_write(device, (uint8_t*)buf, size);
 }
 
@@ -614,6 +627,7 @@ static void spp_rx_buffer_send(spp_device_t* device)
     {
         buf = (spp_rx_buf_t*)node;
         device->rx_bytes += buf->length;
+        spp_dump_trans_data(device, buf->buffer, buf->length);
         if (euv_pipe_write(device->handle, buf->buffer, buf->length, euv_write_complete) != 0) {
             BT_LOGE("Spp write to slave port %d failed", device->conn_port);
             break;
@@ -744,6 +758,7 @@ static int do_spp_write(spp_device_t* device, uint8_t* buffer, uint16_t length)
         }
 
         bt_pm_busy(PROFILE_SPP, &device->addr);
+        spp_dump_trans_data(device, tmpbuf, size);
         status = bt_sal_spp_write(device->conn_port, tmpbuf, size);
         if (status != BT_STATUS_SUCCESS) {
             BT_LOGE("%s write to stack failed", __func__);
@@ -838,6 +853,7 @@ static void spp_on_incoming_data_received(bt_address_t* addr, uint16_t port,
 
     spp_dumpbuffer("master write:", buffer, length);
     device->rx_bytes += length;
+    spp_dump_trans_data(device, buffer, length);
     ret = euv_pipe_write(device->handle, buffer, length, euv_write_complete);
     if (ret != 0) {
         BT_LOGE("Spp write to slave port %d failed", device->conn_port);
@@ -942,6 +958,7 @@ static bt_status_t spp_init(void)
 
     memset(&g_spp_handle, 0, sizeof(g_spp_handle));
     g_spp_handle.started = 0;
+    g_spp_handle.dump_enabled = 0;
 
     return BT_STATUS_SUCCESS;
 }
@@ -1205,6 +1222,40 @@ static bt_status_t spp_disconnect(void* handle, bt_address_t* addr, uint16_t por
     return ret;
 }
 
+static bt_status_t spp_enable_dump(void* handle)
+{
+    if (!handle)
+        return BT_STATUS_FAIL;
+
+    pthread_mutex_lock(&g_spp_handle.spp_lock);
+    if (!g_spp_handle.started) {
+        pthread_mutex_unlock(&g_spp_handle.spp_lock);
+        return BT_STATUS_NOT_ENABLED;
+    }
+
+    g_spp_handle.dump_enabled = 1;
+    BT_LOGI("SPP data dump enabled");
+    pthread_mutex_unlock(&g_spp_handle.spp_lock);
+    return BT_STATUS_SUCCESS;
+}
+
+static bt_status_t spp_disable_dump(void* handle)
+{
+    if (!handle)
+        return BT_STATUS_FAIL;
+
+    pthread_mutex_lock(&g_spp_handle.spp_lock);
+    if (!g_spp_handle.started) {
+        pthread_mutex_unlock(&g_spp_handle.spp_lock);
+        return BT_STATUS_NOT_ENABLED;
+    }
+
+    g_spp_handle.dump_enabled = 0;
+    BT_LOGI("SPP data dump disabled");
+    pthread_mutex_unlock(&g_spp_handle.spp_lock);
+    return BT_STATUS_SUCCESS;
+}
+
 static void spp_cleanup(void)
 {
 }
@@ -1260,6 +1311,8 @@ static spp_interface_t sppInterface = {
     .server_stop = spp_server_stop,
     .connect = spp_connect,
     .disconnect = spp_disconnect,
+    .enable_dump = spp_enable_dump,
+    .disable_dump = spp_disable_dump,
 };
 
 static const void* get_spp_profile_interface(void)


### PR DESCRIPTION
bug: v/85159

Add dynamic logging control for SPP data transmission to aid in debugging, introducing the spp_dump_trans_data macro to log function name, SPP port, proxy handle, data size, and first 16 bytes of data at key points including euv_read_complete, spp_rx_buffer_send, spp_on_incoming_data_received, and do_spp_write, with runtime enable/disable via new spp_enable_dump and spp_disable_dump functions, extended interface, and public APIs bt_spp_enable_dump and bt_spp_disable_dump, minimizing performance impact by default disabling logging and allowing on-demand activation.

