### PR TITLE
SPP: add credits control for recv data

### DIFF
--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -994,6 +994,8 @@ bt_status_t bt_sal_spp_data_received_response(uint16_t conn_port, uint8_t* buf)
     }
 
     spp_conn_unlock();
+
+    bt_rfcomm_dlc_update_credits(&spp_conn->rfcomm_dlc);
     return BT_STATUS_SUCCESS;
 }
 

--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -353,6 +353,8 @@ static void spp_rfcomm_connected(struct bt_rfcomm_dlc* rfcomm_dlc)
 
     BT_LOGD("%s, rfcomm_dlc: %p", __func__, rfcomm_dlc);
 
+    bt_rfcomm_dlc_set_rx_credit_mode(rfcomm_dlc, BT_RFCOMM_RX_CREDIT_MANUAL);
+
     spp_conn_lock();
     spp_conn = spp_find_connection_by_dlc(rfcomm_dlc);
     if (!spp_conn) {


### PR DESCRIPTION
bug: v/85608

rootcause: Adding SPP process handling to the bluetooth service resolves the issue of non-flow control data piling up in the protocol stack.

## Summary

Adding SPP process handling to the bluetooth service resolves the issue of non-flow control data piling up in the protocol stack.

## Impact

spp rx data

## Testing

test spp  rx pass

