### PR TITLE
cs: Fix CS functionality abnormal issue.

### DIFF
--- a/service/profiles/cs/cs_ras.c
+++ b/service/profiles/cs/cs_ras.c
@@ -323,7 +323,7 @@ bool ras_is_filter_bit_set(uint16_t mode, uint16_t filter_bit)
     }
 
     // Retrieve the current filter mask
-    uint32_t current_filter_mask = ras_srv->ras_filter[mode];
+    uint16_t current_filter_mask = ras_srv->ras_filter[mode];
 
     // Check if the specific filter bit is set
     // We shift the filter_bit into the correct position and mask it to check
@@ -335,16 +335,9 @@ static void ras_set_filter(uint16_t filter_value)
     // Extract the mode (bits 0-1)
     uint16_t mode = filter_value & CS_RAS_FILTER_MODE_MASK;
 
-    // Extract the filter mask (bits 2-15)
-    uint16_t filter_mask = filter_value & ~CS_RAS_FILTER_MODE_MASK;
-
     // Use the mode directly as an index into ras_filter
     if (mode < CS_RAS_FILTER_MODE_MAX) {
-        // Clear the filter bits (2-15)
-        ras_srv->ras_filter[mode] &= CS_RAS_FILTER_MODE_MASK;
-
-        // Set the new filter mask (bits 2-15)
-        ras_srv->ras_filter[mode] |= filter_mask;
+        ras_srv->ras_filter[mode] = filter_value;
     } else {
         // Handle error case if mode is out of range
         BT_LOGE("Error: Mode %d is out of valid range (0 to %d)", mode, CS_RAS_FILTER_MODE_MAX - 1);
@@ -814,7 +807,7 @@ static void cs_ras_split_on_demand_segment(bt_address_t* addr, uint8_t* buf, int
  */
 static size_t transform_step_data_to_ras_format_filtered(
     uint8_t* data, size_t data_len,
-    uint8_t* buf, uint32_t* ras_filter, uint8_t role,
+    uint8_t* buf, uint16_t* ras_filter, uint8_t role,
     uint8_t num_antenna_paths)
 {
     size_t in_offset = 0;
@@ -830,7 +823,7 @@ static size_t transform_step_data_to_ras_format_filtered(
         }
 
         uint8_t* step_data = &data[in_offset + 3];
-        uint32_t filter_mask = ras_filter[step_mode];
+        uint16_t filter = ras_filter[step_mode];
 
         // Write Step_Mode to the output
         buf[out_offset++] = step_mode;
@@ -858,14 +851,14 @@ static size_t transform_step_data_to_ras_format_filtered(
              ************************************************************/
         case CS_RAS_SUBEVENT_STEP_MODE_0:
             if (role == CS_RAS_ROLE_INITIATOR) {
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_QUALITY);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_RSSI);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_ANTENNA);
-                COPY_FIELD_IF_ENABLED(2, CS_RAS_FILTER_BIT_FREQ_OFFSET);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_0_FILTER_PACKET_QUALITY_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_0_FILTER_PACKET_RSSI_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_0_FILTER_PACKET_ANTENNA_BIT);
+                COPY_FIELD_IF_ENABLED(2, CS_RAS_MODE_0_FILTER_MEASURED_FREQ_OFFSET_BIT);
             } else { // Reflector
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_QUALITY);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_RSSI);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_ANTENNA);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_0_FILTER_PACKET_QUALITY_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_0_FILTER_PACKET_RSSI_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_0_FILTER_PACKET_ANTENNA_BIT);
             }
             break;
         /*  MODE 1 — Time-of-Flight (ToF) Mode
@@ -892,22 +885,22 @@ static size_t transform_step_data_to_ras_format_filtered(
          *
          **************************************************************/
         case CS_RAS_SUBEVENT_STEP_MODE_1:
