### PR TITLE
gattc: add null check for value in element read callback

### DIFF
--- a/service/profiles/gatt/gattc_service.c
+++ b/service/profiles/gatt/gattc_service.c
@@ -869,7 +869,8 @@ void if_gattc_on_element_read(bt_address_t* addr, uint16_t element_id, uint8_t* 
     msg->param.read.status = status;
     msg->param.read.element_id = element_id;
     msg->param.read.length = length;
-    memcpy(msg->param.read.value, value, length);
+    if (value && length > 0)
+        memcpy(msg->param.read.value, value, length);
     gattc_send_message(msg);
 }
 


### PR DESCRIPTION
## Summary
Add null pointer and length check before memcpy in if_gattc_on_element_read to prevent crash when stack reports a read result with null value pointer.

## Impact
Prevents potential null pointer dereference crash in GATT client element read callback path. No API changes.

## Testing
Code review and static analysis. The fix adds a defensive null/length check before memcpy.