### PR TITLE
Bugfix/fix bluetooth bt tool adv moudle cb change to const

### DIFF
--- a/feature/feature_async/src/bluetooth_ble_impl.c
+++ b/feature/feature_async/src/bluetooth_ble_impl.c
@@ -299,7 +299,7 @@ static void on_advertising_stopped_cb(bt_advertiser_t* adv, uint8_t adv_id)
     adv_info->busy = false;
 }
 
-static advertiser_callback_t adv_callback = {
+static const advertiser_callback_t adv_callback = {
     sizeof(adv_callback),
     on_advertising_start_cb,
     on_advertising_stopped_cb
@@ -595,7 +595,7 @@ void system_bluetooth_ble_Advertiser_interface_adv_startAdvertising(FeatureInter
     adv_info->start_userdata = (void*)data;
 
     status = bt_le_start_advertising_async(adv_info->ins, &adv_params,
-        p_adv_data, adv_len, p_scan_rsp_data, scan_rsp_len, &adv_callback,
+        p_adv_data, adv_len, p_scan_rsp_data, scan_rsp_len, (advertiser_callback_t *)&adv_callback,
         start_adv_cb, (void*)data);
 
     if (status != BT_STATUS_SUCCESS) {
@@ -1563,7 +1563,7 @@ static void mtu_updated_callback(gattc_handle_t conn_handle, gatt_status_t statu
     bt_list_remove(gattc_info->userdata_list, data);
 }
 
-static bt_gattc_feature_callbacks_t gattc_cbs = {
+static const bt_gattc_feature_callbacks_t gattc_cbs = {
     sizeof(gattc_cbs),
     .on_connected = connect_callback,
     .on_disconnected = disconnect_callback,
@@ -1761,7 +1761,7 @@ void system_bluetooth_ble_GattClient_interface_gattc_connect(FeatureInterfaceHan
             gattc_info->gattc->addr_type, gattc_connect_cb, (void*)data);
     } else {
         status = bt_gattc_feature_create_client_async(gattc_info->ins, &gattc_info->gattc->remote_address, gattc_create_cb,
-            &gattc_cbs, (void*)data);
+            (bt_gattc_feature_callbacks_t *)&gattc_cbs, (void*)data);
     }
 
     if (status != BT_STATUS_SUCCESS) {

--- a/framework/btwrap/async/bt_gatt_feature.c
+++ b/framework/btwrap/async/bt_gatt_feature.c
@@ -716,7 +716,7 @@ static void feature_on_mtu_updated(void* conn_handle, gatt_status_t status, uint
         client->conn, status, mtu);
 }
 
-static gattc_callbacks_t s_feature_gattc_cbs = {
+static const gattc_callbacks_t s_feature_gattc_cbs = {
     sizeof(s_feature_gattc_cbs),
     feature_on_connected,
     feature_on_disconnected,
@@ -806,7 +806,7 @@ bt_status_t bt_gattc_feature_create_client_async(bt_instance_t* ins, bt_address_
     bt_list_add_tail(g_gatt_client_list, client);
 
     status = bt_gattc_create_connect_async(
-        ins, &client->conn, &s_feature_gattc_cbs, create_client_cb, client);
+        ins, &client->conn, (gattc_callbacks_t *)&s_feature_gattc_cbs, create_client_cb, client);
 
     if (status != BT_STATUS_SUCCESS) {
         bt_list_remove(g_gatt_client_list, client);

--- a/service/ipc/socket/src/bt_socket_advertiser.c
+++ b/service/ipc/socket/src/bt_socket_advertiser.c
@@ -82,7 +82,7 @@ static void on_advertising_stopped_cb(bt_advertiser_t* adv, uint8_t adv_id)
     free(adv);
 }
 
-static advertiser_callback_t g_advertiser_socket_cb = {
+static const advertiser_callback_t g_advertiser_socket_cb = {
     sizeof(g_advertiser_socket_cb),
     on_advertising_start_cb,
     on_advertising_stopped_cb,
@@ -106,7 +106,7 @@ void bt_socket_server_advertiser_process(service_poll_t* poll,
             packet->adv_pl._bt_le_start_advertising.adv_len,
             packet->adv_pl._bt_le_start_advertising.scan_rsp_data,
             packet->adv_pl._bt_le_start_advertising.scan_rsp_len,
-            &g_advertiser_socket_cb);
+            (advertiser_callback_t *)&g_advertiser_socket_cb);
 
         if (!packet->adv_r.remote)
             free(adver);

--- a/service/ipc/socket/src/bt_socket_scan.c
+++ b/service/ipc/socket/src/bt_socket_scan.c
@@ -201,7 +201,7 @@ static void on_scan_stopped_cb(bt_scanner_t* scanner)
     free(scanner);
 }
 
-static scanner_callbacks_t g_scanner_socket_cb = {
+static const scanner_callbacks_t g_scanner_socket_cb = {
     sizeof(g_scanner_socket_cb),
     on_scan_result_cb,
     on_scan_status_cb,
@@ -221,7 +221,7 @@ void bt_socket_server_scan_process(service_poll_t* poll,
 
         scan->ins = ins;
         scan->remote = packet->scan_pl._bt_le_start_scan.remote;
-        packet->scan_r.remote = PTR2INT(uint64_t) scanner_start_scan(scan, &g_scanner_socket_cb);
+        packet->scan_r.remote = PTR2INT(uint64_t) scanner_start_scan(scan, (scanner_callbacks_t *)&g_scanner_socket_cb);
         if (!packet->scan_r.remote)
             free(scan);
         break;

--- a/service/ipc/socket/src/bt_socket_spp.c
+++ b/service/ipc/socket/src/bt_socket_spp.c
@@ -95,7 +95,7 @@ static void spp_connection_state_cb(void* handle, bt_address_t* addr,
 
     bt_socket_server_send(ins, &packet, BT_SPP_CONNECTION_STATE_CB);
 }
-static spp_callbacks_t g_spp_socket_cb = {
+static const spp_callbacks_t g_spp_socket_cb = {
     .size = sizeof(g_spp_socket_cb),
     .connection_state_cb = spp_connection_state_cb,
     .proxy_state_cb = spp_proxy_state_cb,
@@ -113,7 +113,7 @@ void bt_socket_server_spp_process(service_poll_t* poll,
     switch (packet->code) {
     case BT_SPP_REGISTER_APP: {
         if (ins->spp_cookie == NULL) {
-            ins->spp_cookie = profile->register_app(ins, packet->spp_pl._bt_spp_register_app.name_len ? packet->spp_pl._bt_spp_register_app.name : NULL, &g_spp_socket_cb);
+            ins->spp_cookie = profile->register_app(ins, packet->spp_pl._bt_spp_register_app.name_len ? packet->spp_pl._bt_spp_register_app.name : NULL, (spp_callbacks_t *)&g_spp_socket_cb);
             packet->spp_r.handle = PTR2INT(uint64_t) ins->spp_cookie;
         } else {
             packet->spp_r.handle = 0;

--- a/service/profiles/hid/hid_device_service.c
+++ b/service/profiles/hid/hid_device_service.c
@@ -546,7 +546,7 @@ exit:
     return status;
 }
 
-static hid_device_interface_t deviceInterface = {
+static const hid_device_interface_t deviceInterface = {
     .size = sizeof(deviceInterface),
     .register_callbacks = hid_device_register_callbacks,
     .unregister_callbacks = hid_device_unregister_callbacks,

--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -1252,7 +1252,7 @@ static int spp_dump(void)
     return 0;
 }
 
-static spp_interface_t sppInterface = {
+static const spp_interface_t sppInterface = {
     .size = sizeof(sppInterface),
     .register_app = spp_register_app,
     .unregister_app = spp_unregister_app,

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -137,7 +137,7 @@ NET_BUF_POOL_DEFINE(bt_a2dp_tx_pool, CONFIG_BT_MAX_CONN, CONFIG_ZBLUE_A2DP_SOURC
     CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 /* codec information elements for the endpoint */
-static struct bt_a2dp_codec_ie sbc_src_ie = {
+static const struct bt_a2dp_codec_ie sbc_src_ie = {
     .len = 4, /* BT_A2DP_SBC_IE_LENGTH */
     .codec_ie = {
         0x2B, /* 16000 | 32000 | 44100 | 48000 | mono | dual channel | stereo | join stereo */
@@ -1104,7 +1104,7 @@ static void zblue_on_stream_recv(struct bt_a2dp_stream* stream,
 }
 #endif /* CONFIG_BLUETOOTH_A2DP_SINK */
 
-static struct bt_a2dp_stream_ops stream_ops = {
+static const struct bt_a2dp_stream_ops stream_ops = {
     .configured = zblue_on_stream_configured,
     .established = zblue_on_stream_established,
     .released = zblue_on_stream_released,
@@ -1164,7 +1164,7 @@ static uint8_t bt_a2dp_discover_endpoint_cb(struct bt_a2dp* a2dp,
     }
 
     a2dp_info->stream = (struct bt_a2dp_stream*)calloc(1, sizeof(struct bt_a2dp_stream));
-    bt_a2dp_stream_cb_register(a2dp_info->stream, &stream_ops);
+    bt_a2dp_stream_cb_register(a2dp_info->stream, (struct bt_a2dp_stream_ops *)&stream_ops);
 
     if (a2dp_info->role == SEP_SRC) {
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
@@ -1430,7 +1430,7 @@ static int zblue_on_config_req(struct bt_a2dp* a2dp, struct bt_a2dp_ep* ep,
 
     a2dp_info->stream = (struct bt_a2dp_stream*)calloc(1, sizeof(struct bt_a2dp_stream));
     *stream = a2dp_info->stream; /* The a2dp_stream saved in SAL is assigned a value in zblue. */
-    bt_a2dp_stream_cb_register(a2dp_info->stream, &stream_ops);
+    bt_a2dp_stream_cb_register(a2dp_info->stream, (struct bt_a2dp_stream_ops *)&stream_ops);
     *rsp_err_code = BT_AVDTP_SUCCESS;
     return 0;
 }
@@ -1516,7 +1516,7 @@ static void zblue_on_suspend_rsp(struct bt_a2dp_stream* stream, uint8_t rsp_err_
         BT_LOGE("%s, suspend fail: %d", __func__, rsp_err_code);
 }
 
-static struct bt_a2dp_cb a2dp_cbks = {
+static const struct bt_a2dp_cb a2dp_cbks = {
     .connected = zblue_on_connected,
     .disconnected = zblue_on_disconnected,
     .config_req = zblue_on_config_req,
@@ -1565,7 +1565,7 @@ bt_status_t bt_sal_a2dp_source_init(uint8_t max_connections)
     }
 #endif /* CONFIG_BLUETOOTH_A2DP_AAC_CODEC */
 
-    SAL_CHECK_RET(bt_a2dp_register_cb(&a2dp_cbks), 0);
+    SAL_CHECK_RET(bt_a2dp_register_cb((struct bt_a2dp_cb *)&a2dp_cbks), 0);
 
     return BT_STATUS_SUCCESS;
 #else
@@ -1605,7 +1605,7 @@ bt_status_t bt_sal_a2dp_sink_init(uint8_t max_connections)
     }
 #endif /* CONFIG_BLUETOOTH_A2DP_AAC_CODEC */
 
-    SAL_CHECK_RET(bt_a2dp_register_cb(&a2dp_cbks), 0);
+    SAL_CHECK_RET(bt_a2dp_register_cb((struct bt_a2dp_cb *)&a2dp_cbks), 0);
 
     return BT_STATUS_SUCCESS;
 #else

--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -149,7 +149,7 @@ static int zblue_on_link_key_load(bt_addr_le_t* addr, uint8_t* key_value, uint8_
 
 static bt_security_t g_security_level = BT_SECURITY_L2;
 
-static struct bt_conn_cb g_conn_cbs = {
+static const struct bt_conn_cb g_conn_cbs = {
 #ifndef CONFIG_BT_CONN_REQ_AUTO_HANDLE
     .connect_req = zblue_on_connect_req,
 #endif /* CONFIG_BT_CONN_REQ_AUTO_HANDLE */
@@ -166,13 +166,13 @@ static struct bt_conn_cb g_conn_cbs = {
 };
 
 #if defined(CONFIG_SETTINGS_ZBLUE)
-static struct bt_settings_zblue_cb g_setting_cbs = {
+static const struct bt_settings_zblue_cb g_setting_cbs = {
     .linkkey_notify = zblue_on_link_key_notify,
     .linkkey_load = zblue_on_link_key_load,
 };
 #endif
 
-static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
+static const struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
     .pairing_complete = zblue_on_br_pairing_complete,
     .pairing_complete_ctkd = zblue_on_br_pairing_complete_ctkd,
     .pairing_failed = zblue_on_br_pairing_failed,
@@ -653,27 +653,27 @@ static void zblue_on_discovery_complete_cb(const struct bt_br_discovery_result* 
     adapter_on_discovery_state_changed(BT_DISCOVERY_STOPPED);
 }
 
-static struct bt_br_discovery_cb g_br_discovery_cb = {
+static const struct bt_br_discovery_cb g_br_discovery_cb = {
     .recv = zblue_on_discovery_recv_cb,
     .timeout = zblue_on_discovery_complete_cb
 };
 
 static void zblue_register_callback(void)
 {
-    bt_br_discovery_cb_register(&g_br_discovery_cb);
-    bt_conn_cb_register(&g_conn_cbs);
-    bt_conn_auth_cb_register(&g_conn_auth_cbs);
-    bt_conn_auth_info_cb_register(&g_conn_auth_info_cbs);
+    bt_br_discovery_cb_register((struct bt_br_discovery_cb *)&g_br_discovery_cb);
+    bt_conn_cb_register((struct bt_conn_cb *)&g_conn_cbs);
+    bt_conn_auth_cb_register((struct bt_conn_auth_cb *)&g_conn_auth_cbs);
+    bt_conn_auth_info_cb_register((struct bt_conn_auth_info_cb *)&g_conn_auth_info_cbs);
 #ifdef CONFIG_SETTINGS_ZBLUE
-    bt_setting_cb_register(&g_setting_cbs);
+    bt_setting_cb_register((struct bt_settings_zblue_cb *)&g_setting_cbs);
 #endif
 }
 
 static void zblue_unregister_callback(void)
 {
-    bt_br_discovery_cb_unregister(&g_br_discovery_cb);
+    bt_br_discovery_cb_unregister((struct bt_br_discovery_cb *)&g_br_discovery_cb);
     bt_conn_auth_cb_register(NULL);
-    bt_conn_auth_info_cb_unregister(&g_conn_auth_info_cbs);
+    bt_conn_auth_info_cb_unregister((struct bt_conn_auth_info_cb *)&g_conn_auth_info_cbs);
 }
 #endif
 

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -107,7 +107,10 @@ static enum bt_security_err zblue_on_pairing_accept(struct bt_conn* conn, const 
 static void zblue_register_callback(void);
 static void zblue_unregister_callback(void);
 
-static struct bt_conn_cb g_conn_cbs = {
+static le_conn_info_t* le_conn_add(const bt_address_t* addr);
+static le_conn_info_t* le_conn_find(const bt_address_t* addr);
+
+static const struct bt_conn_cb g_conn_cbs = {
     .connected = zblue_on_connected,
     .disconnected = zblue_on_disconnected,
 #ifdef CONFIG_BT_SMP
@@ -119,7 +122,7 @@ static struct bt_conn_cb g_conn_cbs = {
 #endif
 };
 
-static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
+static const struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
     .pairing_complete_ctkd = zblue_on_pairing_complete_ctkd,
     .pairing_complete = zblue_on_pairing_complete,
     .pairing_failed = zblue_on_pairing_failed,
@@ -127,7 +130,7 @@ static struct bt_conn_auth_info_cb g_conn_auth_info_cbs = {
 };
 
 #if defined(CONFIG_SETTINGS_ZBLUE)
-static struct bt_settings_zblue_cb g_setting_cbs = {
+static const struct bt_settings_zblue_cb g_setting_cbs = {
     .irk_notify = zblue_on_irk_notify,
     .irk_load = zblue_on_irk_load,
     .ltk_notify = zblue_on_ltk_notify,
@@ -758,22 +761,22 @@ static void zblue_on_bond_deleted(uint8_t id, const bt_addr_le_t* peer)
 
 static void zblue_register_callback(void)
 {
-    bt_conn_cb_register(&g_conn_cbs);
+    bt_conn_cb_register((struct bt_conn_cb *)&g_conn_cbs);
 #ifdef CONFIG_BT_SMP
-    bt_conn_le_auth_cb_register(&g_conn_auth_cbs);
-    bt_conn_auth_info_cb_register(&g_conn_auth_info_cbs);
+    bt_conn_le_auth_cb_register((struct bt_conn_auth_cb *)&g_conn_auth_cbs);
+    bt_conn_auth_info_cb_register((struct bt_conn_auth_info_cb *)&g_conn_auth_info_cbs);
 #endif
 #ifdef CONFIG_SETTINGS_ZBLUE
-    bt_setting_cb_register(&g_setting_cbs);
+    bt_setting_cb_register((struct bt_settings_zblue_cb *)&g_setting_cbs);
 #endif
 }
 
 static void zblue_unregister_callback(void)
 {
-    bt_conn_cb_unregister(&g_conn_cbs);
+    bt_conn_cb_unregister((struct bt_conn_cb *)&g_conn_cbs);
 #ifdef CONFIG_BT_SMP
     bt_conn_le_auth_cb_register(NULL);
-    bt_conn_auth_info_cb_unregister(&g_conn_auth_info_cbs);
+    bt_conn_auth_info_cb_unregister((struct bt_conn_auth_info_cb *)&g_conn_auth_info_cbs);
 #endif
 }
 

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -130,7 +130,7 @@ static void zblue_on_tg_register_notification_req(struct bt_avrcp_tg* tg, uint8_
 static void zblue_on_tg_set_absolute_volume_req(struct bt_avrcp_tg* tg, uint8_t tid, uint8_t absolute_volume);
 #endif
 
-static struct bt_avrcp_tg_cb avrcp_tg_cbks = {
+static const struct bt_avrcp_tg_cb avrcp_tg_cbks = {
 #ifdef CONFIG_BLUETOOTH_AVRCP_TARGET
     .unit_info_req = zblue_on_tg_unit_info_req,
     .subunit_info_req = zblue_on_tg_subunit_info_req,

--- a/service/stacks/zephyr/sal_hfp_ag_interface.c
+++ b/service/stacks/zephyr/sal_hfp_ag_interface.c
@@ -952,7 +952,7 @@ static void zblue_on_ag_transmit_dtmf_code(struct bt_hfp_ag* ag, char code)
     hfp_ag_on_received_dtmf(&sal_conn->addr, code);
 }
 
-static struct bt_hfp_ag_cb g_hfp_ag_cb = {
+static const struct bt_hfp_ag_cb g_hfp_ag_cb = {
     .connected = zblue_on_ag_connected,
     .disconnected = zblue_on_ag_disconnected,
     .sco_connected = zblue_on_ag_sco_connected,
@@ -992,7 +992,7 @@ bt_status_t bt_sal_hfp_ag_init(uint32_t features, uint8_t max_connection)
     BT_LOGD("%s, HFP AG init", __func__);
     g_sal_ag_conn_list = bt_list_new(free_connection);
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_register)(&g_hfp_ag_cb), 0);
+    SAL_CHECK_RET(Z_API(bt_hfp_ag_register)((struct bt_hfp_ag_cb *)&g_hfp_ag_cb), 0);
     return BT_STATUS_SUCCESS;
 }
 

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -888,7 +888,7 @@ static void zblue_on_current_call(struct bt_hfp_hf* hf, struct bt_hfp_hf_current
     hfp_hf_on_current_call_response(&sal_conn->addr, idx, dir, status, mpty, call->number, call->type);
 }
 
-static struct bt_hfp_hf_cb hf_callbacks = {
+static const struct bt_hfp_hf_cb hf_callbacks = {
     .connected = zblue_on_connected,
     .disconnected = zblue_hf_disconnected,
     .sco_connected = zblue_on_sco_connected,
@@ -932,7 +932,7 @@ bt_status_t bt_sal_hfp_hf_init(uint32_t hf_features, uint8_t max_connection)
     int err;
     g_sal_hf_conn_list = bt_list_new(free_connection);
 
-    err = Z_API(bt_hfp_hf_register)(&hf_callbacks);
+    err = Z_API(bt_hfp_hf_register)((struct bt_hfp_hf_cb *)&hf_callbacks);
 
     if (err) {
         bt_list_free(g_sal_hf_conn_list);

--- a/service/stacks/zephyr/sal_hid_device_interface.c
+++ b/service/stacks/zephyr/sal_hid_device_interface.c
@@ -61,7 +61,7 @@ typedef struct sal_bt_hid_device_mgr {
     uint8_t* description;
 } sal_bt_hid_device_mgr_t;
 
-static struct bt_sdp_attribute hid_attrs_template[] = {
+static const struct bt_sdp_attribute hid_attrs_template[] = {
     BT_SDP_NEW_SERVICE,
     BT_SDP_LIST(
         BT_SDP_ATTR_SVCLASS_ID_LIST,
@@ -539,7 +539,7 @@ void hid_vc_unplug_callback(struct bt_hid_device* hid)
     hid_device_on_virtual_cable_unplug(&hid_conn->addr);
 }
 
-static struct bt_hid_device_cb hid_callback = {
+static const struct bt_hid_device_cb hid_callback = {
     .accept = hid_accept_callback,
     .connected = hid_connect_callback,
     .disconnected = hid_disconnected_callback,
@@ -556,7 +556,7 @@ bt_status_t bt_sal_hid_device_init()
     int err;
     sal_bt_hid_device_mgr_t* hid_mgr = &g_hid_device_mgr;
 
-    err = Z_API(bt_hid_device_register)(&hid_callback);
+    err = Z_API(bt_hid_device_register)((struct bt_hid_device_cb *)&hid_callback);
     if (err != 0) {
         BT_LOGE("HID register cb fail,err:%d", err);
         return BT_STATUS_FAIL;

--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -95,7 +95,7 @@ extern struct net_buf_pool sdp_pool;
 NET_BUF_POOL_FIXED_DEFINE(rfcomm_tx_pool, SPP_DEFAULT_CREDITS,
     SAL_SPP_RFCOMM_MFS + SPP_MFS_EXTRA_SIZE, CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
-static struct bt_sdp_attribute spp_attrs_template[] = {
+static const struct bt_sdp_attribute spp_attrs_template[] = {
     BT_SDP_NEW_SERVICE,
     BT_SDP_LIST(
         BT_SDP_ATTR_SVCLASS_ID_LIST,
@@ -438,7 +438,7 @@ static void spp_rfcomm_sent(struct bt_rfcomm_dlc* rfcomm_dlc, int err)
     spp_conn_unlock();
 }
 
-static struct bt_rfcomm_dlc_ops g_rfcomm_ops = {
+static const struct bt_rfcomm_dlc_ops g_rfcomm_ops = {
     .connected = spp_rfcomm_connected,
     .disconnected = spp_rfcomm_disconnected,
     .recv = spp_rfcomm_recv,
@@ -523,7 +523,7 @@ static sal_spp_connection_t* spp_connection_new(bt_address_t* addr, uint16_t con
         return NULL;
     }
 
-    spp_conn->rfcomm_dlc.ops = &g_rfcomm_ops;
+    spp_conn->rfcomm_dlc.ops = (struct bt_rfcomm_dlc_ops *)&g_rfcomm_ops;
     spp_conn->rfcomm_dlc.mtu = SAL_SPP_RFCOMM_MFS;
     memcpy(&spp_conn->addr, addr, sizeof(bt_address_t));
 

--- a/tools/a2dp_source.c
+++ b/tools/a2dp_source.c
@@ -27,7 +27,7 @@ static int connect_cmd(void* handle, int argc, char* argv[]);
 static int disconnect_cmd(void* handle, int argc, char* argv[]);
 static int get_state_cmd(void* handle, int argc, char* argv[]);
 
-static bt_command_t g_a2dp_tables[] = {
+static const bt_command_t g_a2dp_tables[] = {
     { "connect", connect_cmd, 0, "\"establish a2dp signal and stream connection, params: <address>\"" },
     { "disconnect", disconnect_cmd, 0, "\"disconnect a2dp signal and stream connection, params: <address>\"" },
     { "state", get_state_cmd, 0, "\"get a2dp connection or audio state , params: <address>\"" },
@@ -131,7 +131,7 @@ int a2dp_src_command_exec(void* handle, int argc, char* argv[])
     int ret = CMD_USAGE_FAULT;
 
     if (argc > 0)
-        ret = execute_command_in_table(handle, g_a2dp_tables, ARRAY_SIZE(g_a2dp_tables), argc, argv);
+        ret = execute_command_in_table(handle, (bt_command_t *)g_a2dp_tables, ARRAY_SIZE(g_a2dp_tables), argc, argv);
 
     if (ret < 0)
         usage();

--- a/tools/adv.c
+++ b/tools/adv.c
@@ -28,7 +28,7 @@ static int stop_adv_cmd(void* handle, int argc, char* argv[]);
 static int set_adv_data_cmd(void* handle, int argc, char* argv[]);
 static int dump_adv_cmd(void* handle, int argc, char* argv[]);
 
-static struct option adv_options[] = {
+static const struct option adv_options[] = {
     { "adv_type", required_argument, 0, 't' },
     { "mode", required_argument, 0, 'm' },
     { "interval", required_argument, 0, 'i' },
@@ -45,13 +45,13 @@ static struct option adv_options[] = {
     { 0, 0, 0, 0 }
 };
 
-static struct option adv_stop_options[] = {
+static const struct option adv_stop_options[] = {
     { "advid", required_argument, 0, 'i' },
     { "handle", required_argument, 0, 'h' },
     { 0, 0, 0, 0 }
 };
 
-static bt_command_t g_adv_tables[] = {
+static const bt_command_t g_adv_tables[] = {
     { "start", start_adv_cmd, 1, "start advertising\n"
                                  "\t  -t or --adv_type, advertising type opt(adv_ind/direct_ind/nonconn_ind/scan_ind)\n"
                                  "\t  -m or --mode,     advertising mode opt(legacy/ext/auto, default auto)\n"
@@ -98,7 +98,7 @@ static void on_advertising_stopped_cb(bt_advertiser_t* adv, uint8_t adv_id)
     PRINT("%s, handle:%p, adv_id:%d", __func__, adv, adv_id);
 }
 
-static advertiser_callback_t adv_callback = {
+static const advertiser_callback_t adv_callback = {
     sizeof(adv_callback),
     on_advertising_start_cb,
     on_advertising_stopped_cb
@@ -404,7 +404,7 @@ static int start_adv_cmd(void* handle, int argc, char* argv[])
     adv_handle = bt_le_start_advertising(handle, &params,
         p_adv_data, adv_len,
         p_scan_rsp_data, scan_rsp_len,
-        &adv_callback);
+        (advertiser_callback_t *)&adv_callback);
 
     PRINT("Advertising handle:%p", adv_handle);
     /* free advertiser data */
@@ -482,7 +482,7 @@ int adv_command_exec(void* handle, int argc, char* argv[])
     int ret = CMD_USAGE_FAULT;
 
     if (argc > 0)
-        ret = execute_command_in_table_offset(handle, g_adv_tables, ARRAY_SIZE(g_adv_tables), argc, argv, 0);
+        ret = execute_command_in_table_offset(handle, (bt_command_t *)g_adv_tables, ARRAY_SIZE(g_adv_tables), argc, argv, 0);
 
     if (ret < 0)
         usage();


### PR DESCRIPTION
Memory Optimization: Change the bluetooth bt_tool adv module to const for reduce the ram size.
    
bug:v/84960
    
Rootcause: To reduce RAM resource consumption, the `adv_options`,a dv_stop_options,
`g_adv_tables` and `adv_callback` in the bt_tools adv module must be marked with the `const` modifier.
This ensures it is compiled and linked into Flash memory instead of RAM.
    
Signed-off-by: huangyulong3 <huangyulong3@xiaomi.com>