-            if (role == CS_RAS_ROLE_REFLECTOR) {
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_QUALITY);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_NADM);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_RSSI);
-                COPY_FIELD_IF_ENABLED(2, CS_RAS_FILTER_BIT_TOA_TOD);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_ANTENNA);
-                COPY_FIELD_IF_ENABLED(4, CS_RAS_FILTER_BIT_PKT_PCT1);
-                COPY_FIELD_IF_ENABLED(4, CS_RAS_FILTER_BIT_PKT_PCT2);
+            if (role == CS_RAS_ROLE_INITIATOR) {
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_1_FILTER_PACKET_QUALITY_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_1_FILTER_PACKET_NADM_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_1_FILTER_PACKET_RSSI_BIT);
+                COPY_FIELD_IF_ENABLED(2, CS_RAS_MODE_1_FILTER_TOD_TOA_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_1_FILTER_PACKET_ANTENNA_BIT);
+                COPY_FIELD_IF_ENABLED(4, CS_RAS_MODE_1_FILTER_PACKET_PCT_1_BIT);
+                COPY_FIELD_IF_ENABLED(4, CS_RAS_MODE_1_FILTER_PACKET_PCT_2_BIT);
             } else { // Reflector
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_QUALITY);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_NADM);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_RSSI);
-                COPY_FIELD_IF_ENABLED(2, CS_RAS_FILTER_BIT_TOD_TOA);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_ANTENNA);
-                COPY_FIELD_IF_ENABLED(4, CS_RAS_FILTER_BIT_PKT_PCT1);
-                COPY_FIELD_IF_ENABLED(4, CS_RAS_FILTER_BIT_PKT_PCT2);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_1_FILTER_PACKET_QUALITY_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_1_FILTER_PACKET_NADM_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_1_FILTER_PACKET_RSSI_BIT);
+                COPY_FIELD_IF_ENABLED(2, CS_RAS_MODE_1_FILTER_TOD_TOA_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_1_FILTER_PACKET_ANTENNA_BIT);
+                COPY_FIELD_IF_ENABLED(4, CS_RAS_MODE_1_FILTER_PACKET_PCT_1_BIT);
+                COPY_FIELD_IF_ENABLED(4, CS_RAS_MODE_1_FILTER_PACKET_PCT_2_BIT);
             }
             break;
         /*****************************************************************
@@ -922,15 +915,12 @@ static size_t transform_step_data_to_ras_format_filtered(
          *******************************************************************/
         case CS_RAS_SUBEVENT_STEP_MODE_2:
             // Initiator and Reflector are the same.
-            COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_ANT_PERM_IDX);
+            COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_2_FILTER_ANTENNA_PERMUTATION_INDEX_BIT);
 
