### PR TITLE
a2dp: Fix the issue of no sound from earbuds after repeated reconnect…

### DIFF
--- a/service/profiles/a2dp/a2dp_state_machine.c
+++ b/service/profiles/a2dp/a2dp_state_machine.c
@@ -392,6 +392,7 @@ static void idle_enter(state_machine_t* sm)
     A2DP_DBG_ENTER(sm, &a2dp_sm->addr);
 
     a2dp_sm->audio_ready = false;
+    a2dp_sm->pending = PENDING_NONE;
     if (prev_state != NULL) {
         bt_pm_conn_close(PROFILE_A2DP, &a2dp_sm->addr);
         if (a2dp_sm->peer_sep == SEP_SRC) {


### PR DESCRIPTION
…ion.

bug: v/87645

After sending STREAM_SUSPEND_REQ without receiving a response, STREAM_START_REQ is received and enters open state, then DISCONNECTED_EVT is received, causing pending to remain in stop state, which prevents music from playing normally after reconnection.

