### PR TITLE
spp: increase max connections from 2 to 9

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -746,7 +746,7 @@ menuconfig BLUETOOTH_SPP
 if BLUETOOTH_SPP
 config BLUETOOTH_SPP_MAX_CONNECTIONS
 	int "SPP max connections"
-	default 1
+	default 8
 
 config BLUETOOTH_SPP_SERVER_MAX_CONNECTIONS
 	int "SPP Server max connections"


### PR DESCRIPTION

bug: v/85292

spp: increase max connections from 2 to 9
- Modify BLUETOOTH_SPP_MAX_CONNECTIONS constant in kconfig
