### PR TITLE
Supports user confirm in BLE Just Work pairing mode

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -873,6 +873,11 @@ bt_status_t bt_sal_set_io_capability(bt_controller_id_t id, bt_io_capability_t c
     bt_conn_auth_cb_register(NULL);
     bt_conn_auth_cb_register(&g_conn_auth_cbs);
 
+#ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
+    /* Keep consistency with legacy stack: sync LE IO capability with BR/EDR IO capability */
+    bt_sal_le_set_io_capability(id, cap);
+#endif
+
     return BT_STATUS_SUCCESS;
 #else
     return BT_STATUS_NOT_SUPPORTED;

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -1040,6 +1040,9 @@ bt_status_t bt_sal_le_set_io_capability(bt_controller_id_t id, bt_io_capability_
         g_conn_auth_cbs.cancel = zblue_on_auth_cancel;
         break;
     case BT_IO_CAPABILITY_NOINPUTNOOUTPUT:
+#ifndef CONFIG_HCI_AUTO_REPLY_IN_JUST_WORK
+        g_conn_auth_cbs.passkey_confirm = zblue_on_auth_passkey_confirm;
+#endif
         g_conn_auth_cbs.cancel = zblue_on_auth_cancel;
         break;
     default:
@@ -1457,6 +1460,8 @@ bt_status_t bt_sal_le_smp_reply(bt_controller_id_t id, bt_address_t* addr, bool 
 
     switch (type) {
     case PAIR_TYPE_PASSKEY_CONFIRMATION:
+        SAL_CHECK(bt_conn_auth_passkey_confirm(conn), 0);
+        break;
     case PAIR_TYPE_CONSENT:
         SAL_CHECK(bt_conn_auth_pairing_confirm(conn), 0);
         break;


### PR DESCRIPTION
bug: v/85869

1. Configure the correct `passkey_confirm` interface.

2. Follow the legacy stack; `le` iocap and `bt_iocap` are consistent.

3. No input/output iocap also supports `passkey confirm cb`.