### PR TITLE
add miss bt_conn_unref

### DIFF
--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -446,6 +446,7 @@ bt_status_t bt_sal_cm_try_disconnect_profiles(bt_address_t* addr, bool is_unpair
     }
 
     if (bt_conn_get_info(conn, &info) < 0) {
+        bt_conn_unref(conn);
         return BT_STATUS_FAIL;
     }
 
@@ -508,6 +509,7 @@ static bt_status_t bt_sal_try_profile_connect(bt_address_t* addr)
     }
 
     if (bt_conn_get_info(conn, &info) < 0) {
+        bt_conn_unref(conn);
         return BT_STATUS_FAIL;
     }
 


### PR DESCRIPTION
bug: v/83903

need bt_conn_unref after bt_conn_lookup_addr_br.