-            // Tone_PCT[k]
-            // Actual size = (Num_Antenna_Paths + 1) × 3 octets
-            // COPY_FIELD_IF_ENABLED((num_antenna_paths + 1) * 3, CS_RAS_FILTER_BIT_TONE_PCT);
-            COPY_FIELD_IF_ENABLED((num_antenna_paths + 1) * 3, CS_RAS_FILTER_BIT_TONE_PCT);
-            // Tone_Quality_Indicator[k]
-            // COPY_FIELD_IF_ENABLED((num_antenna_paths + 1) * 1, CS_RAS_FILTER_BIT_TONE_QUALITY);
-            COPY_FIELD_IF_ENABLED((num_antenna_paths + 1) * 1, CS_RAS_FILTER_BIT_TONE_QUALITY);
+            while (remaining > 0) {
+                COPY_FIELD_IF_ENABLED(3, CS_RAS_MODE_2_FILTER_TONE_PCT_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_2_FILTER_TONE_QUALITY_INDICATOR_BIT);
+            }
             break;
         /*  MODE 3 — Combined (ToF + Tone) Mode
          *  ------------------------------------------------------------
@@ -963,27 +953,31 @@ static size_t transform_step_data_to_ras_format_filtered(
          ********************************************************************/
         case CS_RAS_SUBEVENT_STEP_MODE_3:
             if (role == CS_RAS_ROLE_INITIATOR) {
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_QUALITY);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_NADM);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_RSSI);
-                COPY_FIELD_IF_ENABLED(2, CS_RAS_FILTER_BIT_TOA_TOD);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_ANTENNA);
-                COPY_FIELD_IF_ENABLED(4, CS_RAS_FILTER_BIT_PKT_PCT1);
-                COPY_FIELD_IF_ENABLED(4, CS_RAS_FILTER_BIT_PKT_PCT2);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_ANT_PERM_IDX);
-                COPY_FIELD_IF_ENABLED((num_antenna_paths + 1) * 3, CS_RAS_FILTER_BIT_TONE_PCT);
-                COPY_FIELD_IF_ENABLED((num_antenna_paths + 1) * 1, CS_RAS_FILTER_BIT_TONE_QUALITY);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_PACKET_QUALITY_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_PACKET_NADM_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_PACKET_RSSI_BIT);
+                COPY_FIELD_IF_ENABLED(2, CS_RAS_MODE_3_FILTER_TOD_TOA_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_PACKET_ANTENNA_BIT);
+                COPY_FIELD_IF_ENABLED(4, CS_RAS_MODE_3_FILTER_PACKET_PCT_1_BIT);
+                COPY_FIELD_IF_ENABLED(4, CS_RAS_MODE_3_FILTER_PACKET_PCT_2_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_ANTENNA_PERMUTATION_INDEX_BIT);
+                while (remaining > 0) {
+                    COPY_FIELD_IF_ENABLED(3, CS_RAS_MODE_3_FILTER_TONE_PCT_BIT);
+                    COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_TONE_QUALITY_INDICATOR_BIT);
+                }
             } else { // Reflector
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_QUALITY);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_NADM);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_RSSI);
-                COPY_FIELD_IF_ENABLED(2, CS_RAS_FILTER_BIT_TOD_TOA);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_PKT_ANTENNA);
-                COPY_FIELD_IF_ENABLED(4, CS_RAS_FILTER_BIT_PKT_PCT1);
-                COPY_FIELD_IF_ENABLED(4, CS_RAS_FILTER_BIT_PKT_PCT2);
-                COPY_FIELD_IF_ENABLED(1, CS_RAS_FILTER_BIT_ANT_PERM_IDX);
-                COPY_FIELD_IF_ENABLED((num_antenna_paths + 1) * 3, CS_RAS_FILTER_BIT_TONE_PCT);
-                COPY_FIELD_IF_ENABLED((num_antenna_paths + 1) * 1, CS_RAS_FILTER_BIT_TONE_QUALITY);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_PACKET_QUALITY_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_PACKET_NADM_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_PACKET_RSSI_BIT);
+                COPY_FIELD_IF_ENABLED(2, CS_RAS_MODE_3_FILTER_TOD_TOA_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_PACKET_ANTENNA_BIT);
+                COPY_FIELD_IF_ENABLED(4, CS_RAS_MODE_3_FILTER_PACKET_PCT_1_BIT);
+                COPY_FIELD_IF_ENABLED(4, CS_RAS_MODE_3_FILTER_PACKET_PCT_2_BIT);
+                COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_ANTENNA_PERMUTATION_INDEX_BIT);
+                while (remaining > 0) {
+                    COPY_FIELD_IF_ENABLED(3, CS_RAS_MODE_3_FILTER_TONE_PCT_BIT);
+                    COPY_FIELD_IF_ENABLED(1, CS_RAS_MODE_3_FILTER_TONE_QUALITY_INDICATOR_BIT);
+                }
             }
             break;
         default:
