### PR TITLE
spp: prevent service loop deadlock on rfcomm_tx_pool exhaustion

### DIFF
--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -745,6 +745,15 @@ static int do_spp_write(spp_device_t* device, uint8_t* buffer, uint16_t length)
 
         bt_pm_busy(PROFILE_SPP, &device->addr);
         status = bt_sal_spp_write(device->conn_port, tmpbuf, size);
+        if (status == BT_STATUS_NOMEM) {
+            BT_LOGW("%s tx pool full, caching data", __func__);
+            bt_pm_idle(PROFILE_SPP, &device->addr);
+            spp_cache_fragement(device, tmpbuf, size);
+            euv_pipe_read_stop(device->handle);
+            device->remaining_quota = 0;
+            return length - remaining;
+        }
+
         if (status != BT_STATUS_SUCCESS) {
             BT_LOGE("%s write to stack failed", __func__);
             bt_pm_idle(PROFILE_SPP, &device->addr);

--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -1018,7 +1018,13 @@ bt_status_t bt_sal_spp_write(uint16_t conn_port, uint8_t* buf, uint16_t size)
 
     spp_conn_unlock();
 
-    nbuf = bt_rfcomm_create_pdu(&rfcomm_tx_pool);
+    nbuf = net_buf_alloc(&rfcomm_tx_pool, K_NO_WAIT);
+    if (!nbuf) {
+        BT_LOGW("rfcomm_tx_pool exhausted");
+        return BT_STATUS_NOMEM;
+    }
+
+    net_buf_reserve(nbuf, SPP_MFS_EXTRA_SIZE - 1); /* exclude trailing FCS byte */
     net_buf_add_mem(nbuf, buf, size);
 
     ret = bt_rfcomm_dlc_send(&spp_conn->rfcomm_dlc, nbuf);


### PR DESCRIPTION
bug: v/85736

Replace K_FOREVER blocking net_buf alloc in bt_sal_spp_write with K_NO_WAIT non-blocking alloc. When rfcomm_tx_pool is exhausted, return BT_STATUS_NOMEM instead of blocking the service loop thread indefinitely.

In do_spp_write, handle BT_STATUS_NOMEM by caching unsent data via spp_cache_fragement and stopping euv_pipe reads, rather than dropping the data. Recovery occurs naturally when in-flight buffers complete and spp_on_outgoing_complete restores remaining_quota.

