### PR TITLE
Trigger profile handlers on ACL failure

### DIFF
--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -1699,12 +1699,15 @@ bt_status_t bt_sal_a2dp_sink_init(uint8_t max_connections)
 #ifdef CONFIG_BLUETOOTH_A2DP_SOURCE
 static bt_status_t a2dp_source_profile_connect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
-    struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
+    struct bt_conn* conn;
     struct zblue_a2dp_info_t* a2dp_info;
     struct bt_a2dp* a2dp;
 
+    conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     if (!conn) {
-        BT_LOGE("%s, acl not connected", __func__);
+        BT_LOGW("%s, acl not connected", __func__);
+        bt_sal_a2dp_source_event_callback(a2dp_event_new(DISCONNECTED_EVT, addr));
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_A2DP, CONN_ID_DEFAULT);
         return BT_STATUS_FAIL;
     }
 
@@ -1732,6 +1735,8 @@ static bt_status_t a2dp_source_profile_connect(bt_controller_id_t id, bt_address
     return BT_STATUS_SUCCESS;
 
 error:
+    bt_sal_a2dp_source_event_callback(a2dp_event_new(DISCONNECTED_EVT, addr));
+    bt_sal_cm_profile_disconnected_callback(addr, PROFILE_A2DP, CONN_ID_DEFAULT);
     bt_conn_unref(conn);
     return BT_STATUS_FAIL;
 }
@@ -1749,12 +1754,15 @@ bt_status_t bt_sal_a2dp_source_connect(bt_controller_id_t id, bt_address_t* addr
 #ifdef CONFIG_BLUETOOTH_A2DP_SINK
 static bt_status_t a2dp_sink_profile_connect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
-    struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
+    struct bt_conn* conn;
     struct zblue_a2dp_info_t* a2dp_info;
     struct bt_a2dp* a2dp;
 
+    conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     if (!conn) {
-        BT_LOGE("%s, acl not connected", __func__);
+        BT_LOGW("%s, acl not connected", __func__);
+        bt_sal_a2dp_sink_event_callback(a2dp_event_new(DISCONNECTED_EVT, addr));
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT);
         return BT_STATUS_FAIL;
     }
 
@@ -1781,6 +1789,8 @@ static bt_status_t a2dp_sink_profile_connect(bt_controller_id_t id, bt_address_t
     return BT_STATUS_SUCCESS;
 
 error:
+    bt_sal_a2dp_sink_event_callback(a2dp_event_new(DISCONNECTED_EVT, addr));
+    bt_sal_cm_profile_disconnected_callback(addr, PROFILE_A2DP_SINK, CONN_ID_DEFAULT);
     bt_conn_unref(conn);
     return BT_STATUS_FAIL;
 }

