### PR TITLE
Fix GATTC discovery filter UUID handling

### DIFF
--- a/service/profiles/gatt/gattc_service.c
+++ b/service/profiles/gatt/gattc_service.c
@@ -241,7 +241,10 @@ static bt_status_t gattc_discover_start(gattc_connection_t* connection, bt_uuid_
 
     bt_status_t status;
 
-    if (!filter_uuid) {
+    /* bt_gattc_discover_service sets filter_uuid.type = 0 when caller passes NULL,
+     * so a non-NULL pointer with type==0 still means "discover all services".
+     */
+    if (!filter_uuid || !filter_uuid->type) {
         status = bt_sal_gatt_client_discover_all_services(PRIMARY_ADAPTER, &connection->remote_addr);
     } else {
         status = bt_sal_gatt_client_discover_service_by_uuid(PRIMARY_ADAPTER, &connection->remote_addr, filter_uuid);


### PR DESCRIPTION
bug: v/83024

Restore the type==0 check so a non-NULL filter_uuid with type 0 is treated

as "discover all services," matching bt_gattc_discover_service behavior.

Add an inline comment to document the NULL-to-type=0 contract and avoid

invalid UUID discovery calls that can break subscription flow.