### PR TITLE
Implement CTKD support for cross-transport key derivation

### DIFF
--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -56,6 +56,7 @@ typedef union {
     } le_set_bond;
     int security_level;
     bool bondable;
+    uint8_t ctkd_mode;
 } sal_adapter_args_t;
 
 typedef struct {
@@ -1653,10 +1654,43 @@ uint16_t bt_sal_le_get_appearance(bt_controller_id_t id)
 #endif /* CONFIG_BT_DEVICE_APPEARANCE_GATT_WRITABLE */
 }
 
+#ifdef CONFIG_BT_CLASSIC
+static void STACK_CALL(enable_key_derivation)(void* args)
+{
+    sal_adapter_req_t* req = args;
+
+    bt_smp_set_ctkd_mode_mc(req->id, req->adpt.ctkd_mode);
+}
+#endif
+
 bt_status_t bt_sal_le_enable_key_derivation(bt_controller_id_t id, bool brkey_to_lekey, bool lekey_to_brkey)
 {
-    /* todo: */
+#ifdef CONFIG_BT_CLASSIC
+    sal_adapter_req_t* req;
+    uint8_t ctkd_mode = 0;
+
+    if (brkey_to_lekey) {
+        ctkd_mode |= BT_SMP_CTKD_BR_TO_LE;
+    }
+    if (lekey_to_brkey) {
+        ctkd_mode |= BT_SMP_CTKD_LE_TO_BR;
+    }
+
+    req = sal_adapter_req(id, NULL, STACK_CALL(enable_key_derivation));
+    if (!req) {
+        BT_LOGE("%s, req null", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    req->adpt.ctkd_mode = ctkd_mode;
+
+    BT_LOGD("%s, brkey_to_lekey: %d, lekey_to_brkey: %d, mode: 0x%02x",
+        __func__, brkey_to_lekey, lekey_to_brkey, ctkd_mode);
+
+    return sal_send_req(req);
+#else
     SAL_NOT_SUPPORT;
+#endif
 }
 
 #endif /* CONFIG_BLUETOOTH_BLE_SUPPORT */

--- a/tools/bt_tools.c
+++ b/tools/bt_tools.c
@@ -51,6 +51,7 @@ static int get_le_addr_cmd(void* handle, int argc, char** argv);
 static int set_identity_addr_cmd(void* handle, int argc, char** argv);
 static int set_scan_parameters_cmd(void* handle, int argc, char** argv);
 static int set_debug_mode_cmd(void* handle, int argc, char** argv);
+static int set_ctkd_mode_cmd(void* handle, int argc, char** argv);
 static int get_local_name_cmd(void* handle, int argc, char** argv);
 static int set_local_name_cmd(void* handle, int argc, char** argv);
 static int get_local_cod_cmd(void* handle, int argc, char** argv);
@@ -269,6 +270,7 @@ static bt_command_t g_set_cmd_tables[] = {
                                       "\t\t\t<mode>:\n"
                                       "\t\t\t  \"pts\"\n"
                                       "\t\t\t  \"rssi\"\n" },
+    { "ctkd", set_ctkd_mode_cmd, 0, "set ctkd mode, params: <br_to_le> <le_to_br> (0: disable, 1: enable)" },
     { "help", NULL, 0, "show set help info" },
     //{ "", , "set " },
 };
@@ -1458,6 +1460,31 @@ static int enhance_mode_cmd(void* handle, int argc, char** argv)
         bt_device_enable_enhanced_mode(handle, &addr, mode);
     else
         bt_device_disable_enhanced_mode(handle, &addr, mode);
+
+    return CMD_OK;
+}
+
+static int set_ctkd_mode_cmd(void* handle, int argc, char** argv)
+{
+    if (argc < 2) {
+        PRINT("Usage: set ctkd mode <br_to_le> <le_to_br>");
+        PRINT("  br_to_le: 0=disable, 1=enable BR->LE CTKD");
+        PRINT("  le_to_br: 0=disable, 1=enable LE->BR CTKD");
+        return CMD_PARAM_NOT_ENOUGH;
+    }
+
+    bool br_to_le = atoi(argv[0]) != 0;
+    bool le_to_br = atoi(argv[1]) != 0;
+
+    bt_status_t status = bt_adapter_le_enable_key_derivation(g_bttool_ins, br_to_le, le_to_br);
+    if (status != BT_STATUS_SUCCESS) {
+        PRINT("Failed to set CTKD mode: %d", status);
+        return CMD_ERROR;
+    }
+
+    PRINT("CTKD mode set: BR->LE=%s, LE->BR=%s",
+        br_to_le ? "enabled" : "disabled",
+        le_to_br ? "enabled" : "disabled");
 
     return CMD_OK;
 }


### PR DESCRIPTION
depends-on: [open-vela/external_zblue/pull/182]

bug: v/85866

Implemented Cross-Transport Key Derivation (CTKD) functionality to enable secure key derivation between BR/EDR and BLE transports.

Changes:
- service/stacks/zephyr/sal_adapter_le_interface.c:
  * Added ctkd_mode field to sal_adapter_args_t union
  * Implemented enable_key_derivation() function
  * Completed bt_sal_le_enable_key_derivation() implementation with support for bidirectional key derivation (BR->LE and LE->BR)
  * Added proper CONFIG_BT_CLASSIC conditional compilation

- tools/bt_tools.c:
  * Added set_ctkd_mode_cmd() function for CLI control
  * Registered 'setctkd' and 'set ctkd' commands in command tables
  * Provides user-friendly interface to enable/disable CTKD modes

This feature allows devices to derive encryption keys across different Bluetooth transports, improving security and user experience during dual-mode connections.