### PR TITLE
sal: bugfix for build error.

### DIFF
--- a/service/src/connection_manager_dlf.c
+++ b/service/src/connection_manager_dlf.c
@@ -19,7 +19,7 @@
 #include "bt_debug.h"
 #include "bt_utils.h"
 #include "hci_parser.h"
-#include "sal_adapter_interface.h"
+#include "sal_interface.h"
 #include "service_loop.h"
 #include "vendor/bt_vendor.h"
 #include "vendor/bt_vendor_common.h"

--- a/service/stacks/include/sal_adapter_le_interface.h
+++ b/service/stacks/include/sal_adapter_le_interface.h
@@ -57,11 +57,4 @@ uint16_t bt_sal_le_get_appearance(bt_controller_id_t id);
 bt_status_t bt_sal_le_enable_key_derivation(bt_controller_id_t id, bool brkey_to_lekey, bool lekey_to_brkey);
 bt_status_t bt_sal_get_identity_addr(bt_address_t* addr, bt_address_t* id_addr);
 
-struct bt_conn* get_le_conn_from_addr(bt_address_t* addr);
-bt_status_t get_le_addr_from_conn(struct bt_conn* conn, bt_address_t* addr);
-
-#if defined(CONFIG_BT_USER_PHY_UPDATE)
-ble_phy_type_t le_phy_convert_from_stack(uint8_t mode);
-uint8_t le_phy_convert_from_service(ble_phy_type_t mode);
-#endif
 #endif /* __SAL_ADAPTER_LE_INTERFACE_H_ */

--- a/service/stacks/include/sal_adapter_le_interface.h
+++ b/service/stacks/include/sal_adapter_le_interface.h
@@ -25,9 +25,6 @@
 #include "power_manager.h"
 #include "vhal/bt_vhal.h"
 
-#define GATT_ROLE_SERVER (1UL << 0)
-#define GATT_ROLE_CLIENT (1UL << 1)
-
 bt_status_t bt_sal_le_init(const bt_vhal_interface* vhal);
 void bt_sal_le_cleanup(void);
 bt_status_t bt_sal_le_enable(bt_controller_id_t id);

--- a/service/stacks/include/sal_interface.h
+++ b/service/stacks/include/sal_interface.h
@@ -32,9 +32,7 @@
 #endif
 #include "sal_debug_interface.h"
 
-#if defined(CONFIG_BLUETOOTH_STACK_BREDR_BLUELET) || defined(CONFIG_BLUETOOTH_STACK_LE_BLUELET)
-#include "sal_adapter_interface.h"
-#endif
+#define BT_INVALID_CONNECTION_HANDLE 0xFFFF
 
 typedef struct bt_stack_info {
     char name[32];

--- a/service/stacks/zephyr/include/sal_zblue.h
+++ b/service/stacks/zephyr/include/sal_zblue.h
@@ -16,6 +16,7 @@
 #ifndef __SAL_ZBLUE_H_
 #define __SAL_ZBLUE_H_
 
+#include "bluetooth.h"
 #include "bt_addr.h"
 #include "bt_status.h"
 

--- a/service/stacks/zephyr/include/sal_zephyr_interface.h
+++ b/service/stacks/zephyr/include/sal_zephyr_interface.h
@@ -1,0 +1,36 @@
+/****************************************************************************
+ *  Copyright (C) 2025 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+#ifndef __SAL_ZEPHYR_INTERFACE_H_
+#define __SAL_ZEPHYR_INTERFACE_H_
+
+#include <stdint.h>
+
+#include "bluetooth.h"
+#include "bluetooth_define.h"
+#include "bt_addr.h"
+#include "bt_status.h"
+#include "power_manager.h"
+#include "vhal/bt_vhal.h"
+
+struct bt_conn* get_le_conn_from_addr(bt_address_t* addr);
+bt_status_t get_le_addr_from_conn(struct bt_conn* conn, bt_address_t* addr);
+
+#if defined(CONFIG_BT_USER_PHY_UPDATE)
+ble_phy_type_t le_phy_convert_from_stack(uint8_t mode);
+uint8_t le_phy_convert_from_service(ble_phy_type_t mode);
+#endif
+
+#endif /* __SAL_ZEPHYR_INTERFACE_H_ */

--- a/service/stacks/zephyr/include/sal_zephyr_interface.h
+++ b/service/stacks/zephyr/include/sal_zephyr_interface.h
@@ -25,6 +25,9 @@
 #include "power_manager.h"
 #include "vhal/bt_vhal.h"
 
+#define GATT_ROLE_SERVER (1UL << 0)
+#define GATT_ROLE_CLIENT (1UL << 1)
+
 struct bt_conn* get_le_conn_from_addr(bt_address_t* addr);
 bt_status_t get_le_addr_from_conn(struct bt_conn* conn, bt_address_t* addr);
 

--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -40,6 +40,7 @@
 #include "sal_adapter_le_interface.h"
 #include "sal_connection_manager.h"
 #include "sal_interface.h"
+#include "sal_zephyr_interface.h"
 #include "sal_zblue.h"
 
 #include <settings_zblue.h>
@@ -48,8 +49,6 @@
 #include "keys.h"
 
 #include "utils/log.h"
-
-#define BT_INVALID_CONNECTION_HANDLE 0xFFFF
 
 #define STACK_CALL(func) zblue_##func
 

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -23,6 +23,7 @@
 #include "sal_gatt_server_interface.h"
 #include "sal_interface.h"
 #include "sal_zblue.h"
+#include "sal_zephyr_interface.h"
 #include "service_loop.h"
 
 #include <zephyr/bluetooth/bluetooth.h>

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -26,6 +26,7 @@
 #include "sal_gatt_client_interface.h"
 #include "sal_interface.h"
 #include "sal_zblue.h"
+#include "sal_zephyr_interface.h"
 #include "service_loop.h"
 #include "utils/log.h"
 

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -33,6 +33,7 @@
 #include "sal_connection_manager.h"
 #include "sal_interface.h"
 #include "sal_zblue.h"
+#include "sal_zephyr_interface.h"
 #include "service_loop.h"
 #include "utils/log.h"
 

--- a/service/stacks/zephyr/sal_zblue.c
+++ b/service/stacks/zephyr/sal_zblue.c
@@ -17,6 +17,7 @@
 
 #include "sal_zblue.h"
 #include "sal_interface.h"
+#include "sal_zephyr_interface.h"
 #include "utils/log.h"
 
 static bt_conn_info_t g_conn_info[CONFIG_BT_MAX_CONN];


### PR DESCRIPTION
bug: v/84474

1. ../../frameworks/connectivity/bluetooth/service/stacks/zephyr/include/sal_zblue.h:36:30: error: unknown type name 'bt_transport_t'
2. ../../frameworks/connectivity/bluetooth/service/stacks/zephyr/sal_zblue.error: 'GATT_ROLE_SERVER' undeclared
