### PR TITLE
Fix A2DP crash issue

### DIFF
--- a/service/profiles/a2dp/a2dp_device.c
+++ b/service/profiles/a2dp/a2dp_device.c
@@ -63,7 +63,7 @@ a2dp_device_t* a2dp_device_new(void* ctx, uint8_t peer_sep, bt_address_t* bd_add
     a2dp_device_t* device;
     a2dp_state_machine_t* a2dp_sm;
 
-    device = (a2dp_device_t*)malloc(sizeof(a2dp_device_t));
+    device = (a2dp_device_t*)zalloc(sizeof(a2dp_device_t));
     if (!device)
         return NULL;
 

--- a/service/stacks/zephyr/sal_a2dp_interface.c
+++ b/service/stacks/zephyr/sal_a2dp_interface.c
@@ -1898,6 +1898,13 @@ bt_status_t bt_sal_a2dp_source_send_data(bt_controller_id_t id, bt_address_t* re
         return BT_STATUS_NOMEM;
     }
 
+    if (nbytes > net_buf_tailroom(media_packet_buf)) {
+        BT_LOGE("%s, nbytes(%u) exceeds tailroom(%zu)", __func__,
+            nbytes, net_buf_tailroom(media_packet_buf));
+        net_buf_unref(media_packet_buf);
+        return BT_STATUS_PARM_INVALID;
+    }
+
     // buf = Media Packet Header(AVDTP_RTP_HEADER_LEN) + Media Payload
     // nbytes = Media Payload Length
     net_buf_add_mem(media_packet_buf, &buf[AVDTP_RTP_HEADER_LEN], nbytes);


### PR DESCRIPTION
bug: v/87941

bt_sal_a2dp_source_send_data calls net_buf_add_mem(media_packet_buf, &buf[AVDTP_RTP_HEADER_LEN], nbytes) without validating whether nbytes exceeds the available space in media_packet_buf. The buffer is allocated from bt_a2dp_tx_pool with a data size of CONFIG_ZBLUE_A2DP_SOURCE_BUF_SIZE (default 660 bytes). After bt_a2dp_stream_create_pdu reserves protocol headers (STREAM_DATA_RESERVED, i.e. AVDTP_RTP_HEADER_LEN = 12 bytes), the actual usable payload space is CONFIG_ZBLUE_A2DP_SOURCE_BUF_SIZE - STREAM_DATA_RESERVED (648 bytes). Zephyr's net_buf_add_mem only has an __ASSERT_NO_MSG check which is stripped in release builds. If nbytes exceeds the tailroom, a buffer overflow occurs, corrupting adjacent memory and potentially causing hard faults or data corruption.

Fix: Add a length check before buffer allocation using CONFIG_ZBLUE_A2DP_SOURCE_BUF_SIZE - STREAM_DATA_RESERVED as the maximum payload limit. When nbytes exceeds this limit, log an error and return BT_STATUS_PARM_INVALID, avoiding unnecessary buffer allocation and out-of-bounds writes.

