### PR TITLE
fix build waring when CONFIG_BLUETOOTH_BLE_SUPPORT not enable

### DIFF
--- a/framework/api/bt_device.c
+++ b/framework/api/bt_device.c
@@ -31,7 +31,11 @@ bt_status_t BTSYMBOLS(bt_device_get_identity_address)(bt_instance_t* ins, bt_add
 
 ble_addr_type_t BTSYMBOLS(bt_device_get_address_type)(bt_instance_t* ins, bt_address_t* addr)
 {
+#ifdef CONFIG_BLUETOOTH_BLE_SUPPORT
     return adapter_get_le_remote_address_type(addr);
+#else
+    return 0;
+#endif
 }
 
 bt_device_type_t BTSYMBOLS(bt_device_get_device_type)(bt_instance_t* ins, bt_address_t* addr)


### PR DESCRIPTION
bug: v/84604

if ble not support, return 0.