### PR TITLE
Fix GATT discovery and CCCD for Zephyr stack

### DIFF
--- a/framework/include/bt_gatt_defs.h
+++ b/framework/include/bt_gatt_defs.h
@@ -23,6 +23,8 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "bt_uuid.h"
+
 /**
  * @cond
  */
@@ -144,19 +146,19 @@ typedef enum {
 
 /* GATT_H_DESCRIPTOR */
 #define GATT_H_CEPD(_value, _length, _handle) \
-    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(0x2900), GATT_PERM_READ, ATTR_AUTO_RSP, NULL, NULL, _value, _length, _handle)
+    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CEPD), GATT_PERM_READ, ATTR_AUTO_RSP, NULL, NULL, _value, _length, _handle)
 
 /* GATT_H_DESCRIPTOR */
 #define GATT_H_CUDD(_value, _length, _handle) \
-    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(0x2901), GATT_PERM_READ, ATTR_AUTO_RSP, NULL, NULL, _value, _length, _handle)
+    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CUDD), GATT_PERM_READ, ATTR_AUTO_RSP, NULL, NULL, _value, _length, _handle)
 
 /* GATT_H_DESCRIPTOR */
 #define GATT_H_CCCD(_perm, _change, _handle) \
-    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(0x2902), _perm, ATTR_RSP_BY_APP, NULL, _change, NULL, 0, _handle)
+    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CCCD), _perm, ATTR_RSP_BY_APP, NULL, _change, NULL, 0, _handle)
 
 /* GATT_H_DESCRIPTOR */
 #define GATT_H_CPFD(_value, _length, _handle) \
-    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(0x2904), GATT_PERM_READ, ATTR_AUTO_RSP, NULL, NULL, _value, _length, _handle)
+    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CPFD), GATT_PERM_READ, ATTR_AUTO_RSP, NULL, NULL, _value, _length, _handle)
 
 /**
  * @endcond

--- a/framework/include/bt_uuid.h
+++ b/framework/include/bt_uuid.h
@@ -32,6 +32,12 @@ extern "C" {
 #define BT_UUID_HFP 0x111E
 #define BT_UUID_HFP_AG 0x111F
 
+/* GATT Descriptor UUIDs (16-bit) */
+#define BT_UUID_GATT_CEPD 0x2900
+#define BT_UUID_GATT_CUDD 0x2901
+#define BT_UUID_GATT_CCCD 0x2902
+#define BT_UUID_GATT_CPFD 0x2904
+
 typedef enum {
     BT_UUID16_TYPE = 2,
     BT_UUID32_TYPE = 4,

--- a/service/profiles/gatt/gattc_service.c
+++ b/service/profiles/gatt/gattc_service.c
@@ -985,6 +985,58 @@ void* if_gattc_get_remote(void* conn_handle)
     return connection->remote;
 }
 
+uint16_t if_gattc_find_ccc_handle_by_value_handle(bt_address_t* addr, uint16_t value_handle)
+{
+    static const bt_uuid_t uuid_ccc = BT_UUID_DECLARE_16(BT_UUID_GATT_CCCD);
+    bt_list_node_t* node;
+    gattc_connection_t* connection;
+
+    if (!addr || !value_handle) {
+        return 0;
+    }
+
+    connection = find_gattc_connection_by_addr(addr);
+    if (!connection || !connection->services) {
+        return 0;
+    }
+
+    for (node = bt_list_head(connection->services); node != NULL; node = bt_list_next(connection->services, node)) {
+        gattc_service_t* service = (gattc_service_t*)bt_list_node(node);
+        int start = -1;
+
+        if (!service || !service->elements || service->element_size <= 0) {
+            continue;
+        }
+
+        for (int i = 0; i < service->element_size; i++) {
+            if (service->elements[i].handle == value_handle) {
+                start = i + 1;
+                break;
+            }
+        }
+
+        if (start < 0) {
+            continue;
+        }
+
+        for (int i = start; i < service->element_size; i++) {
+            const gatt_element_t* elem = &service->elements[i];
+
+            if (elem->type != GATT_DESCRIPTOR) {
+                break;
+            }
+
+            if (!bt_uuid_compare(&elem->uuid, &uuid_ccc)) {
+                return elem->handle;
+            }
+        }
+
+        return 0;
+    }
+
+    return 0;
+}
+
 static const profile_service_t gattc_service = {
     .auto_start = true,
     .name = PROFILE_GATTC_NAME,

--- a/service/profiles/gatt/gattc_service.c
+++ b/service/profiles/gatt/gattc_service.c
@@ -93,6 +93,7 @@ typedef struct
     gattc_callbacks_t* callbacks;
     bt_list_t* services;
     bt_list_t* pend_ops;
+    bool discovering;
 
 } gattc_connection_t;
 
