### PR TITLE
bluetooth/spp: implement bt_sal_spp_connect_with_option for SPP client connect

### DIFF
--- a/service/stacks/zephyr/sal_spp_interface.c
+++ b/service/stacks/zephyr/sal_spp_interface.c
@@ -1104,5 +1104,10 @@ bt_status_t bt_sal_spp_connect_request_reply(bt_address_t* addr, uint16_t port, 
 
 bt_status_t bt_sal_spp_connect_with_option(bt_address_t* addr, uint16_t conn_port, bt_uuid_t* uuid128, uint8_t insecure)
 {
-    return BT_STATUS_UNSUPPORTED;
+    if (insecure) {
+        BT_LOGW("%s: insecure connection not supported yet", __func__);
+        return BT_STATUS_UNSUPPORTED;
+    }
+
+    return bt_sal_spp_connect(addr, conn_port, uuid128);
 }


### PR DESCRIPTION
## Summary
Implement bt_sal_spp_connect_with_option for SPP client connection support.

Previously this function returned BT_STATUS_UNSUPPORTED directly, causing SPP client connect to fail.

Now for non-insecure mode, it calls bt_sal_spp_connect to establish connection. Insecure mode is not yet supported and still returns BT_STATUS_UNSUPPORTED.

## Impact
- Enables SPP client connection functionality via bttool `spp connect` command
- No breaking changes

## Testing
- Tested on device with bttool
- Command: `spp connect <bd_addr> <port> <uuid>`