### PR TITLE
pm: add bt_cm_enable/disable_enhanced_mode for BR/EDR low-latency sniff

### DIFF
--- a/framework/include/bluetooth.h
+++ b/framework/include/bluetooth.h
@@ -215,9 +215,20 @@ typedef enum {
 } ble_connect_filter_policy_t;
 
 typedef enum {
-    EM_LE_LOW_LATENCY,
+    /* ---------------- LE Enhanced Modes ---------------- */
+    EM_LE_MODE_START,
+    EM_LE_LOW_LATENCY = EM_LE_MODE_START,
     EM_LE_HIGH_TPUT,
     EM_LE_LOW_POWER,
+    EM_LE_MODE_END,
+
+    /* ---------------- BR/EDR Enhanced Modes ---------------- */
+    EM_BR_MODE_START = 0xF0,
+    EM_BR_LOW_LATENCY,
+    EM_BR_ULTRA_LOW_LATENCY,
+    EM_BR_HIGH_TPUT,
+    EM_BR_LOW_POWER,
+    EM_BR_MODE_END,
 } bt_enhanced_mode_t;
 
 typedef enum {

--- a/service/src/connection_manager.c
+++ b/service/src/connection_manager.c
@@ -19,6 +19,7 @@
 #include "adapter_internel.h"
 #include "bluetooth.h"
 #include "hci_error.h"
+#include "power_manager.h"
 #include "service_loop.h"
 #include "service_manager.h"
 
@@ -34,6 +35,16 @@
 #endif
 
 #include "utils/log.h"
+
+#define BT_CM_LL_SNIFF_INTERVAL_MAX 160
+#define BT_CM_LL_SNIFF_INTERVAL_MIN 40
+#define BT_CM_LL_SNIFF_ATTEMPT 4
+#define BT_CM_LL_SNIFF_TIMEOUT 1
+
+#define BT_CM_ULL_SNIFF_INTERVAL_MAX 18
+#define BT_CM_ULL_SNIFF_INTERVAL_MIN 10
+#define BT_CM_ULL_SNIFF_ATTEMPT 4
+#define BT_CM_ULL_SNIFF_TIMEOUT 1
 
 #define CM_RECONNECT_INTERVAL (12000) /* reconnect Interval */
 #define PROFILE_CONNECT_INTERVAL (500) /* Interval between HFP and A2DP */
@@ -60,6 +71,26 @@ typedef struct {
     bt_cm_timer_t cm_timer;
     service_timer_t* a2dp_conn_timer;
 } bt_connection_manager_t;
+
+typedef struct {
+    uint16_t max_interval; /** Maximum sniff interval */
+    uint16_t min_interval; /** Minimum sniff interval */
+    uint16_t attempt; /** Sniff attempt parameter */
+    uint16_t timeout; /** Sniff timeout parameter */
+    uint16_t idle_timeout_ms; /** Idle timeout before entering sniff */
+} bt_cm_sniff_param_t;
+
+static bt_cm_sniff_param_t g_bt_cm_sniff_param_table[] = {
+    /* Low Latency */
+    { BT_CM_LL_SNIFF_INTERVAL_MAX, BT_CM_LL_SNIFF_INTERVAL_MIN,
+        BT_CM_LL_SNIFF_ATTEMPT, BT_CM_LL_SNIFF_TIMEOUT,
+        1000 },
+
+    /* Ultra Low Latency */
+    { BT_CM_ULL_SNIFF_INTERVAL_MAX, BT_CM_ULL_SNIFF_INTERVAL_MIN,
+        BT_CM_ULL_SNIFF_ATTEMPT, BT_CM_ULL_SNIFF_TIMEOUT,
+        1000 },
+};
 
 static bt_connection_manager_t g_connection_manager;
 
@@ -493,14 +524,66 @@ void bt_cm_process_disconnect_event(bt_address_t* addr, uint8_t transport, uint3
         bt_cm_process_reconnection(addr, hci_reason_code);
 }
 
-bt_status_t bt_cm_enable_enhanced_mode(bt_address_t* addr, uint8_t mode)
+static inline void bt_cm_sniff_param_to_pm_mode(const bt_cm_sniff_param_t* in,
+    bt_pm_mode_t* out)
+{
+    out->max = in->max_interval;
+    out->min = in->min_interval;
+    out->attempt = in->attempt;
+    out->timeout = in->timeout;
+    out->mode = BT_LINK_MODE_SNIFF; /** BR/EDR sniff link mode */
+}
+
+static inline int sniff_param_table_index_from_mode(bt_enhanced_mode_t mode)
 {
     switch (mode) {
-    case EM_LE_LOW_LATENCY: {
+    case EM_BR_LOW_LATENCY:
+        return 0;
+    case EM_BR_ULTRA_LOW_LATENCY:
+        return 1;
+
+    default:
+        return -1;
+    }
+}
+
+static bt_status_t bt_cm_apply_bredr_sniff_mode(bt_address_t* addr, uint8_t table_idx)
+{
+    bt_pm_mode_t sniff_params;
+    bt_cm_sniff_param_t* p;
+
+    if (!addr) {
+        return BT_STATUS_PARM_INVALID;
+    }
+
+    p = &g_bt_cm_sniff_param_table[table_idx];
+
+    /* Do not pass bt_cm_sniff_param_t directly.
+     * In the future, we may have multiple clients with different sniff_param values.
+     * We will choose the best pm mode and idle timeout from them, so set them separately.
+     */
+    bt_cm_sniff_param_to_pm_mode(p, &sniff_params);
+
+    return bt_pm_set_app_profile_sniff(addr, &sniff_params);
+}
+
+bt_status_t bt_cm_enable_enhanced_mode(bt_address_t* addr, uint8_t mode)
+{
+    int table_idx;
+
+    switch (mode) {
 #ifdef CONFIG_LE_DLF_SUPPORT
+    case EM_LE_LOW_LATENCY:
         return bt_cm_enable_dlf(addr);
 #endif
-    }
+
+    case EM_BR_LOW_LATENCY:
+    case EM_BR_ULTRA_LOW_LATENCY:
+        table_idx = sniff_param_table_index_from_mode(mode);
+        if (table_idx < 0) {
+            return BT_STATUS_PARM_INVALID;
+        }
+        return bt_cm_apply_bredr_sniff_mode(addr, table_idx);
     default:
         return BT_STATUS_NOT_SUPPORTED;
     }
@@ -509,11 +592,15 @@ bt_status_t bt_cm_enable_enhanced_mode(bt_address_t* addr, uint8_t mode)
 bt_status_t bt_cm_disable_enhanced_mode(bt_address_t* addr, uint8_t mode)
 {
     switch (mode) {
-    case EM_LE_LOW_LATENCY: {
 #ifdef CONFIG_LE_DLF_SUPPORT
+    case EM_LE_LOW_LATENCY:
         return bt_cm_disable_dlf(addr);
 #endif
-    }
+
+    case EM_BR_LOW_LATENCY:
+    case EM_BR_ULTRA_LOW_LATENCY:
+        return bt_pm_set_app_profile_sniff(addr, NULL);
+
     default:
         return BT_STATUS_NOT_SUPPORTED;
     }

--- a/service/src/power_manager.c
+++ b/service/src/power_manager.c
@@ -190,6 +190,9 @@ typedef struct {
     uint8_t hci_status;
     uint16_t interval;
     service_timer_t* request_timer;
+
+    bt_pm_mode_t app_preferred_sniff_params;
+    bool immediate_sniff_switch;
 } bt_pm_device_t;
 
 static const bt_pm_mode_t g_pm_mode[] = {
@@ -391,6 +394,9 @@ static bt_pm_device_t* pm_conn_device_add(bt_address_t* peer_addr)
 
     memcpy(&device->peer_addr, peer_addr, sizeof(bt_address_t));
     device->mode = BT_LINK_MODE_ACTIVE;
+
+    device->app_preferred_sniff_params = g_pm_mode[BT_PM_SNIFF & BT_PM_PREF_MODE_MASK];
+
     list_add_tail(&manager->pm_devices, &device->srv_node);
     return device;
 }
@@ -404,7 +410,7 @@ static void pm_conn_device_remove(bt_pm_device_t* device)
     }
 }
 
-static bt_status_t pm_request_sniff(bt_address_t* peer_addr, bt_pm_mode_index_t index)
+static bt_status_t pm_request_sniff(bt_address_t* peer_addr, bt_pm_mode_index_t index, uint16_t profile_id)
 {
     bt_pm_device_t* device;
     bt_pm_mode_t mode;
@@ -421,7 +427,12 @@ static bt_status_t pm_request_sniff(bt_address_t* peer_addr, bt_pm_mode_index_t 
         return BT_STATUS_FAIL;
     }
 
-    memcpy(&mode, &g_pm_mode[index], sizeof(bt_pm_mode_t));
+    if (profile_id == PROFILE_SPP) {
+        memcpy(&mode, &device->app_preferred_sniff_params, sizeof(bt_pm_mode_t));
+    } else {
+        memcpy(&mode, &g_pm_mode[index], sizeof(bt_pm_mode_t));
+    }
+
     if (device->mode == BT_LINK_MODE_SNIFF && device->interval <= mode.max && device->interval >= mode.min) {
         return BT_STATUS_SUCCESS;
     }
@@ -597,7 +608,7 @@ static void pm_mode_request(bt_address_t* peer_addr, uint8_t req, uint16_t profi
         if (pm_action & BT_PM_ACTIVE) {
             pm_request_active(peer_addr);
         } else if (pm_action & BT_PM_SNIFF) {
-            pm_request_sniff(peer_addr, pm_action & BT_PM_PREF_MODE_MASK);
+            pm_request_sniff(peer_addr, pm_action & BT_PM_PREF_MODE_MASK, profile_id);
         }
     } break;
     case BT_PM_RESTART: {
@@ -830,7 +841,15 @@ void bt_pm_remote_link_mode_changed(bt_address_t* addr, uint8_t mode, uint16_t s
     case BT_LINK_MODE_ACTIVE: {
         pm_stop_timer(addr);
         pm_request_stop_timer(device);
-        pm_mode_request(addr, BT_PM_RESTART, manager->last_profile_id);
+        if (device->immediate_sniff_switch) {
+            /* Force switch to our sniff parameters immediately
+             * to avoid being overridden by peer device
+             */
+            device->immediate_sniff_switch = false;
+            pm_request_sniff(addr, BT_PM_SNIFF & BT_PM_PREF_MODE_MASK, PROFILE_SPP);
+        } else {
+            pm_mode_request(addr, BT_PM_RESTART, manager->last_profile_id);
+        }
     } break;
     case BT_LINK_MODE_SNIFF: {
         pm_stop_timer(addr);
@@ -864,4 +883,31 @@ void bt_pm_remote_device_disconnected(bt_address_t* addr)
     pm_stop_timer(addr);
 
     pm_conn_device_remove(device);
+}
+
+bt_status_t bt_pm_set_app_profile_sniff(bt_address_t* peer_addr, bt_pm_mode_t* sniff_params)
+{
+    bt_pm_device_t* device;
+
+    device = pm_conn_device_find(peer_addr);
+    if (!device) {
+        BT_LOGE("%s, fail to find device:%s", __func__, bt_addr_str(peer_addr));
+        return BT_STATUS_FAIL;
+    }
+
+    if (!sniff_params) {
+        device->app_preferred_sniff_params = g_pm_mode[BT_PM_SNIFF & BT_PM_PREF_MODE_MASK];
+    } else {
+        device->app_preferred_sniff_params = *sniff_params;
+    }
+
+    if (device->mode == BT_LINK_MODE_ACTIVE) {
+        device->immediate_sniff_switch = false;
+    } else {
+        /* Force switching sniff parameters */
+        device->immediate_sniff_switch = true;
+        pm_request_active(peer_addr);
+    }
+
+    return BT_STATUS_SUCCESS;
 }

--- a/service/src/power_manager.h
+++ b/service/src/power_manager.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 
 #include "bt_addr.h"
+#include "bt_status.h"
 
 typedef struct {
     uint16_t max;
@@ -43,5 +44,7 @@ void bt_pm_cleanup(void);
 void bt_pm_remote_link_mode_changed(bt_address_t* addr, uint8_t mode, uint16_t sniff_interval);
 void bt_pm_remote_device_connected(bt_address_t* addr);
 void bt_pm_remote_device_disconnected(bt_address_t* addr);
+
+bt_status_t bt_pm_set_app_profile_sniff(bt_address_t* peer_addr, bt_pm_mode_t* sniff_params);
 
 #endif /* __BT_POWER_MANAGER_H__ */

--- a/tools/bt_tools.c
+++ b/tools/bt_tools.c
@@ -79,6 +79,7 @@ static int search_cmd(void* handle, int argc, char** argv);
 static int start_service_cmd(void* handle, int argc, char** argv);
 static int stop_service_cmd(void* handle, int argc, char** argv);
 static int set_phy_cmd(void* handle, int argc, char** argv);
+static int enhance_mode_cmd(void* handle, int argc, char** argv);
 static int dump_cmd(void* handle, int argc, char** argv);
 static int quit_cmd(void* handle, int argc, char** argv);
 static void bttool_ins_uninit(bttool_t* bttool);
@@ -171,6 +172,8 @@ static bt_command_t g_cmd_tables[] = {
     { "start", start_service_cmd, 0, "start profile service, Not implemented" },
     { "stop", stop_service_cmd, 0, "stop profile service,  Not implemented" },
     { "setphy", set_phy_cmd, 0, SET_LE_PHY_USAGE },
+    { "enhance", enhance_mode_cmd, 0,
+        "enhance <peer-addr> <mode> <enable(0|1)>, mode: le_ll le_ht le_lp br_ll br_ul br_ht br_lp" },
 #ifdef CONFIG_BLUETOOTH_BLE_ADV
     { "adv", adv_command_exec, 0, "advertising cmd,   input \'adv\' show usage" },
 #endif
@@ -1380,6 +1383,76 @@ static int set_phy_cmd(void* handle, int argc, char** argv)
     }
 
     bt_device_set_le_phy(handle, &addr, tx_phy, rx_phy);
+
+    return CMD_OK;
+}
+
+static bool parse_mode_string(const char* str, bt_enhanced_mode_t* out_mode)
+{
+    if (!str || !out_mode)
+        return false;
+
+    switch (str[0]) {
+    case 'l': // le_*
+        if (strcmp(str, "le_ll") == 0) {
+            *out_mode = EM_LE_LOW_LATENCY;
+            return true;
+        }
+        if (strcmp(str, "le_ht") == 0) {
+            *out_mode = EM_LE_HIGH_TPUT;
+            return true;
+        }
+        if (strcmp(str, "le_lp") == 0) {
+            *out_mode = EM_LE_LOW_POWER;
+            return true;
+        }
+        break;
+    case 'b': // br_*
+        if (strcmp(str, "br_ll") == 0) {
+            *out_mode = EM_BR_LOW_LATENCY;
+            return true;
+        }
+        if (strcmp(str, "br_ul") == 0) {
+            *out_mode = EM_BR_ULTRA_LOW_LATENCY;
+            return true;
+        }
+        if (strcmp(str, "br_ht") == 0) {
+            *out_mode = EM_BR_HIGH_TPUT;
+            return true;
+        }
+        if (strcmp(str, "br_lp") == 0) {
+            *out_mode = EM_BR_LOW_POWER;
+            return true;
+        }
+        break;
+    }
+
+    return false;
+}
+
+static int enhance_mode_cmd(void* handle, int argc, char** argv)
+{
+    bt_address_t addr;
+    bt_enhanced_mode_t mode;
+    int enable_flag;
+
+    if (argc < 3)
+        return CMD_PARAM_NOT_ENOUGH;
+
+    if (bt_addr_str2ba(argv[0], &addr) < 0)
+        return CMD_INVALID_ADDR;
+
+    if (!parse_mode_string(argv[1], &mode))
+        return CMD_INVALID_PARAM;
+
+    enable_flag = atoi(argv[2]);
+    if (enable_flag != 0 && enable_flag != 1)
+        return CMD_INVALID_ADDR;
+
+    if (enable_flag)
+        bt_device_enable_enhanced_mode(handle, &addr, mode);
+    else
+        bt_device_disable_enhanced_mode(handle, &addr, mode);
 
     return CMD_OK;
 }


### PR DESCRIPTION
bug: v/67000

Add bt_cm_enable_enhanced_mode() and bt_cm_disable_enhanced_mode(). Support EM_BR_SNIFF_LOW_LATENCY and EM_BR_SNIFF_ULTRA_LOW_LATENCY. They switch to lower sniff intervals for short-term low latency needs. Disable API restores the default sniff parameters.