### PR TITLE
SPP: Add dynamic log control for SPP data transmission

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -757,8 +757,15 @@ config BLUETOOTH_SPP_RPMSG_NET
 	default n
 	depends on NET_RPMSG
 
+config BLUETOOTH_SPP_DUMP_ENABLE
+	bool "Enable SPP data dump"
+	default y
+	help
+		Enable SPP data dump for debugging transmission issues.
+		When enabled, SPP data packets will be dumped to logs for debugging.
+
 endif #BLUETOOTH_SPP
-	
+
 config BLUETOOTH_HID_DEVICE
 	bool "Human Interface Device Profile (HID)"
 	default n

--- a/framework/api/bt_trace.c
+++ b/framework/api/bt_trace.c
@@ -19,6 +19,16 @@
 #include "utils/btsnoop_log.h"
 #include "utils/log.h"
 
+void BTSYMBOLS(bluetooth_enable_log)(bt_instance_t* ins, uint8_t log_type)
+{
+    bt_log_module_enable((int)log_type, false);
+}
+
+void BTSYMBOLS(bluetooth_disable_log)(bt_instance_t* ins, uint8_t log_type)
+{
+    bt_log_module_disable((int)log_type, false);
+}
+
 void BTSYMBOLS(bluetooth_enable_btsnoop_log)(bt_instance_t* ins)
 {
     bt_log_module_enable(LOG_ID_SNOOP, false);

--- a/framework/common/bt_trace.h
+++ b/framework/common/bt_trace.h
@@ -36,6 +36,22 @@ typedef enum {
 } btsnoop_filter_flag_t;
 
 /**
+ * @brief Enable bluetooth log
+ *
+ * @param ins - bluetooth client instance.
+ * @param log_type - log type to enable.
+ */
+void BTSYMBOLS(bluetooth_enable_log)(bt_instance_t* ins, uint8_t log_type);
+
+/**
+ * @brief Disable bluetooth log
+ *
+ * @param ins - bluetooth client instance.
+ * @param log_type - log type to disable.
+ */
+void BTSYMBOLS(bluetooth_disable_log)(bt_instance_t* ins, uint8_t log_type);
+
+/**
  * @brief Enable bluetooth btsnoop log
  *
  * @param ins - bluetooth client instance.
@@ -69,6 +85,8 @@ void BTSYMBOLS(bluetooth_remove_btsnoop_filter)(bt_instance_t* ins, btsnoop_filt
 #ifdef CONFIG_BLUETOOTH_FRAMEWORK_ASYNC
 #include "bt_async.h"
 
+bt_status_t bluetooth_enable_log_async(bt_instance_t* ins, uint8_t log_type, bt_status_cb_t cb, void* userdata);
+bt_status_t bluetooth_disable_log_async(bt_instance_t* ins, uint8_t log_type, bt_status_cb_t cb, void* userdata);
 bt_status_t bluetooth_enable_btsnoop_log_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
 bt_status_t bluetooth_disable_btsnoop_log_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
 bt_status_t bluetooth_set_btsnoop_filter_async(bt_instance_t* ins, btsnoop_filter_flag_t filter_flag,

--- a/framework/socket/async/bt_trace_async.c
+++ b/framework/socket/async/bt_trace_async.c
@@ -20,22 +20,34 @@
 #include "bt_trace.h"
 #include "utils/btsnoop_log.h"
 
-bt_status_t bluetooth_enable_btsnoop_log_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata)
+bt_status_t bluetooth_enable_log_async(bt_instance_t* ins, uint8_t log_type, bt_status_cb_t cb, void* userdata)
 {
     bt_message_packet_t packet = { 0 };
 
     BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
 
+    packet.log_pl._bt_log_set_type.log_type = log_type;
     return bt_socket_client_send_with_reply(ins, &packet, BT_LOG_ENABLE, NULL, (void*)cb, userdata);
+}
+
+bt_status_t bluetooth_disable_log_async(bt_instance_t* ins, uint8_t log_type, bt_status_cb_t cb, void* userdata)
+{
+    bt_message_packet_t packet = { 0 };
+
+    BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
+
+    packet.log_pl._bt_log_set_type.log_type = log_type;
+    return bt_socket_client_send_with_reply(ins, &packet, BT_LOG_DISABLE, NULL, (void*)cb, userdata);
+}
+
+bt_status_t bluetooth_enable_btsnoop_log_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata)
+{
+    return bluetooth_enable_log_async(ins, 0, cb, userdata);
 }
 
 bt_status_t bluetooth_disable_btsnoop_log_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata)
 {
-    bt_message_packet_t packet = { 0 };
-
-    BT_SOCKET_INS_VALID(ins, BT_STATUS_PARM_INVALID);
-
-    return bt_socket_client_send_with_reply(ins, &packet, BT_LOG_DISABLE, NULL, (void*)cb, userdata);
+    return bluetooth_disable_log_async(ins, 0, cb, userdata);
 }
 
 bt_status_t bluetooth_set_btsnoop_filter_async(bt_instance_t* ins, btsnoop_filter_flag_t filter_flag,

--- a/framework/socket/bt_trace.c
+++ b/framework/socket/bt_trace.c
@@ -19,22 +19,34 @@
 #include "bt_socket.h"
 #include "utils/btsnoop_log.h"
 
-void bluetooth_enable_btsnoop_log(bt_instance_t* ins)
+void bluetooth_enable_log(bt_instance_t* ins, uint8_t log_type)
 {
     bt_message_packet_t packet;
 
     BT_SOCKET_INS_VALID(ins, );
 
+    packet.log_pl._bt_log_set_type.log_type = log_type;
     (void)bt_socket_client_sendrecv(ins, &packet, BT_LOG_ENABLE);
+}
+
+void bluetooth_disable_log(bt_instance_t* ins, uint8_t log_type)
+{
+    bt_message_packet_t packet;
+
+    BT_SOCKET_INS_VALID(ins, );
+
+    packet.log_pl._bt_log_set_type.log_type = log_type;
+    (void)bt_socket_client_sendrecv(ins, &packet, BT_LOG_DISABLE);
+}
+
+void bluetooth_enable_btsnoop_log(bt_instance_t* ins)
+{
+    bluetooth_enable_log(ins, 0);
 }
 
 void bluetooth_disable_btsnoop_log(bt_instance_t* ins)
 {
-    bt_message_packet_t packet;
-
-    BT_SOCKET_INS_VALID(ins, );
-
-    (void)bt_socket_client_sendrecv(ins, &packet, BT_LOG_DISABLE);
+    bluetooth_disable_log(ins, 0);
 }
 
 void bluetooth_set_btsnoop_filter(bt_instance_t* ins, btsnoop_filter_flag_t filter_flag)

--- a/service/ipc/socket/include/bt_message_log.h
+++ b/service/ipc/socket/include/bt_message_log.h
@@ -46,6 +46,10 @@ BT_LOG_MESSAGE_START,
         uint32_t filter_flag;
     } _bt_log_set_flag,
         _bt_log_remove_flag;
+    struct {
+        uint8_t log_type;
+        uint8_t reserved[3];
+    } _bt_log_set_type;
 } bt_message_log_t;
 
 #endif /* _BT_MESSAGE_LOG_H__ */

--- a/service/ipc/socket/src/bt_socket_log.c
+++ b/service/ipc/socket/src/bt_socket_log.c
@@ -60,13 +60,13 @@ void bt_socket_server_log_process(service_poll_t* poll,
 {
     switch (packet->code) {
     case BT_LOG_ENABLE: {
-        BTSYMBOLS(bluetooth_enable_btsnoop_log)
-        (ins);
+        BTSYMBOLS(bluetooth_enable_log)
+        (ins, packet->log_pl._bt_log_set_type.log_type);
         break;
     }
     case BT_LOG_DISABLE: {
-        BTSYMBOLS(bluetooth_disable_btsnoop_log)
-        (ins);
+        BTSYMBOLS(bluetooth_disable_log)
+        (ins, packet->log_pl._bt_log_set_type.log_type);
         break;
     }
     case BT_LOG_SET_FILTER: {

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -48,11 +48,7 @@
 #define DEFAULT_PACKET_SIZE (255)
 #define SENDING_BUFS_QUOTA 13
 #define CACHE_SEND_TIMEOUT 15
-#ifdef CONFIG_BLUETOOTH_SPP_DUMPBUFFER
-#define spp_dumpbuffer(m, a, n) lib_dumpbuffer(m, a, n)
-#else
-#define spp_dumpbuffer(m, a, n)
-#endif
+#define SPP_DUMP_MAX_BYTES 16
 
 #define STACK_SVR_PORT(scn) (((scn << 1) & 0x3E) + 1)
 #define STACK_CONN_PORT(scn, conn_id, accept) \
@@ -151,6 +147,9 @@ typedef struct {
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
+#ifdef CONFIG_BLUETOOTH_SPP_DUMP_ENABLE
+static void spp_dump_buffer(const spp_device_t* device, const char* direction, const uint8_t* buffer, uint32_t length);
+#endif
 static int do_spp_write(spp_device_t* device, uint8_t* buffer, uint16_t length);
 static void spp_server_cleanup_devices(spp_server_t* server);
 static void spp_proxy_connection_callback(euv_pipe_t* handle, int status, void* user_data);
@@ -166,6 +165,28 @@ static struct spp_service_global g_spp_handle = { .started = 0 };
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+#ifdef CONFIG_BLUETOOTH_SPP_DUMP_ENABLE
+static void spp_dump_buffer(const spp_device_t* device, const char* direction, const uint8_t* buffer, uint32_t length)
+{
+    if (!bt_log_spp_dump_is_enable())
+        return;
+
+    if (!device) {
+        BT_LOGD("SPP port [null] device %s: skip dump", direction);
+        return;
+    }
+
+    if (!buffer) {
+        BT_LOGD("SPP port %" PRIu16 " %s: [null] buffer", device->conn_id, direction);
+        return;
+    }
+
+    BT_LOGD("SPP port %" PRIu16 " %s: %" PRIu32 " bytes", device->conn_id, direction, length);
+
+    lib_dumpbuffer("data:", buffer, length > SPP_DUMP_MAX_BYTES ? SPP_DUMP_MAX_BYTES : length);
+}
+#endif
+
 #if 0
 static const char* spp_event_to_string(uint8_t event)
 {
@@ -573,7 +594,9 @@ static void euv_read_complete(euv_pipe_t* handle, const uint8_t* buf, ssize_t si
         return;
     }
 
-    spp_dumpbuffer("master read:", buf, size);
+#ifdef CONFIG_BLUETOOTH_SPP_DUMP_ENABLE
+    spp_dump_buffer(device, "master read", buf, size);
+#endif
     do_spp_write(device, (uint8_t*)buf, size);
 }
 
@@ -614,11 +637,13 @@ static void spp_rx_buffer_send(spp_device_t* device)
     {
         buf = (spp_rx_buf_t*)node;
         device->rx_bytes += buf->length;
+#ifdef CONFIG_BLUETOOTH_SPP_DUMP_ENABLE
+        spp_dump_buffer(device, "master write", buf->buffer, buf->length);
+#endif
         if (euv_pipe_write(device->handle, buf->buffer, buf->length, euv_write_complete) != 0) {
             BT_LOGE("Spp write to slave port %d failed", device->conn_port);
             break;
         }
-        spp_dumpbuffer("master buffer write:", buf->buffer, buf->length);
         list_delete(node);
         free(node);
     }
@@ -743,6 +768,10 @@ static int do_spp_write(spp_device_t* device, uint8_t* buffer, uint16_t length)
             tmpbuf = buffer;
         }
 
+#ifdef CONFIG_BLUETOOTH_SPP_DUMP_ENABLE
+        spp_dump_buffer(device, "slave write", tmpbuf, size);
+#endif
+
         bt_pm_busy(PROFILE_SPP, &device->addr);
         status = bt_sal_spp_write(device->conn_port, tmpbuf, size);
         if (status != BT_STATUS_SUCCESS) {
@@ -836,7 +865,9 @@ static void spp_on_incoming_data_received(bt_address_t* addr, uint16_t port,
         return;
     }
 
-    spp_dumpbuffer("master write:", buffer, length);
+#ifdef CONFIG_BLUETOOTH_SPP_DUMP_ENABLE
+    spp_dump_buffer(device, "master write", buffer, length);
+#endif
     device->rx_bytes += length;
     ret = euv_pipe_write(device->handle, buffer, length, euv_write_complete);
     if (ret != 0) {

--- a/service/utils/log.h
+++ b/service/utils/log.h
@@ -35,6 +35,7 @@
 #define LOG_ID_SNOOP 0
 #define LOG_ID_STACK 1
 #define LOG_ID_FRAMEWORK 2
+#define LOG_ID_SPP_DUMP 3
 
 enum bt_log_level_ {
     BT_LOG_LEVEL_OFF = 0x0,
@@ -100,4 +101,5 @@ void bt_log_server_init(void);
 void bt_log_server_cleanup(void);
 void bt_log_module_enable(int id, bool changed);
 void bt_log_module_disable(int id, bool changed);
+bool bt_log_spp_dump_is_enable(void);
 #endif

--- a/service/utils/log_server.c
+++ b/service/utils/log_server.c
@@ -49,6 +49,7 @@ enum {
 struct bt_logger {
     uint8_t stack_enable;
     uint8_t snoop_enable;
+    uint8_t spp_dump_enable;
 
     uint8_t framework_level;
     int stack_mask;
@@ -59,7 +60,7 @@ struct bt_logger {
     service_poll_t* poll;
 };
 
-static struct bt_logger g_logger = { 0, 0, BT_LOG_LEVEL_OFF, 0, 0, 0, -1 };
+static struct bt_logger g_logger = { 0, 0, 0, BT_LOG_LEVEL_OFF, 0, 0, 0, -1 };
 
 static const char* log_id_str(uint8_t id)
 {
@@ -70,6 +71,8 @@ static const char* log_id_str(uint8_t id)
         return "STACK";
     case LOG_ID_FRAMEWORK:
         return "FRAMEWORK";
+    case LOG_ID_SPP_DUMP:
+        return "SPP_DUMP";
     default:
         return "";
     }
@@ -140,10 +143,17 @@ void bt_log_module_enable(int id, bool changed)
     case LOG_ID_FRAMEWORK: {
         return;
     }
+    case LOG_ID_SPP_DUMP: {
+        if (g_logger.spp_dump_enable)
+            return;
+
+        g_logger.spp_dump_enable = 1;
+        break;
+    }
     }
 
 #if defined(CONFIG_KVDB) && defined(__NuttX__)
-    if (!changed) {
+    if (!changed && property != NULL) {
         property_set_int32(property, 1);
         property_commit();
     }
@@ -178,10 +188,17 @@ void bt_log_module_disable(int id, bool changed)
         g_logger.framework_level = BT_LOG_LEVEL_OFF;
         return;
     }
+    case LOG_ID_SPP_DUMP: {
+        if (!g_logger.spp_dump_enable)
+            return;
+
+        g_logger.spp_dump_enable = 0;
+        break;
+    }
     }
 
 #if defined(CONFIG_KVDB) && defined(__NuttX__)
-    if (!changed) {
+    if (!changed && property != NULL) {
         property_set_int32(property, 0);
         property_commit();
     }
@@ -316,4 +333,9 @@ bool bt_log_print_check(uint8_t level)
         return false;
 
     return true;
+}
+
+bool bt_log_spp_dump_is_enable(void)
+{
+    return g_logger.spp_dump_enable != 0;
 }

--- a/tools/async/log.c
+++ b/tools/async/log.c
@@ -51,8 +51,8 @@ static int unmask_cmd(void* handle, int argc, char* argv[]);
 static int level_cmd(void* handle, int argc, char* argv[]);
 
 static bt_command_t g_log_async_tables[] = {
-    { "enable", enable_cmd, 0, "\"Enable param: (\"snoop\" or \"stack\")\"" },
-    { "disable", disable_cmd, 0, "\"Disable param: (\"snoop\" or \"stack\")\"" },
+    { "enable", enable_cmd, 0, "\"Enable param: (\"snoop\" or \"stack\" or \"spp\")\"" },
+    { "disable", disable_cmd, 0, "\"Disable param: (\"snoop\" or \"stack\" or \"spp\")\"" },
     { "mask", mask_cmd, 0, "\"Enable Stack Profile & Protocol Log <bit>\"\n"
                            "\t\t\tExample enable HCI and L2CAP: \"bttool> log mask 1 4\" \n"
                            "\t\t\tProfile && Protocol Enum:\n"
@@ -107,6 +107,11 @@ static int log_control(void* handle, char* id, int enable)
             bluetooth_enable_btsnoop_log_async(handle, NULL, NULL);
         else
             bluetooth_disable_btsnoop_log_async(handle, NULL, NULL);
+    } else if (strncmp(id, "spp", strlen("spp")) == 0) {
+        if (enable)
+            bluetooth_enable_log_async(handle, LOG_ID_SPP_DUMP, NULL, NULL);
+        else
+            bluetooth_disable_log_async(handle, LOG_ID_SPP_DUMP, NULL, NULL);
     } else
         return CMD_INVALID_PARAM;
 

--- a/tools/log.c
+++ b/tools/log.c
@@ -41,6 +41,7 @@
 #include "bt_tools.h"
 #include "bt_trace.h"
 #include "utils/btsnoop_log.h"
+#include "utils/log.h"
 
 static int enable_cmd(void* handle, int argc, char* argv[]);
 static int disable_cmd(void* handle, int argc, char* argv[]);
@@ -51,8 +52,8 @@ static int unmask_cmd(void* handle, int argc, char* argv[]);
 static int level_cmd(void* handle, int argc, char* argv[]);
 
 static bt_command_t g_log_tables[] = {
-    { "enable", enable_cmd, 0, "\"Enable param: (\"snoop\" or \"stack\")\"" },
-    { "disable", disable_cmd, 0, "\"Disable param: (\"snoop\" or \"stack\")\"" },
+    { "enable", enable_cmd, 0, "\"Enable param: (\"snoop\" or \"stack\" or \"spp\")\"" },
+    { "disable", disable_cmd, 0, "\"Disable param: (\"snoop\" or \"stack\" or \"spp\")\"" },
     { "mask", mask_cmd, 0, "\"Enable Stack Profile & Protocol Log <bit>\"\n"
                            "\t\t\tExample enable HCI and L2CAP: \"bttool> log mask 1 4\" \n"
                            "\t\t\tProfile && Protocol Enum:\n"
@@ -107,6 +108,11 @@ static int log_control(void* handle, char* id, int enable)
             bluetooth_enable_btsnoop_log(handle);
         else
             bluetooth_disable_btsnoop_log(handle);
+    } else if (strncmp(id, "spp", strlen("spp")) == 0) {
+        if (enable)
+            bluetooth_enable_log(handle, LOG_ID_SPP_DUMP);
+        else
+            bluetooth_disable_log(handle, LOG_ID_SPP_DUMP);
     } else
         return CMD_INVALID_PARAM;
 


### PR DESCRIPTION
bug: v/85159

Implemented dynamically controlled SPP data dump functionality for troubleshooting SPP transmission errors.

Modified spp_service.c, changing the spp_dumpbuffer macro to the
spp_dump_buffer function, adding checks for bt_log_spp_dump_is_enable(),
NULL pointer safety, and a maximum 16-byte limit. Added support for
LOG_ID_SPP_DUMP and spp_dump_enable state management in log_server.c.
Added handling for BT_DEBUG_MODE_SPP_DUMP in adapter_service.c, added
support for the spp_dump command in bt_tools.c, and added the
BT_DEBUG_MODE_SPP_DUMP enumeration in bluetooth.h.

