### PR TITLE
Map unknown address type to public for legacy compatibility

### DIFF
--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -188,7 +188,7 @@ static uint8_t zblue_convert_addr_type(ble_addr_type_t addr_type)
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);
@@ -1907,7 +1907,7 @@ bt_status_t bt_sal_le_connect(bt_controller_id_t id, bt_address_t* addr, ble_add
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);

--- a/service/stacks/zephyr/sal_gatt_client_interface.c
+++ b/service/stacks/zephyr/sal_gatt_client_interface.c
@@ -349,7 +349,7 @@ bt_status_t bt_sal_gatt_client_connect(bt_controller_id_t id, bt_address_t* addr
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -1373,7 +1373,7 @@ bt_status_t bt_sal_gatt_server_connect_bear(bt_controller_id_t id, bt_address_t*
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);
@@ -1414,7 +1414,7 @@ bt_status_t bt_sal_gatt_server_connect(bt_controller_id_t id, bt_address_t* addr
         type = BT_ADDR_LE_ANONYMOUS;
         break;
     case BT_LE_ADDR_TYPE_UNKNOWN:
-        type = BT_ADDR_LE_RANDOM;
+        type = BT_ADDR_LE_PUBLIC;
         break;
     default:
         BT_LOGE("%s, invalid type:%d", __func__, addr_type);


### PR DESCRIPTION
bug: v/87917

Map BT_LE_ADDR_TYPE_UNKNOWN to BT_ADDR_LE_PUBLIC instead of BT_ADDR_LE_RANDOM to maintain compatibility with legacy stack behavior where the default address type was public.
