### PR TITLE
HFP: Keep ACL link active during SCO connection

### DIFF
--- a/service/profiles/hfp_ag/hfp_ag_state_machine.c
+++ b/service/profiles/hfp_ag/hfp_ag_state_machine.c
@@ -1212,8 +1212,8 @@ static void audio_on_exit(state_machine_t* sm)
 
     AG_DBG_EXIT(sm, &agsm->addr);
 
-    bt_pm_busy(PROFILE_HFP_AG, &agsm->addr);
     bt_pm_sco_close(PROFILE_HFP_AG, &agsm->addr);
+    bt_pm_idle(PROFILE_HFP_AG, &agsm->addr);
     /* set sco device unavaliable */
     bt_media_set_sco_unavailable();
 

--- a/service/profiles/hfp_hf/hfp_hf_state_machine.c
+++ b/service/profiles/hfp_hf/hfp_hf_state_machine.c
@@ -1427,8 +1427,8 @@ static void audio_on_exit(state_machine_t* sm)
 
     HF_DBG_EXIT(sm, &hfsm->addr);
 
-    bt_pm_busy(PROFILE_HFP_HF, &hfsm->addr);
     bt_pm_sco_close(PROFILE_HFP_HF, &hfsm->addr);
+    bt_pm_idle(PROFILE_HFP_HF, &hfsm->addr);
 
     /* TODO: set sco unavailable */
     bt_media_set_sco_unavailable();

--- a/service/src/power_manager.c
+++ b/service/src/power_manager.c
@@ -226,7 +226,7 @@ static const bt_pm_spec_table_t g_pm_spec[] = {
             { BT_PM_NO_PREF, 0 }, /* conn close  */
             { BT_PM_NO_ACTION, 0 }, /* app open */
             { BT_PM_NO_ACTION, 0 }, /* app close */
-            { BT_PM_SNIFF3, 7000 }, /* sco open */
+            { BT_PM_ACTIVE, 0 }, /* sco open */
             { BT_PM_SNIFF, 7000 }, /* sco close */
             { BT_PM_SNIFF, 7000 }, /* idle */
             { BT_PM_ACTIVE, 0 } /* busy */


### PR DESCRIPTION
bug: v/87639

Keep the ACL link in active mode during SCO connection to reduce control latency for HFP commands such as call termination.

Also fix audio_on_exit to call bt_pm_idle instead of bt_pm_busy, ensuring consistent idle state when SCO is not established.