### PR TITLE
Fix subscription persistence issue after bt_disable/enable

### DIFF
--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -1180,6 +1180,8 @@ bt_status_t bt_sal_gatt_client_register_notifications(bt_controller_id_t id, bt_
         notify->value_handle = element_id;
         notify->ccc_handle = ccc_handle;
         notify->notify = bt_gatt_notify_handler;
+        /* Set VOLATILE flag to clear subscription on disconnect */
+        atomic_set_bit(notify->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
         notify->value = BT_GATT_CCC_NOTIFY;
 
         if (enable) {
@@ -1208,6 +1210,8 @@ bt_status_t bt_sal_gatt_client_register_notifications(bt_controller_id_t id, bt_
         indicate->value_handle = element_id;
         indicate->ccc_handle = ccc_handle;
         indicate->notify = bt_gatt_notify_handler;
+        /* Set VOLATILE flag to clear subscription on disconnect */
+        atomic_set_bit(indicate->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
         indicate->value = BT_GATT_CCC_INDICATE;
 
         if (enable) {


### PR DESCRIPTION


Problem:
After calling bt_disable_mc(), acl disconnected or bt_enable_mc(), bt_gatt_subscribe() returns -EALREADY error when trying to resubscribe to the same CCCD.

Root Cause:
Zephyr Bluetooth stack implements subscription persistence for bonded devices. When a device is bonded and the subscription does not have BT_GATT_SUBSCRIBE_FLAG_VOLATILE set, the subscription parameters are retained in memory after disconnection. Upon reconnection, when the application attempts to subscribe again using the same params pointer, the stack detects a duplicate subscription and returns -EALREADY.

Solution:
Set BT_GATT_SUBSCRIBE_FLAG_VOLATILE flag for all GATT client subscriptions. This flag indicates that the subscription is temporary and should be automatically removed upon disconnection.


follow style's of zephyr sample code

<img width="1026" height="548" alt="image" src="https://github.com/user-attachments/assets/48caae25-7e30-4ee3-af44-d8fb56e968ea" />


