### PR TITLE
commit LE bond settings after load

### DIFF
--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -1135,6 +1135,7 @@ static void STACK_CALL(le_set_bond)(void* args)
 
 #ifdef CONFIG_SETTINGS_ZBLUE
     bt_settings_load(req->id, req->adpt.le_set_bond.id, req->adpt.le_set_bond.key, &le_addr);
+    bt_settings_commit(req->id, req->adpt.le_set_bond.id, req->adpt.le_set_bond.key, &le_addr);
 #endif
 }
 


### PR DESCRIPTION
depends-on: [open-vela/external_zblue/pull/170]

bug: v/85615

After adding LTK/IRK, the stack must trigger the settings commit path so the controller resolving list and related RPA advertise/scan behavior are updated. Previously there was no key-level commit hook for zblue settings, so the commit handler was not invoked for these updates.