### PR TITLE
bluetooth: add libbluetooth dependency on zblue when ZBLUE stack is enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,10 +696,7 @@ if(CONFIG_BLUETOOTH)
     endif()
 
     if(CONFIG_BLUETOOTH_STACK_BREDR_ZBLUE OR CONFIG_BLUETOOTH_STACK_LE_ZBLUE)
-      list(APPEND INCDIR ${NUTTX_APPS_DIR}/external/zblue/zblue/port/include/)
-      list(APPEND INCDIR ${NUTTX_APPS_DIR}/external/zblue/zblue/subsys/settings/include/settings)
-      list(APPEND INCDIR
-           ${NUTTX_APPS_DIR}/external/zblue/zblue/port/include/kernel/include)
+      nuttx_add_dependencies(TARGET libbluetooth DEPENDS zblue)
     endif()
 
     list(APPEND INCDIR ${BLUETOOTH_DIR}/service/ipc)


### PR DESCRIPTION
bug: v/85506

When either ZBLUE stack option is enabled, add a dependency on zblue for libbluetooth via nuttx_add_dependencies, so zblue’s include dirs are applied only to libbluetooth and not globally.

## Depends on
- open-vela/external#47

## Notes
- This PR cannot be tested or merged independently.
- CI must be run with the dependent PR applied.

