### PR TITLE
auto-accept BLE smp CONSENT pairing directly at SAL layer

### DIFF
--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -1639,7 +1639,7 @@ static void zblue_on_auth_pairing_confirm(struct bt_conn* conn)
         return;
     }
 
-    adapter_on_ssp_request(&addr, BT_TRANSPORT_BLE, 0, PAIR_TYPE_CONSENT, 0, NULL);
+    SAL_CHECK(bt_conn_auth_pairing_confirm(conn), 0);
 }
 
 #ifdef CONFIG_BT_SMP_APP_PAIRING_ACCEPT


### PR DESCRIPTION
bug: v/87350

rootcause: bt_device_set_pairing_confirmation() only supports PASSKEY_CONFIRM
  type pairing. When zblue_on_auth_pairing_confirm() is triggered for CONSENT
  type pairing, the previous code called adapter_on_ssp_request(PAIR_TYPE_CONSENT)
  to route through the app-layer callback chain, but the app layer has no way to
  reply via the existing API since set_pairing_confirmation does not handle
  CONSENT. To properly support CONSENT auto-accept without modifying the public
  API, call bt_conn_auth_pairing_confirm() directly at the SAL layer instead.
