### PR TITLE
bluetooth/tools: fix Coverity defects in l2cap tool

### DIFF
--- a/tools/l2cap.c
+++ b/tools/l2cap.c
@@ -155,7 +155,7 @@ static bool bulk_buf_gen(uint8_t** buf, uint32_t length)
         return false;
     }
 
-    strncpy(bulk_buf->delimiter, "Vela", 4);
+    memcpy(bulk_buf->delimiter, "Vela", 4);
     bulk_buf->length = length;
     data_len = length - sizeof(struct bulk_buf_t);
     for (uint32_t i = 0; i < data_len; i++) {
@@ -752,7 +752,7 @@ static int speed_test_cmd(void* handle, int argc, char* argv[])
 
     msg->id = strtoul(argv[0], NULL, 10);
     msg->len = strtoul(argv[1], NULL, 10);
-    if (msg->id < 0 || msg->len <= 0) {
+    if (msg->len == 0) {
         PRINT("invalid param");
         free(msg);
         return CMD_ERROR;


### PR DESCRIPTION
## Summary

Fix two Coverity static analysis defects in `tools/l2cap.c`:

1. **CID: strncpy non-null terminated buffer** — `bulk_buf->delimiter` is a
   fixed 4-byte field (not a C string). Replace `strncpy` with `memcpy` to
   silence the "destination buffer may not be null-terminated" warning.

2. **CID: unsigned compared against 0** — `msg->len` is `uint16_t` (unsigned),
   so `msg->len <= 0` is equivalent to `msg->len == 0`. Changed to `== 0`
   to remove the dead "less-than" branch flagged by Coverity.

bug: v/87430

## Impact

No functional change. Both fixes are cosmetic / static-analysis-only:
- `memcpy` vs `strncpy` produces identical bytes for a 4-char copy into a 4-byte buffer.
- `== 0` vs `<= 0` on unsigned is logically identical.

No impact on build, ABI, or runtime behavior.

## Testing

- Build: `lunch` + `m` on target, clean build passes.
- Coverity: both CIDs resolved after the fix.
- Runtime: L2CAP tool speed test (connect + bulk transfer) verified on device, no regression.