### PR TITLE
bt_socket: Fix mutex UAF in bt_socket_client_deinit

### DIFF
--- a/service/ipc/socket/src/bt_socket_client.c
+++ b/service/ipc/socket/src/bt_socket_client.c
@@ -508,6 +508,14 @@ void bt_socket_client_free_callbacks(bt_instance_t* ins, callbacks_list_t* cbsl)
 void bt_socket_client_deinit(bt_instance_t* ins)
 {
     uv_sem_destroy(&ins->message_processed);
+
+    /* Wait for any in-progress sendrecv to release the mutex before
+     * destroying it. sem_post was already called (by UV_DISCONNECT handler)
+     * to unblock sendrecv, but sendrecv may not have been scheduled yet to
+     * call uv_mutex_unlock. Acquiring the mutex here ensures sendrecv has
+     * fully exited before we destroy it, preventing UAF on the mutex. */
+    uv_mutex_lock(&ins->mutex);
+    uv_mutex_unlock(&ins->mutex);
     uv_mutex_destroy(&ins->mutex);
 
     if (ins->packet)


### PR DESCRIPTION
bug: v/85879

rootcause: bt_socket_client_deinit calls uv_mutex_destroy immediately after uv_sem_destroy, but the sendrecv thread may have just been unblocked by sem_post and not yet been scheduled to call uv_mutex_unlock. The deinit thread destroys the mutex prematurely, causing sendrecv to operate on an already-destroyed mutex, triggering UAF. Fix by adding a lock/unlock pair before uv_mutex_destroy to leverage mutex happens-before semantics, ensuring sendrecv has fully exited the critical section before destruction.

