### PR TITLE
spp: fix pipe read stall after tx pool full recovery

### DIFF
--- a/service/profiles/spp/spp_service.c
+++ b/service/profiles/spp/spp_service.c
@@ -869,10 +869,16 @@ static void spp_on_outgoing_complete(uint16_t port, uint8_t* buffer, uint16_t le
     if (!device)
         return;
 
-    if (!device->remaining_quota && device->handle != NULL) {
-        euv_pipe_read_start(device->handle, device->next_to_read, euv_read_complete, euv_alloc_buffer);
-    }
     device->remaining_quota++;
+
+    if (device->remaining_quota == 1 && device->handle != NULL) {
+        if (device->cache_buf.length > 0) {
+            /* flush cached data before restarting pipe read */
+            do_spp_write(device, NULL, 0);
+        } else {
+            euv_pipe_read_start(device->handle, device->mfs, euv_read_complete, euv_alloc_buffer);
+        }
+    }
 }
 
 static void spp_on_connect_request_received(bt_address_t* addr, uint16_t port)


### PR DESCRIPTION
bug: v/87572

When bt_sal_spp_write returns BT_STATUS_NOMEM, the complete packet
(size == mfs) is cached via spp_cache_fragement, setting
cache_buf.length = mfs. On recovery, spp_on_outgoing_complete directly
calls euv_pipe_read_start, causing euv_alloc_buffer to compute
len = mfs - mfs = 0. libuv gets a zero-length buffer, pipe read
stalls, and the connection eventually drops.

Fix by incrementing remaining_quota before the recovery check to
prevent uint8_t underflow (0 - 1 = 0xFF), then branching on
cache_buf.length: flush cached data via do_spp_write if present,
otherwise restart pipe read with mfs.

Signed-off-by: chejinxian1 <chejinxian1@xiaomi.com>