### PR TITLE
Bluetooth Adapter: add log for scan mode and bondable state

### DIFF
--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -2375,6 +2375,7 @@ bt_status_t adapter_set_scan_mode(bt_scan_mode_t mode, bool bondable)
     adapter->properties.bondable = bondable;
 
 error:
+    BT_LOGI("scanmode: %d, bondable: %d", (int)adapter->properties.scan_mode, (int)adapter->properties.bondable);
     adapter_unlock();
     return status;
 }


### PR DESCRIPTION
bug: v/85755

Add `BT_LOGI` log to print scan mode and bondable state in `adapter_set_scan_mode` function for better debugging and monitoring of adapter scan mode changes.