@@ -1063,22 +1057,12 @@ static uint8_t* ras_subevent_data_conversion(bt_address_t* addr, bt_srv_conn_le_
 {
     memset(ras_srv->latest_local_steps, 0, sizeof(ras_srv->latest_local_steps));
 
-    if (result->len <= CS_RAS_STEP_DATA_BUF_LEN) {
-        memcpy(ras_srv->latest_local_steps, result->step_data_buf,
-            result->len);
-        BT_LOGD("step data[%d]", result->len);
-        BT_DUMPBUFFER("step data", result->step_data_buf, result->len);
-    } else {
-        BT_LOGD("Not enough memory to store step data. (%d > %d)",
-            result->len, CS_RAS_STEP_DATA_BUF_LEN);
-    }
-
     uint8_t* stream_buf = ras_srv->latest_local_steps;
     int bit_offset = 0;
 
     /**
-     * Rangging Counter.
-     * Rangging Counter is lower 12-bits of CS Procedure_Counter Provided by the Core Controller.
+     * Ranging Counter.
+     * Ranging Counter is lower 12-bits of CS Procedure_Counter Provided by the Core Controller.
      */
     ras_write_bits(stream_buf, &bit_offset, result->header.procedure_counter, 12);
 
@@ -1096,14 +1080,23 @@ static uint8_t* ras_subevent_data_conversion(bt_address_t* addr, bt_srv_conn_le_
      */
     ras_write_bits(stream_buf, &bit_offset, result->header.reference_power_level, 8);
     /**
-     * Antenna paths that are reported:
+     * Antenna Paths Mask (8 bits)
      * Bit0: 1 if Antenna Path_1 included; 0 if not.
      * Bit1: 1 if Antenna Path_2 included; 0 if not.
      * Bit2: 1 if Antenna Path_3 included; 0 if not.
      * Bit3: 1 if Antenna Path_4 included; 0 if not.
      * Bits 4-7: RFU
+     *
+     * Note: HCI provides num_antenna_paths as a count (1-4) of antenna paths used.
+     * The RAS Antenna_Paths_Mask sets bits 0..(N-1) for N antenna paths.
+     * Example: num_antenna_paths=4 means paths 1-4 used, mask=0x0F (bits 0-3)
      */
-    ras_write_bits(stream_buf, &bit_offset, result->header.num_antenna_paths, 8);
+    uint8_t antenna_paths_mask = 0;
+    if (result->header.num_antenna_paths >= 1 && result->header.num_antenna_paths <= 4) {
+        // Convert count to bitmask: count=1->0x01, count=2->0x03, count=3->0x07, count=4->0x0F
+        antenna_paths_mask = (1 << result->header.num_antenna_paths) - 1;
+    }
+    ras_write_bits(stream_buf, &bit_offset, antenna_paths_mask, 8);
     /**
      * Starting ACL addrection event count for the results reported in the event.
      */
@@ -1162,7 +1155,7 @@ static uint8_t* ras_subevent_data_conversion(bt_address_t* addr, bt_srv_conn_le_
     ras_srv->ras_seg_offset = 0;
     ras_srv->remaining_len = transform_step_data_to_ras_format_filtered(result->step_data_buf,
         result->len, stream_buf + CS_RAS_SUB_PROCUDURE_HEAD,
-        ras_srv->ras_filter, ras_srv->ras_role, result->header.num_antenna_paths & 0x0F);
+        ras_srv->ras_filter, ras_srv->ras_role, result->header.num_antenna_paths);
     ras_srv->remaining_len += CS_RAS_SUB_PROCUDURE_HEAD;
     ras_subevent_debug_info_print(result, stream_buf);
     return stream_buf;
@@ -1211,7 +1204,7 @@ static void cs_ras_process_on_demand_ranging_data(bt_address_t* addr, bt_srv_con
 
 static void cs_ras_subevent_result_cb(bt_address_t* addr, bt_srv_conn_le_cs_subevent_result_t* result)
 {
-    if (result->header.procedure_done_status == BT_LE_SRV_CS_PROCEDURE_COMPLETE && ras_check_ranging_mode(addr) == CS_RAS_RANGING_MODE_REAL_TIME) {
+    if (result->header.subevent_done_status == BT_LE_SRV_CS_SUBEVENT_COMPLETE && ras_check_ranging_mode(addr) == CS_RAS_RANGING_MODE_REAL_TIME) {
         BT_LOGD("Recv the real-time ranging data.");
         cs_ras_process_real_time_ranging_data(addr, result);
         return;
@@ -1453,7 +1446,7 @@ int bt_cs_ras_enable(void)
     ras_srv->ras_feature = 0x07000007;
 
     for (int i = 0; i < CS_RAS_FILTER_MODE_MAX; i++) {
-        ras_srv->ras_filter[i] = 0xFFFFFFFF;
+        ras_srv->ras_filter[i] = 0xFFFF; // All 16 bits set to 1 (all fields enabled)
     }
 
     bt_cs_ras_gatts_init(&ras_cb);

--- a/service/profiles/include/cs_ras.h
+++ b/service/profiles/include/cs_ras.h
@@ -366,16 +366,16 @@ typedef uint8_t ras_rang_mode_t;
  * @brief Copy a field to the output buffer if the corresponding filter bit is enabled.
  *
  * This macro conditionally copies a field of data from a source pointer `p`
- * to an output buffer `buf` depending on the `filter_mask`. It also updates
+ * to an output buffer `buf` depending on the `filter`. It also updates
  * offsets and tracks remaining bytes.
  *
  * @param _size        Size of the field in bytes.
- * @param _filter_bit  Bitmask corresponding to the field in the filter_mask.
+ * @param _filter_bit  Bitmask corresponding to the field in the filter.
  *
  * @details
  * - The field is only copied if:
  *   1. There are enough bytes remaining (`remaining >= _size`), and
- *   2. The corresponding bit in `filter_mask` is set (`filter_mask & _filter_bit`).
+ *   2. The corresponding bit in `filter` is set (`filter & _filter_bit`).
  * - After copying, the output offset (`out_offset`) is incremented by `_size`.
  * - Regardless of copying, the source pointer `p` is advanced by `_size`,
  *   and `remaining` bytes are decreased by `_size`.
@@ -388,7 +388,7 @@ typedef uint8_t ras_rang_mode_t;
 #define COPY_FIELD_IF_ENABLED(_size, _filter_bit)              \
     do {                                                       \
         if (remaining >= (_size)) {                            \
-            if (filter_mask & (_filter_bit)) {                 \
+            if (filter & (_filter_bit)) {                 \
                 memcpy(&buf[out_offset], p, (_size));          \
                 out_offset += (_size);                         \
             }                                                  \
@@ -486,46 +486,6 @@ enum {
     CS_RAS_IDX_MAX
 };
 
-/*******************************************************************************************
- *
- *  FILTER BIT MAPPING TABLE
- *  ------------------------------------------------------------
- *  Each field can be individually filtered out using the
- *  uint32_t ras_filter[CS_RAS_FILTER_MODE_MAX] bitmask.
- *
- *  +----------------------------+-------------------------------+
- *  | Field Name                 | Bit Definition                |
- *  +----------------------------+-------------------------------+
- *  | Packet_Quality             | CS_RAS_FILTER_BIT_PKT_QUALITY     (BIT(0))  |
- *  | Packet_NADM                | CS_RAS_FILTER_BIT_PKT_NADM        (BIT(1))  |
- *  | Packet_RSSI                | CS_RAS_FILTER_BIT_PKT_RSSI        (BIT(2))  |
- *  | Packet_Antenna             | CS_RAS_FILTER_BIT_PKT_ANTENNA     (BIT(3))  |
- *  | Packet_PCT1                | CS_RAS_FILTER_BIT_PKT_PCT1        (BIT(4))  |
- *  | Packet_PCT2                | CS_RAS_FILTER_BIT_PKT_PCT2        (BIT(5))  |
- *  | Measured_Freq_Offset       | CS_RAS_FILTER_BIT_FREQ_OFFSET     (BIT(6))  |
- *  | ToA_ToD_Initiator          | CS_RAS_FILTER_BIT_TOA_TOD         (BIT(7))  |
- *  | ToD_ToA_Reflector          | CS_RAS_FILTER_BIT_TOD_TOA         (BIT(8))  |
- *  | Antenna_Permutation_Index  | CS_RAS_FILTER_BIT_ANT_PERM_IDX    (BIT(9))  |
- *  | Tone_PCT[k]                | CS_RAS_FILTER_BIT_TONE_PCT        (BIT(10)) |
- *  | Tone_Quality_Indicator[k]  | CS_RAS_FILTER_BIT_TONE_QUALITY    (BIT(11)) |
- *  +----------------------------+-------------------------------+
- *
- *******************************************************************************************/
-typedef enum {
-    CS_RAS_FILTER_BIT_PKT_QUALITY = BIT(0),
-    CS_RAS_FILTER_BIT_PKT_NADM = BIT(1),
-    CS_RAS_FILTER_BIT_PKT_RSSI = BIT(2),
-    CS_RAS_FILTER_BIT_PKT_ANTENNA = BIT(3),
-    CS_RAS_FILTER_BIT_PKT_PCT1 = BIT(4),
-    CS_RAS_FILTER_BIT_PKT_PCT2 = BIT(5),
-    CS_RAS_FILTER_BIT_FREQ_OFFSET = BIT(6),
-    CS_RAS_FILTER_BIT_TOA_TOD = BIT(7),
-    CS_RAS_FILTER_BIT_TOD_TOA = BIT(8),
-    CS_RAS_FILTER_BIT_ANT_PERM_IDX = BIT(9),
-    CS_RAS_FILTER_BIT_TONE_PCT = BIT(10),
-    CS_RAS_FILTER_BIT_TONE_QUALITY = BIT(11),
-} ras_filter_bits_t;
-
 /**
  * @brief RAS Mode 0 Filter Bit Definitions.
  *
@@ -533,13 +493,10 @@ typedef enum {
  * Each bit indicates whether a particular type of packet or measurement data
  * should be included in the Ranging Service procedure.
  */
-enum {
-    CS_RAS_MODE_0_FILTER_PACKET_QUALITY,
-    CS_RAS_MODE_0_FILTER_PACKET_RSSI,
-    CS_RAS_MODE_0_FILTER_PACKET_ANTENNA,
-    CS_RAS_MODE_0_FILTER_MEASURED_FREQ_OFFSET,
-    CS_RAS_MODE_0_FILTER_MAX,
-};
+#define CS_RAS_MODE_0_FILTER_PACKET_QUALITY_BIT BIT(2)
+#define CS_RAS_MODE_0_FILTER_PACKET_RSSI_BIT BIT(3)
+#define CS_RAS_MODE_0_FILTER_PACKET_ANTENNA_BIT BIT(4)
+#define CS_RAS_MODE_0_FILTER_MEASURED_FREQ_OFFSET_BIT BIT(5)
 
 /**
  * @brief RAS Mode 1 Filter Bit Definitions.
@@ -547,16 +504,13 @@ enum {
  * Filter bit positions for RAS Mode 1, specifying which packet or measurement
  * fields are included in the Ranging Service procedure.
  */
-enum {
-    CS_RAS_MODE_1_FILTER_PACKET_QUALITY,
-    CS_RAS_MODE_1_FILTER_PACKET_NADM,
-    CS_RAS_MODE_1_FILTER_PACKET_RSSI,
-    CS_RAS_MODE_1_FILTER_TOD_TOA,
-    CS_RAS_MODE_1_FILTER_PACKET_ANTENNA,
-    CS_RAS_MODE_1_FILTER_PACKET_PCT_1,
-    CS_RAS_MODE_1_FILTER_PACKET_PCT_2,
-    CS_RAS_MODE_1_FILTER_MAX,
-};
+#define CS_RAS_MODE_1_FILTER_PACKET_QUALITY_BIT BIT(2)
+#define CS_RAS_MODE_1_FILTER_PACKET_NADM_BIT BIT(3)
+#define CS_RAS_MODE_1_FILTER_PACKET_RSSI_BIT BIT(4)
+#define CS_RAS_MODE_1_FILTER_TOD_TOA_BIT BIT(5)
+#define CS_RAS_MODE_1_FILTER_PACKET_ANTENNA_BIT BIT(6)
+#define CS_RAS_MODE_1_FILTER_PACKET_PCT_1_BIT BIT(7)
+#define CS_RAS_MODE_1_FILTER_PACKET_PCT_2_BIT BIT(8)
 
 /**
  * @brief RAS Mode 2 Filter Bit Definitions.
@@ -564,16 +518,13 @@ enum {
  * Filter bit positions for RAS Mode 2, primarily used for antenna permutation
  * and tone analysis in the Ranging Service procedure.
  */
-enum {
-    CS_RAS_MODE_2_FILTER_ANTENNA_PERMUTATION_INDEX,
-    CS_RAS_MODE_2_FILTER_TONE_PCT,
-    CS_RAS_MODE_2_FILTER_TONE_QUALITY_INDICATOR,
-    CS_RAS_MODE_2_FILTER_ANTENNA_PATH_1,
-    CS_RAS_MODE_2_FILTER_ANTENNA_PATH_2,
-    CS_RAS_MODE_2_FILTER_ANTENNA_PATH_3,
-    CS_RAS_MODE_2_FILTER_ANTENNA_PATH_4,
-    CS_RAS_MODE_2_FILTER_MAX,
-};
+#define CS_RAS_MODE_2_FILTER_ANTENNA_PERMUTATION_INDEX_BIT BIT(2)
+#define CS_RAS_MODE_2_FILTER_TONE_PCT_BIT BIT(3)
+#define CS_RAS_MODE_2_FILTER_TONE_QUALITY_INDICATOR_BIT BIT(4)
+#define CS_RAS_MODE_2_FILTER_ANTENNA_PATH_1_BIT BIT(5)
+#define CS_RAS_MODE_2_FILTER_ANTENNA_PATH_2_BIT BIT(6)
+#define CS_RAS_MODE_2_FILTER_ANTENNA_PATH_3_BIT BIT(7)
+#define CS_RAS_MODE_2_FILTER_ANTENNA_PATH_4_BIT BIT(8)
 
 /**
  * @brief RAS Mode 3 Filter Bit Definitions.
@@ -581,23 +532,20 @@ enum {
  * Filter bit positions for RAS Mode 3. Combines Mode 1 and Mode 2 filters
  * to enable comprehensive packet and antenna/tone analysis.
  */
-enum {
-    CS_RAS_MODE_3_FILTER_PACKET_QUALITY,
-    CS_RAS_MODE_3_FILTER_PACKET_NADM,
-    CS_RAS_MODE_3_FILTER_PACKET_RSSI,
-    CS_RAS_MODE_3_FILTER_TOD_TOA,
-    CS_RAS_MODE_3_FILTER_PACKET_ANTENNA,
-    CS_RAS_MODE_3_FILTER_PACKET_PCT_1,
-    CS_RAS_MODE_3_FILTER_PACKET_PCT_2,
-    CS_RAS_MODE_3_FILTER_ANTENNA_PERMUTATION_INDEX,
-    CS_RAS_MODE_3_FILTER_TONE_PCT,
-    CS_RAS_MODE_3_FILTER_TONE_QUALITY_INDICATOR,
-    CS_RAS_MODE_3_FILTER_ANTENNA_PATH_1,
-    CS_RAS_MODE_3_FILTER_ANTENNA_PATH_2,
-    CS_RAS_MODE_3_FILTER_ANTENNA_PATH_3,
-    CS_RAS_MODE_3_FILTER_ANTENNA_PATH_4,
-    CS_RAS_MODE_3_FILTER_MAX,
-};
+#define CS_RAS_MODE_3_FILTER_PACKET_QUALITY_BIT BIT(2)
+#define CS_RAS_MODE_3_FILTER_PACKET_NADM_BIT BIT(3)
+#define CS_RAS_MODE_3_FILTER_PACKET_RSSI_BIT BIT(4)
+#define CS_RAS_MODE_3_FILTER_TOD_TOA_BIT BIT(5)
+#define CS_RAS_MODE_3_FILTER_PACKET_ANTENNA_BIT BIT(6)
+#define CS_RAS_MODE_3_FILTER_PACKET_PCT_1_BIT BIT(7)
+#define CS_RAS_MODE_3_FILTER_PACKET_PCT_2_BIT BIT(8)
+#define CS_RAS_MODE_3_FILTER_ANTENNA_PERMUTATION_INDEX_BIT BIT(9)
+#define CS_RAS_MODE_3_FILTER_TONE_PCT_BIT BIT(10)
+#define CS_RAS_MODE_3_FILTER_TONE_QUALITY_INDICATOR_BIT BIT(11)
+#define CS_RAS_MODE_3_FILTER_ANTENNA_PATH_1_BIT BIT(12)
+#define CS_RAS_MODE_3_FILTER_ANTENNA_PATH_2_BIT BIT(13)
+#define CS_RAS_MODE_3_FILTER_ANTENNA_PATH_3_BIT BIT(14)
+#define CS_RAS_MODE_3_FILTER_ANTENNA_PATH_4_BIT BIT(15)
 
 enum {
     CS_RAS_ON_DEMAND_STATE_IDLE = 1,
@@ -670,7 +618,7 @@ typedef struct {
     uint8_t ras_seg_idx; /**< Index of the current Ranging Data segment. */
     uint32_t ras_feature; /**< Bitfield indicating RAS feature support. */
     uint32_t char_notify_state; /**< Bitfield tracking characteristic notification/indication state. */
-    uint32_t ras_filter[CS_RAS_FILTER_MODE_MAX]; /**< Filter settings per RAS mode (0-3). */
+    uint16_t ras_filter[CS_RAS_FILTER_MODE_MAX]; /**< Filter settings per RAS mode (0-3), 16-bit per mode. Bits [1:0] = mode, Bits [15:2] = filter bit mask. */
     uint32_t on_demand_state; /**< Current state of the On-demand RAS procedure. */
     ras_rang_on_demand_t subevent[CS_RAS_STORE_PROCEDURE_NUM_MAX]; /**< Array of On-demand procedure slots. */
     ras_control_point_t control_point; /**< Control Point status for current operation. */


### PR DESCRIPTION
bug: v/87852

This change fixes multiple issues in the Bluetooth CS (Channel Sounding) RAS (Ranging Service) data conversion and transmission:

Filter type overflow: Changed ras_filter from uint32_t to uint16_t to match the RAS spec (16-bit filter mask per mode), and updated the initial value from 0xFFFFFFFF to 0xFFFF.

Filter enum start value: All mode filter bit enums (MODE_0/1/2/3) now start at 2 instead of 0, aligning with the actual bit definitions in the RAS specification.

MODE 1 role condition inverted: In CS_RAS_SUBEVENT_STEP_MODE_1, the Initiator and Reflector role branches were swapped (Reflector was incorrectly executing the Initiator path).

Missing antenna_paths semantic conversion: HCI reports num_antenna_paths as a count (1-4), but RAS requires a bitmask. Added count-to-bitmask conversion (e.g., count=4 → 0x0F).

MODE 2/3 Tone data parsing: Changed Tone_PCT and Tone_Quality_Indicator from bulk copy using (num_antenna_paths+1) to per-tone iteration via while(remaining > 0), matching the RAS spec's per-tone filtering semantics.

Real-time data trigger condition: Changed the condition in cs_ras_subevent_result_cb from procedure_done_status to subevent_done_status, since real-time mode should trigger on each subevent completion, not the entire procedure.

