### PR TITLE
add ATTR_AUTO_RSP_CCC_READ to keep legacy GATT_H_CCCD behavior

### DIFF
--- a/framework/include/bt_gatt_defs.h
+++ b/framework/include/bt_gatt_defs.h
@@ -154,8 +154,11 @@ typedef enum {
 
 /* GATT_H_DESCRIPTOR */
 #define GATT_H_CCCD(_perm, _change, _handle) \
-    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CCCD), _perm, ATTR_RSP_BY_APP, NULL, _change, NULL, 0, _handle)
+    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CCCD), _perm, ATTR_AUTO_RSP, NULL, _change, NULL, 0, _handle)
 
+/* GATT_H_DESCRIPTOR for CCCD with user response (APP handles read/write) */
+#define GATT_H_CCCD_USER_RSP(_perm, _read, _write, _handle) \
+    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CCCD), _perm, ATTR_RSP_BY_APP, _read, _write, NULL, 0, _handle)
 /* GATT_H_DESCRIPTOR */
 #define GATT_H_CPFD(_value, _length, _handle) \
     GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CPFD), GATT_PERM_READ, ATTR_AUTO_RSP, NULL, NULL, _value, _length, _handle)

--- a/framework/include/bt_gatt_defs.h
+++ b/framework/include/bt_gatt_defs.h
@@ -51,6 +51,7 @@ typedef enum {
 typedef enum {
     ATTR_AUTO_RSP,
     ATTR_RSP_BY_APP,
+    ATTR_AUTO_RSP_CCC_READ,
 } gatt_attr_rsp_t;
 
 typedef enum {
@@ -154,7 +155,7 @@ typedef enum {
 
 /* GATT_H_DESCRIPTOR */
 #define GATT_H_CCCD(_perm, _change, _handle) \
-    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CCCD), _perm, ATTR_AUTO_RSP, NULL, _change, NULL, 0, _handle)
+    GATT_H_DESCRIPTOR(BT_UUID_DECLARE_16(BT_UUID_GATT_CCCD), _perm, ATTR_AUTO_RSP_CCC_READ, NULL, _change, NULL, 0, _handle)
 
 /* GATT_H_DESCRIPTOR for CCCD with user response (APP handles read/write) */
 #define GATT_H_CCCD_USER_RSP(_perm, _read, _write, _handle) \

--- a/service/ipc/socket/src/bt_socket_gatts.c
+++ b/service/ipc/socket/src/bt_socket_gatts.c
@@ -272,7 +272,7 @@ void bt_socket_server_gatts_process(service_poll_t* poll, int fd,
             attr_inst->permissions = packet->gatts_pl._bt_gatts_add_attr_table.attr_db[i].permissions;
             attr_inst->attr_length = packet->gatts_pl._bt_gatts_add_attr_table.attr_db[i].attr_length;
 
-            if (attr_inst->rsp_type == ATTR_RSP_BY_APP) {
+            if (attr_inst->rsp_type == ATTR_RSP_BY_APP || attr_inst->rsp_type == ATTR_AUTO_RSP_CCC_READ) {
                 attr_inst->read_cb = on_read_request_cb;
                 attr_inst->write_cb = on_write_request_cb;
             } else if (attr_inst->attr_length) {

--- a/service/profiles/gatt/gatts_service.c
+++ b/service/profiles/gatt/gatts_service.c
@@ -328,7 +328,7 @@ static void gatts_process_message(void* data)
         if (!element)
             break;
 
-        if (element->rsp_type == ATTR_AUTO_RSP) {
+        if (element->rsp_type == ATTR_AUTO_RSP || element->rsp_type == ATTR_AUTO_RSP_CCC_READ) {
             bt_sal_gatt_server_send_response(PRIMARY_ADAPTER, &msg->param.read.addr, msg->param.read.request_id, element->attr_data, element->attr_length);
         } else if (element->read_cb) {
             element->read_cb(service, &msg->param.read.addr, msg->param.read.element_id ^ service->srv_id, msg->param.read.request_id);


### PR DESCRIPTION
add ATTR_AUTO_RSP_CCC_READ to keep legacy GATT_H_CCCD behavior

rootcause:
Previously, CCC descriptors (defined by `GATT_H_CCCD`) would automatically respond to *read requests* within the stack, while forwarding all *write operations* (including write requests and write commands) to the application. This allowed the app to detect when a characteristic's notify/indicate status changed, without needing to implement `on_read_cb`.

During the Android BTIF porting, CCC read requests started being passed up to the application. This introduced compatibility issues for existing services that used `GATT_H_CCCD` without registering an `on_read_cb`, resulting in unhandled read responses.

To preserve backward compatibility, a new `rsp_type` value — `ATTR_AUTO_RSP_CCC_READ` — is introduced for `GATT_H_CCCD`. It restores the original behavior:

* Automatically respond to CCC descriptor read requests inside the stack
* Still forward write requests and write commands to the application via `on_write_cb`

This allows legacy services to continue functioning without modification.
Apps that require full control over both read and write (e.g. Android BTIF layer) should use `GATT_H_CCCD_USER_RSP`.