--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -715,10 +715,11 @@ static zblue_avrcp_info_t* bt_avrcp_create_avrcp_info(struct bt_conn* conn)
 }
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+static void avrcp_on_connection_state_changed(bt_address_t* bd_addr,
+    profile_connection_state_t state);
 static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
 {
     zblue_avrcp_info_t* avrcp_info;
-    avrcp_msg_t* msg;
 
     if (!bt_avrcp_conn) {
         BT_LOGW("%s, bt_avrcp_conn not initialized", __func__);
@@ -734,10 +735,7 @@ static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
 
     avrcp_info->ct = ct;
 
-    msg = avrcp_msg_new(AVRC_CONNECTION_STATE_CHANGED, &avrcp_info->bd_addr);
-    msg->data.conn_state.conn_state = PROFILE_STATE_CONNECTED;
-    msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
-    bt_sal_avrcp_control_event_callback(msg);
+    avrcp_on_connection_state_changed(&avrcp_info->bd_addr, PROFILE_STATE_CONNECTED);
     bt_sal_cm_profile_connected_callback(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT);
     bt_sal_profile_disconnect_register(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT, PRIMARY_ADAPTER, bt_sal_avrcp_disconnect, NULL);
 }
@@ -745,7 +743,6 @@ static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
 static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
 {
     zblue_avrcp_info_t* avrcp_info;
-    avrcp_msg_t* msg;
 
     if (!bt_avrcp_conn) {
         BT_LOGW("%s, bt_avrcp_conn not initialized", __func__);
@@ -760,10 +757,7 @@ static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
 
     avrcp_info->ct = NULL;
 
-    msg = avrcp_msg_new(AVRC_CONNECTION_STATE_CHANGED, &avrcp_info->bd_addr);
-    msg->data.conn_state.conn_state = PROFILE_STATE_DISCONNECTED;
-    msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
-    bt_sal_avrcp_control_event_callback(msg);
+    avrcp_on_connection_state_changed(&avrcp_info->bd_addr, PROFILE_STATE_DISCONNECTED);
     bt_sal_cm_profile_disconnected_callback(&avrcp_info->bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT);
 
     bt_list_remove_avrcp_info(avrcp_info);
@@ -1412,13 +1406,32 @@ static void zblue_on_tg_get_play_status_req(struct bt_avrcp_tg* tg, uint8_t tid)
 #endif
 
 #ifdef CONFIG_BLUETOOTH_AVRCP_CONTROL
+static void avrcp_on_connection_state_changed(bt_address_t* bd_addr,
+    profile_connection_state_t state)
+{
+    avrcp_msg_t* msg;
+
+    msg = avrcp_msg_new(AVRC_CONNECTION_STATE_CHANGED, bd_addr);
+    if (!msg) {
+        BT_LOGE("%s, avrcp_msg_new failed", __func__);
+        return;
+    }
+
+    msg->data.conn_state.conn_state = state;
+    msg->data.conn_state.reason = PROFILE_REASON_UNSPECIFIED;
+    bt_sal_avrcp_control_event_callback(msg);
+}
+
 static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd_addr, void* user_data)
 {
     int err;
-    struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)bd_addr);
+    struct bt_conn* conn;
 
+    conn = bt_conn_lookup_addr_br((bt_addr_t*)bd_addr);
     if (!conn) {
-        BT_LOGW("avrcp_info not found");
+        BT_LOGW("BR/EDR connection not found for AVRCP connect");
+        avrcp_on_connection_state_changed(bd_addr, PROFILE_STATE_DISCONNECTED);
+        bt_sal_cm_profile_disconnected_callback(bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT);
         return BT_STATUS_FAIL;
     }
 
@@ -1426,8 +1439,11 @@ static bt_status_t avrcp_control_connect(bt_controller_id_t id, bt_address_t* bd
 
     bt_conn_unref(conn);
 
-    if (err < 0)
+    if (err < 0) {
+        avrcp_on_connection_state_changed(bd_addr, PROFILE_STATE_DISCONNECTED);
+        bt_sal_cm_profile_disconnected_callback(bd_addr, PROFILE_AVRCP_CT, CONN_ID_DEFAULT);
         return BT_STATUS_FAIL;
+    }
 
     return BT_STATUS_SUCCESS;
 }

--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -369,9 +369,17 @@ static void bt_sal_cm_acl_disconnected(void* data)
     if (bt_sal_connecting_list != NULL) {
         manager = bt_list_find(bt_sal_connecting_list, bt_connection_manager_find, &cm_data->addr);
         if (manager != NULL) {
-            bt_list_remove(bt_sal_connecting_list, manager);
-        } else {
-            BT_LOGW("%s, manager not found.", __func__);
+            /*
+             * Trigger pending profile handlers to let them detect ACL failure
+             * and clean up properly. The handlers will fail (e.g., bt_conn_lookup
+             * returns NULL) and report disconnected state to upper layer.
+             */
+            if (bt_list_is_empty(manager->profile_conn_handler_list)) {
+                /* No pending handlers, remove manager directly */
+                bt_list_remove(bt_sal_connecting_list, manager);
+            } else {
+                bt_sal_trigger_profile_conn_act(manager, bt_sal_connecting_list);
+            }
         }
     }
 
@@ -383,8 +391,6 @@ static void bt_sal_cm_acl_disconnected(void* data)
                 bt_sal_remove_bond_internal(PRIMARY_ADAPTER, &manager->device_addr);
             }
             bt_list_remove(bt_sal_disconnecting_list, manager);