@@ -234,6 +235,75 @@ static void gattc_pendops_delete(gattc_op_t* operation)
     free(operation);
 }
 
+static bt_status_t gattc_discover_start(gattc_connection_t* connection, bt_uuid_t* filter_uuid)
+{
+    CHECK_ENABLED();
+    CHECK_CONNECTION_VALID(g_gattc_manager.connections, connection);
+
+    bt_status_t status;
+
+    if (!filter_uuid) {
+        status = bt_sal_gatt_client_discover_all_services(PRIMARY_ADAPTER, &connection->remote_addr);
+    } else {
+        status = bt_sal_gatt_client_discover_service_by_uuid(PRIMARY_ADAPTER, &connection->remote_addr, filter_uuid);
+    }
+
+    if (status == BT_STATUS_SUCCESS) {
+        connection->discovering = true;
+    }
+
+    return status;
+}
+
+static bt_status_t gattc_discover_start_next(gattc_connection_t* connection)
+{
+    bt_list_node_t* node;
+    gattc_op_t* pendop;
+    bt_uuid_t* uuid;
+    bt_status_t status;
+
+    CHECK_ENABLED();
+    CHECK_CONNECTION_VALID(g_gattc_manager.connections, connection);
+
+    if (connection->discovering) {
+        return BT_STATUS_BUSY;
+    }
+
+    if (!connection->pend_ops) {
+        return BT_STATUS_NOT_READY;
+    }
+
+    while ((node = bt_list_head(connection->pend_ops)) != NULL) {
+        pendop = (gattc_op_t*)bt_list_node(node);
+
+        if (pendop->request != GATTC_REQ_DISCOVER) {
+            BT_LOGE("%s, unexpected pendop->request %d", __func__, pendop->request);
+
+            if_gattc_on_discover_completed(&connection->remote_addr, GATT_STATUS_FAILURE);
+
+            bt_list_remove(connection->pend_ops, pendop);
+            continue;
+        }
+
+        uuid = (pendop->param.discover.type == GATT_DISCOVER_SERVICE)
+            ? &pendop->param.discover.filter_uuid
+            : NULL;
+
+        status = gattc_discover_start(connection, uuid);
+
+        bt_list_remove(connection->pend_ops, pendop);
+
+        if (status == BT_STATUS_SUCCESS) {
+            return BT_STATUS_SUCCESS;
+        }
+
+        BT_LOGE("%s, status %d", __func__, status);
+        if_gattc_on_discover_completed(&connection->remote_addr, GATT_STATUS_FAILURE);
+    }
+
+    return BT_STATUS_NOT_READY;
+}
+
 static void gattc_process_message(void* data)
 {
     gattc_msg_t* msg = (gattc_msg_t*)data;
@@ -260,6 +330,8 @@ static void gattc_process_message(void* data)
             GATT_CBACK(connection->callbacks, on_disconnected, connection, &connection->remote_addr);
             bt_addr_set_empty(&connection->remote_addr);
             bt_list_clear(connection->services);
+            bt_list_clear(connection->pend_ops);
+            connection->discovering = false;
         }
     } break;
     case GATTC_EVENT_DISCOVER_RESULT: {
@@ -279,6 +351,9 @@ static void gattc_process_message(void* data)
     } break;
     case GATTC_EVENT_DISOCVER_CMPL: {
         GATT_CBACK(connection->callbacks, on_discovered, connection, msg->param.discover_cmpl.status, NULL, 0, 0);
+        connection->discovering = false;
+        if (bt_list_length(connection->pend_ops))
+            gattc_discover_start_next(connection);
     } break;
     case GATTC_EVENT_READ: {
         GATT_CBACK(connection->callbacks, on_read, connection, msg->param.read.status, msg->param.read.element_id, msg->param.read.value, msg->param.read.length);
@@ -545,19 +620,27 @@ static bt_status_t if_gattc_disconnect(void* conn_handle)
 
 static bt_status_t if_gattc_discover_service(void* conn_handle, bt_uuid_t* filter_uuid)
 {
+    gattc_op_t* pendop;
     gattc_connection_t* connection = conn_handle;
 
     CHECK_ENABLED();
     CHECK_CONNECTION_VALID(g_gattc_manager.connections, connection);
 
-    bt_status_t status;
-    if (!filter_uuid || !filter_uuid->type) {
-        status = bt_sal_gatt_client_discover_all_services(PRIMARY_ADAPTER, &connection->remote_addr);
-    } else {
-        status = bt_sal_gatt_client_discover_service_by_uuid(PRIMARY_ADAPTER, &connection->remote_addr, filter_uuid);
+    if (connection->discovering) {
+        pendop = gattc_op_new(GATTC_REQ_DISCOVER);
+        if (!pendop)
+            return BT_STATUS_NOMEM;
+
+        pendop->param.discover.conn_handle = connection;
+        pendop->param.discover.type = filter_uuid ? GATT_DISCOVER_SERVICE : GATT_DISCOVER_ALL;
+        if (filter_uuid)
+            memcpy(&pendop->param.discover.filter_uuid, filter_uuid, sizeof(bt_uuid_t));
+
+        bt_list_add_tail(connection->pend_ops, pendop);
+        return BT_STATUS_SUCCESS;
     }
 
-    return status;
+    return gattc_discover_start(connection, filter_uuid);
 }
 
 static bt_status_t if_gattc_get_attribute_by_handle(void* conn_handle, uint16_t attr_handle, gatt_attr_desc_t* attr_desc)

--- a/service/profiles/gatt/gattc_service.c
+++ b/service/profiles/gatt/gattc_service.c
@@ -221,9 +221,8 @@ static void gattc_service_delete(gattc_service_t* service)
         return;
 
     if (service->elements)
-#ifndef CONFIG_BLUETOOTH_STACK_LE_ZBLUE
         free(service->elements);
-#endif
+
     free(service);
 }
 

--- a/service/profiles/include/gattc_event.h
+++ b/service/profiles/include/gattc_event.h
@@ -187,6 +187,7 @@ typedef struct
         struct gattc_discover_req_param {
             void* conn_handle;
             gatt_discover_type_t type;
+            bt_uuid_t filter_uuid;
         } discover;
 
         /**

--- a/service/profiles/include/gattc_service.h
+++ b/service/profiles/include/gattc_service.h
@@ -41,6 +41,8 @@ void if_gattc_on_rssi_read(bt_address_t* addr, int32_t rssi, gatt_status_t statu
 void if_gattc_on_connection_parameter_updated(bt_address_t* addr, uint16_t connection_interval, uint16_t peripheral_latency,
     uint16_t supervision_timeout, bt_status_t status);
 
+uint16_t if_gattc_find_ccc_handle_by_value_handle(bt_address_t* addr, uint16_t value_handle);
+
 /*
  * gattc remote
  */

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -472,6 +472,7 @@ static uint8_t zblue_gatt_client_disc_desc_callback(struct bt_conn* conn, const 
     gatt_element_t* element;
     bt_address_t addr;
     uint16_t start_HDL, end_HDL;
+    gatt_element_t* element_db;
 
     get_le_addr_from_conn(conn, &addr);
     instance = gatt_find_instance_by_addr(&addr);
@@ -491,7 +492,10 @@ static uint8_t zblue_gatt_client_disc_desc_callback(struct bt_conn* conn, const 
                 uint8_t base = instance->current_element_base_idx;
                 uint8_t size = instance->element_size - base;
 
-                if_gattc_on_service_discovered(&instance->addr, &instance->element[base], size);
+                element_db = calloc(size, sizeof(gatt_element_t));
+                memcpy(element_db, &instance->element[base], size * sizeof(gatt_element_t));
+
+                if_gattc_on_service_discovered(&instance->addr, element_db, size);
 
                 service = &instance->service[instance->service_idx];
                 instance->current_element_base_idx = instance->element_size;
@@ -513,7 +517,10 @@ static uint8_t zblue_gatt_client_disc_desc_callback(struct bt_conn* conn, const 
                 uint8_t base = instance->current_element_base_idx;
                 uint8_t size = instance->element_size - base;
 
-                if_gattc_on_service_discovered(&instance->addr, &instance->element[base], size);
+                element_db = calloc(size, sizeof(gatt_element_t));
+                memcpy(element_db, &instance->element[base], size * sizeof(gatt_element_t));
+
+                if_gattc_on_service_discovered(&instance->addr, element_db, size);
                 if_gattc_on_discover_completed(&addr, GATT_STATUS_SUCCESS);
                 gatt_discover_cleanup(instance);
             }
@@ -552,7 +559,10 @@ static uint8_t zblue_gatt_client_disc_desc_callback(struct bt_conn* conn, const 
                 uint8_t base = instance->current_element_base_idx;
                 uint8_t size = instance->element_size - base;
 
-                if_gattc_on_service_discovered(&instance->addr, &instance->element[base], size);
+                element_db = calloc(size, sizeof(gatt_element_t));
+                memcpy(element_db, &instance->element[base], size * sizeof(gatt_element_t));
+
+                if_gattc_on_service_discovered(&instance->addr, element_db, size);
 
                 service = &instance->service[instance->service_idx];
                 instance->current_element_base_idx = instance->element_size;
@@ -574,7 +584,10 @@ static uint8_t zblue_gatt_client_disc_desc_callback(struct bt_conn* conn, const 
                 uint8_t base = instance->current_element_base_idx;
                 uint8_t size = instance->element_size - base;
 
-                if_gattc_on_service_discovered(&instance->addr, &instance->element[base], size);
+                element_db = calloc(size, sizeof(gatt_element_t));
+                memcpy(element_db, &instance->element[base], size * sizeof(gatt_element_t));
+
+                if_gattc_on_service_discovered(&instance->addr, element_db, size);
                 if_gattc_on_discover_completed(&addr, GATT_STATUS_SUCCESS);
                 gatt_discover_cleanup(instance);
             }
@@ -615,6 +628,7 @@ static uint8_t zblue_gatt_client_disc_chrc_callback(struct bt_conn* conn, const 
     gatt_element_t* element;
     bt_address_t addr;
     uint16_t start_HDL, end_HDL;
+    gatt_element_t* element_db;
 
     get_le_addr_from_conn(conn, &addr);
 
@@ -662,7 +676,10 @@ static uint8_t zblue_gatt_client_disc_chrc_callback(struct bt_conn* conn, const 
                 uint8_t base = instance->current_element_base_idx;
                 uint8_t size = instance->element_size - base;
 
-                if_gattc_on_service_discovered(&instance->addr, &instance->element[base], size);
+                element_db = calloc(size, sizeof(gatt_element_t));
+                memcpy(element_db, &instance->element[base], size * sizeof(gatt_element_t));
+
+                if_gattc_on_service_discovered(&instance->addr, element_db, size);
 
                 instance->current_element_base_idx = instance->element_size;
                 service = &instance->service[instance->service_idx];
@@ -683,7 +700,10 @@ static uint8_t zblue_gatt_client_disc_chrc_callback(struct bt_conn* conn, const 
                 uint8_t base = instance->current_element_base_idx;
                 uint8_t size = instance->element_size - base;
 
-                if_gattc_on_service_discovered(&instance->addr, &instance->element[base], size);
+                element_db = calloc(size, sizeof(gatt_element_t));
+                memcpy(element_db, &instance->element[base], size * sizeof(gatt_element_t));
+
+                if_gattc_on_service_discovered(&instance->addr, element_db, size);
                 if_gattc_on_discover_completed(&addr, GATT_STATUS_SUCCESS);
                 gatt_discover_cleanup(instance);
             }

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -174,47 +174,6 @@ static void gatt_delete_subscribe_slot_by_param(struct gatt_instance* instance, 
     }
 }
 
-static void gatt_clear_all_subscribe_slots(struct gatt_instance* instance)
-{
-    memset(instance->subscribe_slot, 0, sizeof(instance->subscribe_slot));
-}
-
-static uint16_t gatt_find_ccc_handle_by_value_handle(struct gatt_instance* instance, uint16_t value_handle)
-{
-    static const struct bt_uuid_16 uuid_ccc = BT_UUID_INIT_16(BT_UUID_GATT_CCC_VAL);
-    static union uuid u;
-    int start = -1;
-
-    for (int i = 0; i < CONFIG_GATT_CLIENT_ELEMENT_MAX; i++) {
-        if (instance->element[i].handle == value_handle) {
-            start = i + 1;
-            break;
-        }
-    }
-
-    if (start < 0) {
-        return 0;
-    }
-
-    for (int i = start; i < CONFIG_GATT_CLIENT_ELEMENT_MAX; i++) {
-        const gatt_element_t* elem = &instance->element[i];
-
-        if ((elem->handle == 0) || (elem->type == GATT_CHARACTERISTIC)) {
-            break;
-        }
-
-        if (!zblue_uuid2_to_uuid1(&u.uuid, &elem->uuid)) {
-            continue;
-        }
-
-        if (!bt_uuid_cmp(&u.uuid, &uuid_ccc.uuid)) {
-            return elem->handle;
-        }
-    }
-
-    return 0;
-}
-
 static struct gatt_instance* gatt_find_instance_by_addr(bt_address_t* addr)
 {
     for (int i = 0; i < CONFIG_BLUETOOTH_GATTC_MAX_CONNECTIONS; i++) {
@@ -1007,17 +966,11 @@ bt_status_t bt_sal_gatt_client_discover_all_services(bt_controller_id_t id, bt_a
     static struct bt_gatt_discover_params disc_params = { 0 };
     struct bt_conn* conn;
     int err;
-    struct gatt_instance* instance;
 
     conn = get_le_conn_from_addr(addr);
     if (!conn) {
         BT_LOGE("%s, conn null", __func__);
         return BT_STATUS_FAIL;
-    }
-
-    instance = gatt_find_instance_by_addr(addr);
-    if (instance) {
-        gatt_clear_all_subscribe_slots(instance);
     }
 
     disc_params.uuid = NULL;
@@ -1041,7 +994,6 @@ bt_status_t bt_sal_gatt_client_discover_service_by_uuid(bt_controller_id_t id, b
     struct bt_conn* conn;
     int err;
     static union uuid u;
-    struct gatt_instance* instance;
 
     conn = get_le_conn_from_addr(addr);
     if (!conn) {
@@ -1052,11 +1004,6 @@ bt_status_t bt_sal_gatt_client_discover_service_by_uuid(bt_controller_id_t id, b
     if (!zblue_uuid2_to_uuid1(&u.uuid, uuid)) {
         BT_LOGE("%s, uuid convert fail", __func__);
         return BT_STATUS_FAIL;
-    }
-
-    instance = gatt_find_instance_by_addr(addr);
-    if (instance) {
-        gatt_clear_all_subscribe_slots(instance);
     }
 
     disc_params.uuid = &u.uuid;
@@ -1223,7 +1170,7 @@ bt_status_t bt_sal_gatt_client_register_notifications(bt_controller_id_t id, bt_
         return BT_STATUS_FAIL;
     }
 
-    ccc_handle = gatt_find_ccc_handle_by_value_handle(instance, element_id);
+    ccc_handle = if_gattc_find_ccc_handle_by_value_handle(&instance->addr, element_id);
     if (!ccc_handle) {
         BT_LOGE("%s, no CCC handle found for element:0x%04x", __func__, element_id);
         return BT_STATUS_FAIL;


### PR DESCRIPTION
Bug: v/83024

This PR fixes several GATT client issues when working with Zephyr / zblue stack.

Some stacks do not support parallel GATT discovery.
Some apps also call discover_service_by_uuid many times.
And Zephyr needs CCC handle for CCCD, not value handle.

These problems make service DB broken and CCCD fail.

This PR includes three related changes.

--------------------------------
1. Serialize GATT discovery

Some stacks (for example zblue) do not support parallel discovery.
We now make if_gattc_discover_service transactional and per-connection serialized.

When a discovery is running:
- new discover requests are queued
- they will start one by one after DISCOVER_CMPL
- all pending discovers are cleared on disconnect

Each queued request keeps its own filter_uuid,
so it runs with the original parameters.

--------------------------------
2. Use single service DB in gattc_service

sal_gatt_client resets element index on every discover call.
So results from bt_sal_gatt_client_discover_service_by_uuid() cannot be accumulated.
After discovery, the service DB becomes incomplete.
Read / write by handle, especially CCCD, may fail.

Now service data is copied by malloc and passed to gattc_service.c.
gattc_service.c owns and frees this memory.
So the GATT service DB is complete and stable.

Future direction:
Only gattc_service.c will keep the service DB.
sal_gatt_client will only use temporary data during discovery.
This part is still TBD.

--------------------------------
3. Add CCC handle query for Zephyr

Zephyr stack needs CCC handle to do CCCD.
Old stack only needs value handle.

A helper is added in gattc_service.c.
It uses the full service DB to map value_handle to ccc_handle.
sal can use it to find the correct CCC handle.

Together these changes fix:
- lost discover results
- broken service DB
- CCCD failure on Zephyr stack
