### PR TITLE
Fix LE own address and unknown address type for legacy compatibility

### DIFF
--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -188,7 +188,7 @@ static uint8_t zblue_convert_addr_type(ble_addr_type_t addr_type)
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);
@@ -1907,7 +1907,7 @@ bt_status_t bt_sal_le_connect(bt_controller_id_t id, bt_address_t* addr, ble_add
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -1886,7 +1886,7 @@ bt_status_t bt_sal_le_connect(bt_controller_id_t id, bt_address_t* addr, ble_add
     req->adpt.conn_param.conn.latency = params->connection_latency;
     req->adpt.conn_param.conn.timeout = params->supervision_timeout;
 
-    req->adpt.conn_param.create.options = BT_CONN_LE_OPT_NONE;
+    req->adpt.conn_param.create.options = BT_CONN_LE_OPT_USE_IDENTITY_ADDR;
     req->adpt.conn_param.create.interval = params->scan_interval;
     req->adpt.conn_param.create.window = params->scan_window;
 

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -313,7 +313,7 @@ static void STACK_CALL(conn_connect)(void* args)
     address.type = req->addr_type;
     memcpy(&address.a, &req->addr, sizeof(address.a));
 
-    err = bt_conn_le_create(&address, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT, &conn);
+    err = bt_conn_le_create(&address, BT_CONN_LE_CREATE_CONN_IDENTITY, BT_LE_CONN_PARAM_DEFAULT, &conn);
     if (err) {
         bt_conn_remove(&req->addr, BT_TRANSPORT_BLE);
         BT_LOGE("%s, failed to create connection (%d)", __func__, err);

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -349,7 +349,7 @@ bt_status_t bt_sal_gatt_client_connect(bt_controller_id_t id, bt_address_t* addr
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -1373,7 +1373,7 @@ bt_status_t bt_sal_gatt_server_connect_bear(bt_controller_id_t id, bt_address_t*
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);
@@ -1414,7 +1414,7 @@ bt_status_t bt_sal_gatt_server_connect(bt_controller_id_t id, bt_address_t* addr
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);


### PR DESCRIPTION
depends-on: [open-vela/external_zblue/pull/200]

Description:

This PR fixes two address-related issues in the Zephyr SAL layer to maintain compatibility with legacy stack behavior:

1. Default own address to identity for LE connections
   - Use BT_CONN_LE_OPT_USE_IDENTITY_ADDR for LE connection creation, ensuring the initiator own address is the actual 
identity address (public or random static) instead of an RPA. This matches the legacy behavior where the own address was 
always the identity address.

2. Map unknown address type to public
   - Change BT_LE_ADDR_TYPE_UNKNOWN mapping from BT_ADDR_LE_RANDOM to BT_ADDR_LE_PUBLIC across all SAL files, aligning 
with the legacy stack default.

Files changed: sal_adapter_le_interface.c, sal_gatt_client_interface.c, sal_gatt_server_interface.c

Depends on: [zblue PR] (adds BT_CONN_LE_OPT_USE_IDENTITY_ADDR option and BT_CONN_LE_CREATE_CONN_IDENTITY macro)