### PR TITLE
Add NULL guards for global connection lists

### DIFF
--- a/service/stacks/zephyr/sal_avrcp_interface.c
+++ b/service/stacks/zephyr/sal_avrcp_interface.c
@@ -720,6 +720,11 @@ static void zblue_on_ct_connected(struct bt_conn* conn, struct bt_avrcp_ct* ct)
     zblue_avrcp_info_t* avrcp_info;
     avrcp_msg_t* msg;
 
+    if (!bt_avrcp_conn) {
+        BT_LOGW("%s, bt_avrcp_conn not initialized", __func__);
+        return;
+    }
+
     avrcp_info = bt_list_find(bt_avrcp_conn, bt_avrcp_info_find_by_conn, conn);
     if (!avrcp_info)
         avrcp_info = bt_avrcp_create_avrcp_info(conn);
@@ -741,6 +746,11 @@ static void zblue_on_ct_disconnected(struct bt_avrcp_ct* ct)
 {
     zblue_avrcp_info_t* avrcp_info;
     avrcp_msg_t* msg;
+
+    if (!bt_avrcp_conn) {
+        BT_LOGW("%s, bt_avrcp_conn not initialized", __func__);
+        return;
+    }
 
     avrcp_info = bt_list_find(bt_avrcp_conn, bt_avrcp_info_find_by_ct, ct);
     if (!avrcp_info) {
@@ -1038,6 +1048,11 @@ static void zblue_on_tg_connected(struct bt_conn* conn, struct bt_avrcp_tg* tg)
 {
     zblue_avrcp_info_t* avrcp_info;
 
+    if (!bt_avrcp_conn) {
+        BT_LOGW("%s, bt_avrcp_conn not initialized", __func__);
+        return;
+    }
+
     avrcp_info = bt_list_find(bt_avrcp_conn, bt_avrcp_info_find_by_conn, conn);
     if (!avrcp_info)
         avrcp_info = bt_avrcp_create_avrcp_info(conn);
@@ -1062,6 +1077,11 @@ static void zblue_on_tg_connected(struct bt_conn* conn, struct bt_avrcp_tg* tg)
 static void zblue_on_tg_disconnected(struct bt_avrcp_tg* tg)
 {
     zblue_avrcp_info_t* avrcp_info;
+
+    if (!bt_avrcp_conn) {
+        BT_LOGW("%s, bt_avrcp_conn not initialized", __func__);
+        return;
+    }
 
     avrcp_info = bt_list_find(bt_avrcp_conn, bt_avrcp_info_find_by_tg, tg);
     if (!avrcp_info) {
@@ -1426,6 +1446,11 @@ static bt_status_t bt_sal_avrcp_disconnect(bt_controller_id_t id, bt_address_t* 
 {
     zblue_avrcp_info_t* avrcp_info;
     int err;
+
+    if (!bt_avrcp_conn || !bd_addr) {
+        BT_LOGW("%s, invalid params", __func__);
+        return BT_STATUS_PARM_INVALID;
+    }
 
     avrcp_info = bt_list_find(bt_avrcp_conn, bt_avrcp_info_find_addr, bd_addr);
     if (!avrcp_info) {

--- a/service/stacks/zephyr/sal_connection_manager.c
+++ b/service/stacks/zephyr/sal_connection_manager.c
@@ -343,6 +343,12 @@ static void bt_sal_cm_acl_connected(void* data)
 
     cm_data = (cm_data_t*)data;
 
+    if (!bt_sal_connecting_list) {
+        BT_LOGW("%s, bt_sal_connecting_list is NULL", __func__);
+        cm_data_destory(cm_data);
+        return;
+    }
+
     manager = bt_list_find(bt_sal_connecting_list, bt_connection_manager_find, &cm_data->addr);
 
     if (manager != NULL) {

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -256,11 +256,17 @@ static inline bt_hfp_hf_connection_t* find_connection_by_context(struct bt_conn*
 
 static inline bt_hfp_hf_connection_t* find_connection_by_addr(bt_address_t* addr)
 {
+    if (!g_sal_hf_conn_list || !addr) {
+        return NULL;
+    }
     return (bt_hfp_hf_connection_t*)bt_list_find(g_sal_hf_conn_list, sal_conn_addr_cmp, addr);
 }
 
 static inline bt_hfp_hf_connection_t* find_connection_by_hf(struct bt_hfp_hf* hf)
 {
+    if (!g_sal_hf_conn_list || !hf) {
+        return NULL;
+    }
     return (bt_hfp_hf_connection_t*)bt_list_find(g_sal_hf_conn_list, sal_conn_hf_cmp, hf);
 }
 

--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -161,6 +161,10 @@ static sal_spp_connection_t* spp_find_connection_by_scn(const bt_address_t* addr
     sal_spp_connection_t* spp_conn;
     bt_list_node_t* node;
 
+    if (!spp_mgr->connections || !addr) {
+        return NULL;
+    }
+
     for (node = bt_list_head(spp_mgr->connections); node != NULL;
          node = bt_list_next(spp_mgr->connections, node)) {
         spp_conn = bt_list_node(node);
@@ -178,6 +182,10 @@ static sal_spp_connection_t* spp_find_connection_by_port(uint16_t conn_port)
     sal_spp_connection_t* spp_conn;
     bt_list_node_t* node;
 
+    if (!spp_mgr->connections) {
+        return NULL;
+    }
+
     for (node = bt_list_head(spp_mgr->connections); node != NULL;
          node = bt_list_next(spp_mgr->connections, node)) {
         spp_conn = bt_list_node(node);
@@ -194,6 +202,10 @@ static sal_spp_connection_t* spp_find_connection_by_dlc(struct bt_rfcomm_dlc* rf
     sal_spp_manager_t* spp_mgr = &g_spp_manager;
     sal_spp_connection_t* spp_conn;
     bt_list_node_t* node;
+
+    if (!spp_mgr->connections || !rfcomm_dlc) {
+        return NULL;
+    }
 
     for (node = bt_list_head(spp_mgr->connections); node != NULL;
          node = bt_list_next(spp_mgr->connections, node)) {
@@ -236,6 +248,10 @@ static sal_spp_connection_t* spp_find_connection_by_dlci(const bt_address_t* add
     sal_spp_connection_t* spp_conn;
     bt_list_node_t* node;
 
+    if (!spp_mgr->connections || !addr) {
+        return NULL;
+    }
+
     for (node = bt_list_head(spp_mgr->connections); node != NULL;
          node = bt_list_next(spp_mgr->connections, node)) {
         spp_conn = bt_list_node(node);
@@ -252,6 +268,10 @@ static sal_spp_server_t* spp_find_server_by_scn(uint16_t scn)
     sal_spp_manager_t* spp_mgr = &g_spp_manager;
     sal_spp_server_t* spp_server;
     bt_list_node_t* node;
+
+    if (!spp_mgr->servers) {
+        return NULL;
+    }
 
     for (node = bt_list_head(spp_mgr->servers); node != NULL;
          node = bt_list_next(spp_mgr->servers, node)) {


### PR DESCRIPTION
bug: v/83789

Add defensive NULL checks before bt_list_find/bt_list_head calls to prevent crashes when global connection lists are not initialized.

Files modified:
- sal_avrcp_interface.c: check bt_avrcp_conn
- sal_connection_manager.c: check bt_sal_connecting_list
- sal_hfp_hf_interface.c: check g_sal_hf_conn_list
- sal_spp_interface.c: check connections/servers lists

- rootcause: bt_list_find() contains assert(list) which crashes when the list parameter is NULL. This can happen if callbacks are invoked before the module is fully initialized or after cleanup.