-        } else {
-            BT_LOGW("%s, manager not found.", __func__);
         }
     }
 

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -1315,11 +1315,14 @@ static void STACK_CALL(conn_connect)(void* args)
 
 static bt_status_t gatts_br_profile_connect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
-    struct bt_conn* conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
+    struct bt_conn* conn;
     int err;
 
+    conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     if (!conn) {
         BT_LOGE("%s, acl not connected", __func__);
+        if_gatts_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED);
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_GATTS, CONN_ID_DEFAULT);
         return BT_STATUS_FAIL;
     }
 
@@ -1333,6 +1336,8 @@ static bt_status_t gatts_br_profile_connect(bt_controller_id_t id, bt_address_t*
     return BT_STATUS_SUCCESS;
 
 error:
+    if_gatts_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED);
+    bt_sal_cm_profile_disconnected_callback(addr, PROFILE_GATTS, CONN_ID_DEFAULT);
     bt_conn_unref(conn);
     return BT_STATUS_FAIL;
 }

--- a/service/stacks/zephyr/sal_hfp_ag_interface.c
+++ b/service/stacks/zephyr/sal_hfp_ag_interface.c
@@ -397,6 +397,7 @@ static bt_status_t do_ag_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
     if (!conn) {
         BT_LOGE("%s, Failed to lookup connection", __func__);
         hfp_ag_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
         return BT_STATUS_NOT_FOUND;
     }
 
@@ -404,6 +405,7 @@ static bt_status_t do_ag_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
     if (!sal_conn) {
         BT_LOGE("%s, could not create new ag connection", __func__);
         hfp_ag_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
         bt_conn_unref(conn);
         return BT_STATUS_NOMEM;
     }
@@ -412,6 +414,7 @@ static bt_status_t do_ag_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
     if (bt_sdp_discover(conn, &sdp_discover) < 0) {
         BT_LOGE("%s, failed to start a SDP discovery", __func__);
         hfp_ag_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
         bt_conn_unref(conn);
         bt_list_remove(g_sal_ag_conn_list, sal_conn);
         return BT_STATUS_FAIL;

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -356,6 +356,7 @@ static bt_status_t do_hf_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
     if (!conn) {
         BT_LOGE("%s, Failed to lookup connection", __func__);
         hfp_hf_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
         return BT_STATUS_NOT_FOUND;
     }
 
@@ -363,6 +364,7 @@ static bt_status_t do_hf_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
     if (!sal_conn) {
         BT_LOGE("%s, could not create new hf connection", __func__);
         hfp_hf_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
         bt_conn_unref(conn);
         return BT_STATUS_NOMEM;
     }
@@ -371,6 +373,7 @@ static bt_status_t do_hf_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
     if (bt_sdp_discover(conn, &sdp_discover) < 0) {
         BT_LOGE("%s, failed to start a SDP discovery", __func__);
         hfp_hf_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+        bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
         bt_conn_unref(conn);
         bt_list_remove(g_sal_hf_conn_list, sal_conn);
         return BT_STATUS_FAIL;


### PR DESCRIPTION
bug: v/87679

When ACL connection fails (e.g., Page Timeout), profile handlers were not triggered, causing upper layer to wait for timeout instead of receiving immediate disconnection notification.

This patch:
1. Triggers pending profile handlers when ACL disconnects, allowing them to detect failure via bt_conn_lookup_addr_br() returning NULL
2. Ensures all profile connect handlers have complete error callbacks in their failure paths

The fix is minimal - no handler signature changes needed. Handlers already check bt_conn_lookup_addr_br() result, which naturally fails when ACL is not available.

Affected profiles: HFP HF/AG, A2DP Source/Sink, AVRCP, GATTS BR, HID, SPP

