### PR TITLE
adapter: skip RNR for CTKD-derived link key to avoid paging conflict

### DIFF
--- a/service/src/adapter_internel.h
+++ b/service/src/adapter_internel.h
@@ -153,6 +153,7 @@ typedef struct {
         struct {
             bt_128key_t key;
             bt_link_key_type_t type;
+            bool is_ctkd;
             bt_status_t status;
         } link_key;
         struct {
@@ -253,7 +254,7 @@ void adapter_on_pin_request(bt_address_t* addr, uint32_t cod,
 void adapter_on_bond_state_changed(bt_address_t* addr, bond_state_t state, uint8_t transport, bt_status_t status, bool is_ctkd);
 void adapter_on_service_search_done(bt_address_t* addr, bt_uuid_t* uuids, uint16_t size);
 void adapter_on_encryption_state_changed(bt_address_t* addr, bool encrypted, uint8_t transport);
-void adapter_on_link_key_update(bt_address_t* addr, bt_128key_t link_key, bt_link_key_type_t type);
+void adapter_on_link_key_update(bt_address_t* addr, bt_128key_t link_key, bt_link_key_type_t type, bool is_ctkd);
 void adapter_on_link_key_removed(bt_address_t* addr, bt_status_t status);
 void adapter_on_link_role_changed(bt_address_t* addr, bt_link_role_t role);
 void adapter_on_link_mode_changed(bt_address_t* addr, bt_link_mode_t mode, uint16_t sniff_interval);

--- a/service/src/adapter_service.c
+++ b/service/src/adapter_service.c
@@ -808,7 +808,8 @@ static void process_ssp_request_evt(bt_address_t* addr, uint8_t transport,
         return;
     }
 
-    if (!device_check_flag(device, DFLAG_NAME_SET | DFLAG_GET_RMT_NAME)) {
+    if (transport == BT_TRANSPORT_BREDR
+        && !device_check_flag(device, DFLAG_NAME_SET | DFLAG_GET_RMT_NAME)) {
         BT_LOGD("ssp, request remote name...");
         bt_sal_get_remote_name(PRIMARY_ADAPTER, addr);
         device_set_flags(device, DFLAG_GET_RMT_NAME);
@@ -908,14 +909,16 @@ static void process_enc_state_change_evt(bt_address_t* addr, bool encrypted,
 }
 
 static void process_link_key_update_evt(bt_address_t* addr, bt_128key_t link_key,
-    bt_link_key_type_t type)
+    bt_link_key_type_t type, bool is_ctkd)
 {
     bt_device_t* device;
     char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
 
     adapter_lock();
     device = adapter_find_create_classic_device(addr);
-    if (!device_check_flag(device, DFLAG_NAME_SET | DFLAG_GET_RMT_NAME)) {
+    /* skip RNR for CTKD-derived keys to avoid paging conflict with the ongoing pairing process */
+    if (!is_ctkd
+        && !device_check_flag(device, DFLAG_NAME_SET | DFLAG_GET_RMT_NAME)) {
         BT_LOGD("linkkey notify, request remote name...");
         bt_sal_get_remote_name(PRIMARY_ADAPTER, addr);
         device_set_flags(device, DFLAG_GET_RMT_NAME);
@@ -977,7 +980,8 @@ static void handle_security_event(void* data)
             evt->enc_state.transport);
         break;
     case LINK_KEY_UPDATE_EVT:
-        process_link_key_update_evt(&evt->addr, evt->link_key.key, evt->link_key.type);
+        process_link_key_update_evt(&evt->addr, evt->link_key.key, evt->link_key.type,
+            evt->link_key.is_ctkd);
         break;
     case LINK_KEY_REMOVED_EVT:
         process_link_key_removed_evt(&evt->addr, evt->link_key.status);
@@ -1914,7 +1918,8 @@ void adapter_on_encryption_state_changed(bt_address_t* addr, bool encrypted, uin
     do_in_service_loop(handle_security_event, evt);
 }
 
-void adapter_on_link_key_update(bt_address_t* addr, bt_128key_t link_key, bt_link_key_type_t type)
+void adapter_on_link_key_update(bt_address_t* addr, bt_128key_t link_key, bt_link_key_type_t type,
+    bool is_ctkd)
 {
     adapter_remote_event_t* evt = create_remote_event(addr, LINK_KEY_UPDATE_EVT);
     if (!evt)
@@ -1922,6 +1927,7 @@ void adapter_on_link_key_update(bt_address_t* addr, bt_128key_t link_key, bt_lin
 
     memcpy(evt->link_key.key, link_key, sizeof(bt_128key_t));
     evt->link_key.type = type;
+    evt->link_key.is_ctkd = is_ctkd;
     do_in_service_loop(handle_security_event, evt);
 }
 

--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -471,7 +471,7 @@ static int zblue_on_link_key_notify(uint8_t dev_id, bt_addr_le_t* addr, const ch
     key_type = link_key->key_type;
     free(link_key);
 
-    adapter_on_link_key_update(&br_addr, key, key_type);
+    adapter_on_link_key_update(&br_addr, key, key_type, false);
     return 0;
 }
 


### PR DESCRIPTION
bug: v/952

Rootcause: When BLE pairing completes and CTKD derives a BREDR link key, process_link_key_update_evt triggers a Remote_Name_Request (paging) on the BREDR address. This conflicts with the ongoing BLE SSP flow which may also be paging, and more critically blocks the MFI SPP Create_Connection issued ~500ms later, causing it to fail with HCI 0x0C COMMAND_DISALLOWED.
