### PR TITLE
L2CAP: Add MPS validation for received segments

### DIFF
--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -861,6 +861,14 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t
         return;
     }
 
+    if (packet->len_received > channel->incoming.le_mps) {
+        BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") received segment length %" PRIu16 " is larger than MPS %" PRIu16,
+            __func__, channel->id, channel->local_cid, packet->len_received, channel->incoming.le_mps);
+        free(packet);
+        l2cap_abort_channel(channel);
+        return;
+    }
+
     if (packet->len_total > channel->incoming.mtu) {
         BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") received sdu length %" PRIu16 " is larger than mtu %" PRIu16,
             __func__, channel->id, channel->local_cid, packet->len_total, channel->incoming.mtu);

--- a/service/src/l2cap_service.c
+++ b/service/src/l2cap_service.c
@@ -879,7 +879,7 @@ static void handle_packet_received(bt_address_t* addr, uint16_t cid, l2cap_pkt_t
 
     if (channel->incoming.credits == 0) {
         BT_LOGE("%s, L2CAP channel(id:%" PRIu16 "/cid:0x%" PRIx16 ") has no incoming credits",
-            __func__, channel->id, channel->local_cid, packet->len_received);
+            __func__, channel->id, channel->local_cid);
         free(packet);
         l2cap_abort_channel(channel);
         return;


### PR DESCRIPTION
bug: v/85177

Add validation check to ensure received segment length does not exceed the negotiated MPS before processing. Abort channel if validation fails to maintain protocol integrity.