### PR TITLE
sal/hfp: move set_volume to service loop work

### DIFF
--- a/service/stacks/zephyr/sal_hfp_ag_interface.c
+++ b/service/stacks/zephyr/sal_hfp_ag_interface.c
@@ -31,6 +31,7 @@
 
 #include <errno.h>
 #include <inttypes.h>
+#include <pthread.h>
 #include <string.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/classic/at.h>
@@ -44,11 +45,23 @@
 #define HFP_AG_INDICATOR_INVALID UINT8_MAX
 
 static bt_list_t* g_sal_ag_conn_list = NULL;
+static pthread_mutex_t g_sal_ag_conn_lock;
+
+static void conn_list_lock(void)
+{
+    pthread_mutex_lock(&g_sal_ag_conn_lock);
+}
+
+static void conn_list_unlock(void)
+{
+    pthread_mutex_unlock(&g_sal_ag_conn_lock);
+}
 
 extern struct net_buf_pool sdp_pool;
 
 static uint8_t zblue_on_sdp_done(struct bt_conn* conn, struct bt_sdp_client_result* result, const struct bt_sdp_discover_params* ignore);
 static void zblue_on_sdp_disconnected(struct bt_conn* conn, const struct bt_sdp_discover_params* params);
+static enum bt_at_cme hfp_at_result_to_cme(hfp_atcmd_result_t result);
 
 static struct bt_sdp_discover_params sdp_discover = {
     .func = zblue_on_sdp_done,
@@ -300,10 +313,13 @@ static bool sal_call_number_cmp(void* sal_context, void* data)
 static bt_hfp_ag_call_info_t* find_call_by_context(struct bt_hfp_ag_call* z_context,
     bt_hfp_ag_connection_t** sal_conn_out)
 {
-    if (!g_sal_ag_conn_list || !z_context) {
+    if (!z_context) {
         return NULL;
     }
 
+    if (!g_sal_ag_conn_list) {
+        return NULL;
+    }
     bt_list_node_t* node;
     for (node = bt_list_head(g_sal_ag_conn_list); node != NULL;
          node = bt_list_next(g_sal_ag_conn_list, node)) {
@@ -395,10 +411,12 @@ static bt_hfp_ag_call_info_t* update_sal_call(bt_hfp_ag_connection_t* sal_conn,
     hfp_call_direction_t dir, hfp_ag_call_state_t call, hfp_call_mode_t mode,
     hfp_call_mpty_type_t mpty, hfp_call_addrtype_t type, const char* number)
 {
+    conn_list_lock();
     bt_hfp_ag_call_info_t* sal_call = find_call_by_number(sal_conn, number);
     if (!sal_call) {
         sal_call = build_sal_call(dir, call, type, number);
         if (!sal_call) {
+            conn_list_unlock();
             return NULL;
         }
 
@@ -407,6 +425,7 @@ static bt_hfp_ag_call_info_t* update_sal_call(bt_hfp_ag_connection_t* sal_conn,
         }
 
         bt_list_add_head(sal_conn->calls, sal_call);
+        conn_list_unlock();
         return sal_call;
     }
 
@@ -416,11 +435,13 @@ static bt_hfp_ag_call_info_t* update_sal_call(bt_hfp_ag_connection_t* sal_conn,
         /* use sal_conn directly instead of find_call_by_context,
          * because context may be NULL for call_sync entries */
         bt_list_remove(sal_conn->calls, sal_call);
+        conn_list_unlock();
         return NULL;
     }
 
     sal_call->type = type;
 
+    conn_list_unlock();
     return sal_call;
 }
 
@@ -434,8 +455,10 @@ static bt_status_t do_ag_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(addr);
     if (sal_conn != NULL) {
+        conn_list_unlock();
         BT_LOGI("%s, Connection already exists, skip", __func__);
         return BT_STATUS_SUCCESS;
     }
@@ -443,6 +466,7 @@ static bt_status_t do_ag_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
     conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     /** Remember to unref @p conn once SLC is initiated or cancelled */
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to lookup connection", __func__);
         hfp_ag_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
         bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
@@ -451,12 +475,14 @@ static bt_status_t do_ag_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
 
     sal_conn = new_sal_connection(conn, NULL);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, could not create new ag connection", __func__);
         hfp_ag_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
         bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
         bt_conn_unref(conn);
         return BT_STATUS_NOMEM;
     }
+    conn_list_unlock();
 
     BT_LOGD("%s, do sdp discover", __func__);
     if (bt_sdp_discover(conn, &sdp_discover) < 0) {
@@ -464,7 +490,9 @@ static bt_status_t do_ag_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
         hfp_ag_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
         bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
         bt_conn_unref(conn);
+        conn_list_lock();
         bt_list_remove(g_sal_ag_conn_list, sal_conn);
+        conn_list_unlock();
         return BT_STATUS_FAIL;
     }
 
@@ -477,6 +505,7 @@ static void do_ag_slc_connect(service_work_t* work, void* userdata)
     bt_hfp_ag_slc_connect_param_t* params = (bt_hfp_ag_slc_connect_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
     struct bt_hfp_ag* ag = NULL;
+    bt_address_t addr;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
@@ -489,8 +518,10 @@ static void do_ag_slc_connect(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_context(params->conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, no pending connection found for conn", __func__);
         bt_conn_unref(params->conn);
         free(params);
@@ -498,11 +529,14 @@ static void do_ag_slc_connect(service_work_t* work, void* userdata)
     }
 
     if (sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGD("%s, already initiating SLC, skip SLC initiating", __func__);
         bt_conn_unref(params->conn);
         free(params);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     BT_LOGD("%s, SLC initiating", __func__);
     if (Z_API(bt_hfp_ag_connect)(params->conn, &ag, params->channel)) {
@@ -510,11 +544,17 @@ static void do_ag_slc_connect(service_work_t* work, void* userdata)
         goto error;
     }
 
+    conn_list_lock();
+    sal_conn = find_connection_by_context(params->conn);
+    if (sal_conn) {
+        sal_conn->ag = ag;
+    }
+    conn_list_unlock();
+
     bt_conn_unref(params->conn);
-    sal_conn->ag = ag;
     free(params);
 
-    hfp_ag_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_CONNECTING, 0, 0);
+    hfp_ag_on_connection_state_changed(&addr, PROFILE_STATE_CONNECTING, 0, 0);
 
     BT_LOGD("%s, HFP AG connecting", __func__);
     return;
@@ -522,21 +562,27 @@ static void do_ag_slc_connect(service_work_t* work, void* userdata)
 error:
     bt_conn_unref(params->conn);
     free(params);
-    hfp_ag_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_DISCONNECTED, 0, 0);
-    bt_sal_cm_profile_disconnected_callback(&sal_conn->addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
+    hfp_ag_on_connection_state_changed(&addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+    bt_sal_cm_profile_disconnected_callback(&addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
+    conn_list_lock();
     bt_list_remove(g_sal_ag_conn_list, sal_conn);
+    conn_list_unlock();
     return;
 }
 
 bt_status_t do_ag_disconnect(bt_controller_id_t id, bt_address_t* addr, void* userdata)
 {
+    struct bt_hfp_ag* ag;
+
     if (!addr) {
         BT_LOGE("%s, addr is NULL", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_FAIL;
     }
@@ -544,10 +590,13 @@ bt_status_t do_ag_disconnect(bt_controller_id_t id, bt_address_t* addr, void* us
     if (!sal_conn->ag) {
         BT_LOGI("%s, HFP AG not connected", __func__);
         bt_list_remove(g_sal_ag_conn_list, sal_conn);
+        conn_list_unlock();
         return BT_STATUS_SUCCESS;
     }
+    ag = sal_conn->ag;
+    conn_list_unlock();
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_disconnect)(sal_conn->ag), 0);
+    SAL_CHECK_RET(Z_API(bt_hfp_ag_disconnect)(ag), 0);
     return BT_STATUS_SUCCESS;
 }
 
@@ -579,6 +628,7 @@ static void do_ag_sco_connect(service_work_t* work, void* userdata)
     struct bt_hfp_ag* ag;
     uint8_t codec;
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
     hfp_codec_config_t cfg = { 0 };
     int err;
 
@@ -598,31 +648,40 @@ static void do_ag_sco_connect(service_work_t* work, void* userdata)
     codec = params->codec;
     free(params);
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_audio_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_CONNECTING, 0xFFFF); // sco conn handle not supported
+    hfp_ag_on_audio_state_changed(&addr, HFP_AUDIO_STATE_CONNECTING, 0xFFFF); // sco conn handle not supported
 
     err = Z_API(bt_hfp_ag_audio_connect)(ag, codec);
     if (err == -EALREADY) {
         BT_LOGW("%s, Audio already connected, notify CONNECTED", __func__);
-        hfp_ag_on_audio_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_CONNECTED, 0xFFFF);
+        hfp_ag_on_audio_state_changed(&addr, HFP_AUDIO_STATE_CONNECTED, 0xFFFF);
     } else if ((err == -ENOTSUP || err == -EINVAL) && codec != BT_HFP_AG_CODEC_CVSD) {
         BT_LOGW("%s, codec=%d not supported, fallback to CVSD", __func__, codec);
-        sal_conn->preferred_codec = BT_HFP_AG_CODEC_CVSD;
+        conn_list_lock();
+        sal_conn = find_connection_by_ag(ag);
+        if (sal_conn) {
+            sal_conn->preferred_codec = BT_HFP_AG_CODEC_CVSD;
+        }
+        conn_list_unlock();
         hfp_codec_to_service_cfg(BT_HFP_AG_CODEC_CVSD, &cfg);
-        hfp_ag_on_codec_changed(&sal_conn->addr, &cfg);
+        hfp_ag_on_codec_changed(&addr, &cfg);
         err = Z_API(bt_hfp_ag_audio_connect)(ag, BT_HFP_AG_CODEC_CVSD);
         if (err) {
             BT_LOGE("%s, Failed to connect HFP AG SCO with CVSD fallback, err=%d", __func__, err);
-            hfp_ag_on_audio_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_DISCONNECTED, 0xFFFF);
+            hfp_ag_on_audio_state_changed(&addr, HFP_AUDIO_STATE_DISCONNECTED, 0xFFFF);
         }
     } else if (err) {
         BT_LOGE("%s, Failed to connect HFP AG SCO, err=%d", __func__, err);
-        hfp_ag_on_audio_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_DISCONNECTED, 0xFFFF);
+        hfp_ag_on_audio_state_changed(&addr, HFP_AUDIO_STATE_DISCONNECTED, 0xFFFF);
     }
 }
 
@@ -631,6 +690,7 @@ static void do_ag_sco_disconnect(service_work_t* work, void* userdata)
     bt_hfp_ag_disconnect_sco_param_t* params;
     struct bt_conn* sco_context;
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
     int err;
 
     params = (bt_hfp_ag_disconnect_sco_param_t*)userdata;
@@ -648,13 +708,17 @@ static void do_ag_sco_disconnect(service_work_t* work, void* userdata)
     sco_context = params->sco_context;
     free(params);
 
+    conn_list_lock();
     sal_conn = find_connection_by_sco_context(sco_context);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, sco_context no longer tracked, skip disconnect", __func__);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_audio_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_DISCONNECTING, 0xFFFF);
+    hfp_ag_on_audio_state_changed(&addr, HFP_AUDIO_STATE_DISCONNECTING, 0xFFFF);
 
     err = bt_conn_disconnect(sco_context, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
     if (err) {
@@ -665,8 +729,11 @@ static void do_ag_sco_disconnect(service_work_t* work, void* userdata)
 static void zblue_on_sdp_disconnected(struct bt_conn* conn, const struct bt_sdp_discover_params* params)
 {
     bt_address_t bd_addr;
+
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_context(conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, no pending connection found", __func__);
         return;
     }
@@ -674,6 +741,8 @@ static void zblue_on_sdp_disconnected(struct bt_conn* conn, const struct bt_sdp_
 
     BT_LOGW("%s, SDP disconnected during discovery", __func__);
     bt_list_remove(g_sal_ag_conn_list, sal_conn);
+    conn_list_unlock();
+
     hfp_ag_on_connection_state_changed(&bd_addr, PROFILE_STATE_DISCONNECTED, 0, 0);
     bt_sal_cm_profile_disconnected_callback(&bd_addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
 }
@@ -682,6 +751,7 @@ static void do_ag_set_volume(service_work_t* work, void* userdata)
 {
     bt_hfp_ag_set_volume_param_t* params = (bt_hfp_ag_set_volume_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag* ag;
     int ret;
 
     if (!params) {
@@ -689,19 +759,23 @@ static void do_ag_set_volume(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available, skip set volume", __func__);
         free(params);
         return;
     }
+    ag = sal_conn->ag;
+    conn_list_unlock();
 
     switch (params->type) {
     case HFP_VOLUME_TYPE_SPK:
-        ret = Z_API(bt_hfp_ag_vgs)(sal_conn->ag, params->gain);
+        ret = Z_API(bt_hfp_ag_vgs)(ag, params->gain);
         break;
     case HFP_VOLUME_TYPE_MIC:
-        ret = Z_API(bt_hfp_ag_vgm)(sal_conn->ag, params->gain);
+        ret = Z_API(bt_hfp_ag_vgm)(ag, params->gain);
         break;
     default:
         BT_LOGE("%s, Unknown volume type: %d", __func__, params->type);
@@ -741,20 +815,25 @@ static void do_ag_voice_recognition(service_work_t* work, void* userdata)
 {
     bt_hfp_ag_voice_recognition_param_t* params = (bt_hfp_ag_voice_recognition_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag* ag;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    ag = sal_conn->ag;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_ag_voice_recognition)(sal_conn->ag, params->activate);
+    int ret = Z_API(bt_hfp_ag_voice_recognition)(ag, params->activate);
     if (ret) {
         BT_LOGE("%s, Failed to %s voice recognition, ret=%d", __func__,
             params->activate ? "start" : "stop", ret);
@@ -767,6 +846,7 @@ static void do_ag_cind_response(service_work_t* work, void* userdata)
 {
     bt_hfp_ag_cind_response_param_t* params = (bt_hfp_ag_cind_response_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag* ag;
     struct bt_hfp_ag_ongoing_call calls[HFP_CALL_LIST_MAX];
     struct bt_hfp_ag_indicator_value indicators[4] = { 0 };
     size_t count = 0;
@@ -776,12 +856,16 @@ static void do_ag_cind_response(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+
+    ag = sal_conn->ag;
 
     sal_conn->indicators.network = params->response.network ? 1 : 0;
     sal_conn->indicators.roam = params->response.roam ? 1 : 0;
@@ -807,12 +891,13 @@ static void do_ag_cind_response(service_work_t* work, void* userdata)
     if (sal_conn->calls) {
         bt_list_foreach(sal_conn->calls, fill_call_info, &ctx);
     }
+    conn_list_unlock();
 
     if (count > HFP_CALL_LIST_MAX) {
         BT_LOGW("%s, reached max call list size", __func__);
     }
 
-    int ret = Z_API(bt_hfp_ag_ongoing_calls)(sal_conn->ag, calls, count, indicators, 4);
+    int ret = Z_API(bt_hfp_ag_ongoing_calls)(ag, calls, count, indicators, 4);
     if (ret) {
         BT_LOGE("%s, bt_hfp_ag_ongoing_calls failed, ret=%d", __func__, ret);
     }
@@ -824,20 +909,25 @@ static void do_ag_dial_response(service_work_t* work, void* userdata)
 {
     bt_hfp_ag_dial_response_param_t* params = (bt_hfp_ag_dial_response_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag* ag;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    ag = sal_conn->ag;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, NULL);
+    int ret = Z_API(bt_hfp_ag_send_vendor)(ag, NULL);
     if (ret) {
         BT_LOGE("%s, bt_hfp_ag_send_vendor failed, ret=%d", __func__, ret);
     }
@@ -849,20 +939,25 @@ static void do_ag_cops_response(service_work_t* work, void* userdata)
 {
     bt_hfp_ag_cops_response_param_t* params = (bt_hfp_ag_cops_response_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag* ag;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    ag = sal_conn->ag;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_ag_set_operator)(sal_conn->ag, 0, params->operator_name);
+    int ret = Z_API(bt_hfp_ag_set_operator)(ag, 0, params->operator_name);
     if (ret) {
         BT_LOGE("%s, bt_hfp_ag_set_operator failed, ret=%d", __func__, ret);
     }
@@ -874,58 +969,92 @@ static void do_ag_device_status(service_work_t* work, void* userdata)
 {
     bt_hfp_ag_device_status_param_t* params = (bt_hfp_ag_device_status_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag* ag;
     uint8_t net_val;
     uint8_t roam_val;
     uint8_t sig_val;
     uint8_t bat_val;
+    uint8_t old_network;
+    uint8_t old_roam;
+    uint8_t old_signal;
+    uint8_t old_battery;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+
+    ag = sal_conn->ag;
+    old_network = sal_conn->indicators.network;
+    old_roam = sal_conn->indicators.roam;
+    old_signal = sal_conn->indicators.signal;
+    old_battery = sal_conn->indicators.battery;
+    conn_list_unlock();
 
     net_val = params->network ? 1 : 0;
     roam_val = params->roam ? 1 : 0;
     sig_val = params->signal > 5 ? 5 : (uint8_t)params->signal;
     bat_val = params->battery > 5 ? 5 : (uint8_t)params->battery;
 
-    if (net_val != sal_conn->indicators.network) {
-        int ret = Z_API(bt_hfp_ag_service_availability)(sal_conn->ag, params->network ? true : false);
+    if (net_val != old_network) {
+        int ret = Z_API(bt_hfp_ag_service_availability)(ag, params->network ? true : false);
         if (ret) {
             BT_LOGE("%s, bt_hfp_ag_service_availability failed, ret=%d", __func__, ret);
         }
-        sal_conn->indicators.network = net_val;
+        conn_list_lock();
+        sal_conn = find_connection_by_addr(&params->addr);
+        if (sal_conn) {
+            sal_conn->indicators.network = net_val;
+        }
+        conn_list_unlock();
     }
 
-    if (roam_val != sal_conn->indicators.roam) {
-        int ret = Z_API(bt_hfp_ag_roaming_status)(sal_conn->ag, params->roam ? 1 : 0);
+    if (roam_val != old_roam) {
+        int ret = Z_API(bt_hfp_ag_roaming_status)(ag, params->roam ? 1 : 0);
         if (ret) {
             BT_LOGE("%s, bt_hfp_ag_roaming_status failed, ret=%d", __func__, ret);
         }
-        sal_conn->indicators.roam = roam_val;
+        conn_list_lock();
+        sal_conn = find_connection_by_addr(&params->addr);
+        if (sal_conn) {
+            sal_conn->indicators.roam = roam_val;
+        }
+        conn_list_unlock();
     }
 
-    if (sig_val != sal_conn->indicators.signal) {
-        int ret = Z_API(bt_hfp_ag_signal_strength)(sal_conn->ag, sig_val);
+    if (sig_val != old_signal) {
+        int ret = Z_API(bt_hfp_ag_signal_strength)(ag, sig_val);
         if (ret) {
             BT_LOGE("%s, bt_hfp_ag_signal_strength failed, ret=%d", __func__, ret);
         }
-        sal_conn->indicators.signal = sig_val;
+        conn_list_lock();
+        sal_conn = find_connection_by_addr(&params->addr);
+        if (sal_conn) {
+            sal_conn->indicators.signal = sig_val;
+        }
+        conn_list_unlock();
     }
 
-    if (bat_val != sal_conn->indicators.battery) {
-        int ret = Z_API(bt_hfp_ag_battery_level)(sal_conn->ag, bat_val);
+    if (bat_val != old_battery) {
+        int ret = Z_API(bt_hfp_ag_battery_level)(ag, bat_val);
         if (ret) {
             BT_LOGE("%s, bt_hfp_ag_battery_level failed, ret=%d", __func__, ret);
         }
-        sal_conn->indicators.battery = bat_val;
+        conn_list_lock();
+        sal_conn = find_connection_by_addr(&params->addr);
+        if (sal_conn) {
+            sal_conn->indicators.battery = bat_val;
+        }
+        conn_list_unlock();
     }
 
     free(params);
@@ -941,14 +1070,18 @@ static void do_ag_inband_ring(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    struct bt_hfp_ag* ag = sal_conn->ag;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_ag_inband_ringtone)(sal_conn->ag, params->enable);
+    int ret = Z_API(bt_hfp_ag_inband_ringtone)(ag, params->enable);
     if (ret) {
         BT_LOGE("%s, bt_hfp_ag_inband_ringtone failed, ret=%d", __func__, ret);
     }
@@ -960,20 +1093,25 @@ static void do_ag_send_at_cmd(service_work_t* work, void* userdata)
 {
     bt_hfp_ag_send_at_cmd_param_t* params = (bt_hfp_ag_send_at_cmd_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag* ag;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    ag = sal_conn->ag;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, params->line);
+    int ret = Z_API(bt_hfp_ag_send_vendor)(ag, params->line);
     if (ret) {
         BT_LOGE("%s, bt_hfp_ag_send_vendor failed, ret=%d", __func__, ret);
     }
@@ -985,6 +1123,7 @@ static void do_ag_error_response(service_work_t* work, void* userdata)
 {
     bt_hfp_ag_error_response_param_t* params = (bt_hfp_ag_error_response_param_t*)userdata;
     bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag* ag;
     const char* line;
     char buf[32] = { 0 };
 
@@ -993,12 +1132,16 @@ static void do_ag_error_response(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    ag = sal_conn->ag;
+    conn_list_unlock();
 
     if (params->result >= HFP_ATCMD_RESULT_CMEERR) {
         enum bt_at_cme cme = hfp_at_result_to_cme(params->result);
@@ -1010,7 +1153,7 @@ static void do_ag_error_response(service_work_t* work, void* userdata)
         line = "ERROR";
     }
 
-    int ret = Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, line);
+    int ret = Z_API(bt_hfp_ag_send_vendor)(ag, line);
     if (ret) {
         BT_LOGE("%s, bt_hfp_ag_send_vendor failed, ret=%d", __func__, ret);
     }
@@ -1025,12 +1168,16 @@ static uint8_t zblue_on_sdp_done(struct bt_conn* conn, struct bt_sdp_client_resu
     uint16_t port;
     bt_address_t bd_addr;
     bt_hfp_ag_slc_connect_param_t* params;
+
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_context(conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, could not find sal_conn", __func__);
         return BT_SDP_DISCOVER_UUID_STOP;
     }
     memcpy(&bd_addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     if (!result) {
         BT_LOGE("%s, remote device does not support HFP HF feature", __func__);
@@ -1070,7 +1217,9 @@ static uint8_t zblue_on_sdp_done(struct bt_conn* conn, struct bt_sdp_client_resu
     return BT_SDP_DISCOVER_UUID_STOP;
 
 error:
+    conn_list_lock();
     bt_list_remove(g_sal_ag_conn_list, sal_conn);
+    conn_list_unlock();
     hfp_ag_on_connection_state_changed(&bd_addr, PROFILE_STATE_DISCONNECTED, 0, 0);
     bt_sal_cm_profile_disconnected_callback(&bd_addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
     return BT_SDP_DISCOVER_UUID_STOP;
@@ -1079,12 +1228,15 @@ error:
 static void zblue_on_ag_connected(struct bt_conn* conn, struct bt_hfp_ag* ag)
 {
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
 
+    conn_list_lock();
     sal_conn = find_connection_by_context(conn);
     if (!sal_conn) {
         BT_LOGD("%s, ag connection incoming", __func__);
         sal_conn = new_sal_connection(conn, ag);
         if (!sal_conn) {
+            conn_list_unlock();
             BT_LOGE("%s, Failed to create HFP AG connection", __func__);
             if (Z_API(bt_hfp_ag_disconnect)(ag)) {
                 BT_LOGE("%s, Failed to disconnect HFP AG connection", __func__);
@@ -1092,23 +1244,30 @@ static void zblue_on_ag_connected(struct bt_conn* conn, struct bt_hfp_ag* ag)
             return;
         }
 
-        hfp_ag_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_CONNECTING, 0, 0);
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
+
+        hfp_ag_on_connection_state_changed(&addr, PROFILE_STATE_CONNECTING, 0, 0);
     } else {
         /* Override conn if both sides attempt to connect at the same time */
         sal_conn->context = conn;
         sal_conn->ag = ag;
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
     }
 
-    bt_sal_cm_profile_connected_callback(&sal_conn->addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
-    bt_sal_profile_disconnect_register(&sal_conn->addr, PROFILE_HFP_AG, CONN_ID_DEFAULT, PRIMARY_ADAPTER, do_ag_disconnect, NULL);
+    bt_sal_cm_profile_connected_callback(&addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
+    bt_sal_profile_disconnect_register(&addr, PROFILE_HFP_AG, CONN_ID_DEFAULT, PRIMARY_ADAPTER, do_ag_disconnect, NULL);
 
-    hfp_ag_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_CONNECTED, 0, 0);
+    hfp_ag_on_connection_state_changed(&addr, PROFILE_STATE_CONNECTED, 0, 0);
 }
 
 static void zblue_on_ag_disconnected(struct bt_hfp_ag* ag)
 {
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
@@ -1118,39 +1277,55 @@ static void zblue_on_ag_disconnected(struct bt_hfp_ag* ag)
     bt_sal_cm_profile_disconnected_callback(&sal_conn->addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
 
     bt_list_remove(g_sal_ag_conn_list, sal_conn);
+    conn_list_unlock();
 }
 
 static void zblue_on_ag_sco_connected(struct bt_hfp_ag* ag, struct bt_conn* sco_conn)
 {
+    bt_address_t addr;
+
     BT_LOGD("%s, HFP AG SCO connected, ag=%p", __func__, ag);
+
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
 
     sal_conn->sco_context = sco_conn;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_audio_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_CONNECTED, 0xFFFF); // sco conn handle not supported
+    hfp_ag_on_audio_state_changed(&addr, HFP_AUDIO_STATE_CONNECTED, 0xFFFF); // sco conn handle not supported
 }
 
 static void zblue_on_ag_sco_disconnected(struct bt_conn* sco_conn, uint8_t reason)
 {
+    bt_address_t addr;
+
     BT_LOGD("%s, HFP AG SCO disconnected, reason=%d", __func__, reason);
+
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_sco_context(sco_conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
 
     sal_conn->sco_context = NULL;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_audio_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_DISCONNECTED, 0xFFFF); // sco conn handle not supported
+    hfp_ag_on_audio_state_changed(&addr, HFP_AUDIO_STATE_DISCONNECTED, 0xFFFF); // sco conn handle not supported
 }
 
 static int zblue_on_ag_vendor_at_cmd(struct bt_hfp_ag* ag, const char* cmd, uint8_t* cme_code)
 {
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
 
     BT_LOGD("%s, cmd:%s", __func__, cmd ? cmd : "(null)");
 
@@ -1158,39 +1333,55 @@ static int zblue_on_ag_vendor_at_cmd(struct bt_hfp_ag* ag, const char* cmd, uint
         return -EINVAL;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return -ENOTCONN;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_received_at_cmd(&sal_conn->addr, cmd, (uint16_t)strlen(cmd));
+    hfp_ag_on_received_at_cmd(&addr, cmd, (uint16_t)strlen(cmd));
 
     return -EINPROGRESS;
 }
 
 static int zblue_on_ag_get_ongoing_call(struct bt_hfp_ag* ag)
 {
-    bt_hfp_ag_connection_t* sal_conn = find_connection_by_ag(ag);
+    bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
+
+    conn_list_lock();
+    sal_conn = find_connection_by_ag(ag);
 
     if (!sal_conn) {
+        conn_list_unlock();
         struct bt_conn* conn = Z_API(bt_hfp_ag_get_conn)(ag);
         if (!conn) {
             BT_LOGE("%s, failed to get conn for ag=%p", __func__, ag);
             return -EINVAL;
         }
         BT_LOGD("%s, connection not found for ag=%p, creating new", __func__, ag);
+        conn_list_lock();
         sal_conn = new_sal_connection(conn, ag);
         bt_conn_unref(conn);
         if (!sal_conn) {
+            conn_list_unlock();
             BT_LOGE("%s, failed to create new sal conn", __func__);
             return -EINVAL;
         }
-        hfp_ag_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_CONNECTING, 0, 0);
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
+        hfp_ag_on_connection_state_changed(&addr, PROFILE_STATE_CONNECTING, 0, 0);
+    } else {
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
     }
 
-    hfp_ag_on_call_sync(&sal_conn->addr);
-    hfp_ag_on_received_cind_request(&sal_conn->addr);
+    hfp_ag_on_call_sync(&addr);
+    hfp_ag_on_received_cind_request(&addr);
     return 0;
 }
 
@@ -1202,18 +1393,23 @@ static int zblue_on_ag_memory_dial(struct bt_hfp_ag* ag, const char* location, c
 static int zblue_on_ag_number_call(struct bt_hfp_ag* ag, const char* number)
 {
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
 
     if (!ag || !number) {
         return -EINVAL;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return -EINVAL;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_dial_number(&sal_conn->addr, (char*)number, strlen(number));
+    hfp_ag_on_dial_number(&addr, (char*)number, strlen(number));
 
     return -EINPROGRESS;
 }
@@ -1227,8 +1423,10 @@ static void zblue_on_ag_outgoing(struct bt_hfp_ag* ag, struct bt_hfp_ag_call* ca
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
@@ -1241,6 +1439,7 @@ static void zblue_on_ag_outgoing(struct bt_hfp_ag* ag, struct bt_hfp_ag_call* ca
         sal_call->state = tele_call_state_to_sal_status(HFP_AG_CALL_STATE_DIALING);
         sal_call->context = call;
     }
+    conn_list_unlock();
 }
 
 static void zblue_on_ag_incoming(struct bt_hfp_ag* ag, struct bt_hfp_ag_call* call, const char* number)
@@ -1252,8 +1451,10 @@ static void zblue_on_ag_incoming(struct bt_hfp_ag* ag, struct bt_hfp_ag_call* ca
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
@@ -1266,6 +1467,7 @@ static void zblue_on_ag_incoming(struct bt_hfp_ag* ag, struct bt_hfp_ag_call* ca
         sal_call->state = tele_call_state_to_sal_status(HFP_AG_CALL_STATE_INCOMING);
         sal_call->context = call;
     }
+    conn_list_unlock();
 }
 
 static void zblue_on_ag_incoming_held(struct bt_hfp_ag_call* call)
@@ -1273,8 +1475,10 @@ static void zblue_on_ag_incoming_held(struct bt_hfp_ag_call* call)
     bt_hfp_ag_connection_t* sal_conn = NULL;
     bt_hfp_ag_call_info_t* sal_call;
 
+    conn_list_lock();
     sal_call = find_call_by_context(call, &sal_conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for call=%p", __func__, call);
         return;
     }
@@ -1285,161 +1489,202 @@ static void zblue_on_ag_incoming_held(struct bt_hfp_ag_call* call)
         sal_call->state = tele_call_state_to_sal_status(HFP_AG_CALL_STATE_WAITING);
         sal_call->context = call;
     }
+    conn_list_unlock();
 }
 
 static void zblue_on_ag_accept(struct bt_hfp_ag_call* call)
 {
     bt_hfp_ag_connection_t* sal_conn = NULL;
     bt_hfp_ag_call_info_t* sal_call;
+    bt_address_t addr;
 
     if (!call) {
         return;
     }
 
+    conn_list_lock();
     sal_call = find_call_by_context(call, &sal_conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for call=%p", __func__, call);
         return;
     }
 
     if (!sal_call) {
+        conn_list_unlock();
         BT_LOGE("%s, call not tracked", __func__);
         return;
     }
 
     if (sal_call->state != BT_HFP_AG_CALL_STATUS_INCOMING && sal_call->state != BT_HFP_AG_CALL_STATUS_WAITING) {
+        conn_list_unlock();
         return;
     }
 
     sal_call->state = BT_HFP_AG_CALL_STATUS_ACTIVE;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_answer_call(&sal_conn->addr);
+    hfp_ag_on_answer_call(&addr);
 }
 
 static void zblue_on_ag_held(struct bt_hfp_ag_call* call)
 {
     bt_hfp_ag_connection_t* sal_conn = NULL;
     bt_hfp_ag_call_info_t* sal_call;
+    bt_address_t addr;
 
     if (!call) {
         return;
     }
 
+    conn_list_lock();
     sal_call = find_call_by_context(call, &sal_conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for call=%p", __func__, call);
         return;
     }
 
     if (!sal_call) {
+        conn_list_unlock();
         BT_LOGE("%s, call not tracked", __func__);
         return;
     }
 
     if (sal_call->state != BT_HFP_AG_CALL_STATUS_ACTIVE) {
+        conn_list_unlock();
         return;
     }
 
     sal_call->state = BT_HFP_AG_CALL_STATUS_HELD;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_hangup_call(&sal_conn->addr);
+    hfp_ag_on_hangup_call(&addr);
 }
 
 static void zblue_on_ag_retrieve(struct bt_hfp_ag_call* call)
 {
     bt_hfp_ag_connection_t* sal_conn = NULL;
     bt_hfp_ag_call_info_t* sal_call;
+    bt_address_t addr;
 
     if (!call) {
         return;
     }
 
+    conn_list_lock();
     sal_call = find_call_by_context(call, &sal_conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for call=%p", __func__, call);
         return;
     }
 
     if (!sal_call) {
+        conn_list_unlock();
         BT_LOGE("%s, call not tracked", __func__);
         return;
     }
 
     if (sal_call->state != BT_HFP_AG_CALL_STATUS_HELD) {
+        conn_list_unlock();
         return;
     }
 
     sal_call->state = BT_HFP_AG_CALL_STATUS_ACTIVE;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_call_control(&sal_conn->addr, HFP_HF_CALL_CONTROL_CHLD_2);
+    hfp_ag_on_call_control(&addr, HFP_HF_CALL_CONTROL_CHLD_2);
 }
 
 static void zblue_on_ag_reject(struct bt_hfp_ag_call* call)
 {
     bt_hfp_ag_connection_t* sal_conn = NULL;
     bt_hfp_ag_call_info_t* sal_call;
+    bt_address_t addr;
 
     if (!call) {
         return;
     }
 
+    conn_list_lock();
     sal_call = find_call_by_context(call, &sal_conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for call=%p", __func__, call);
         return;
     }
 
     if (!sal_call) {
+        conn_list_unlock();
         BT_LOGE("%s, call not tracked", __func__);
         return;
     }
 
     if (sal_call->state != BT_HFP_AG_CALL_STATUS_INCOMING
         && sal_call->state != BT_HFP_AG_CALL_STATUS_WAITING) {
+        conn_list_unlock();
         return;
     }
 
     sal_call->state = BT_HFP_AG_CALL_STATUS_UNKNOWN;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_reject_call(&sal_conn->addr);
+    hfp_ag_on_reject_call(&addr);
 }
 
 static void zblue_on_ag_terminate(struct bt_hfp_ag_call* call)
 {
     bt_hfp_ag_connection_t* sal_conn = NULL;
     bt_hfp_ag_call_info_t* sal_call;
+    bt_address_t addr;
+    int call_count;
 
     if (!call) {
         return;
     }
 
+    conn_list_lock();
     sal_call = find_call_by_context(call, &sal_conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for call=%p", __func__, call);
         return;
     }
 
     if (!sal_call) {
+        conn_list_unlock();
         BT_LOGE("%s, call not tracked", __func__);
         return;
     }
 
     if (sal_call->state != BT_HFP_AG_CALL_STATUS_ACTIVE
         && sal_call->state != BT_HFP_AG_CALL_STATUS_HELD) {
+        conn_list_unlock();
         return;
     }
 
     sal_call->state = BT_HFP_AG_CALL_STATUS_UNKNOWN;
 
     if (!sal_conn->calls) {
-        hfp_ag_on_hangup_call(&sal_conn->addr);
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
+        hfp_ag_on_hangup_call(&addr);
         return;
     }
 
-    if (bt_list_length(sal_conn->calls) == 1) {
-        hfp_ag_on_hangup_call(&sal_conn->addr);
+    call_count = bt_list_length(sal_conn->calls);
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    if (call_count == 1) {
+        hfp_ag_on_hangup_call(&addr);
     } else {
-        hfp_ag_on_call_control(&sal_conn->addr, HFP_HF_CALL_CONTROL_CHLD_1);
+        hfp_ag_on_call_control(&addr, HFP_HF_CALL_CONTROL_CHLD_1);
     }
 }
 
@@ -1447,28 +1692,45 @@ static void zblue_on_ag_available_codec(struct bt_hfp_ag* ag, uint32_t codec_ids
 {
     bt_hfp_ag_connection_t* sal_conn;
     hfp_codec_config_t cfg = { 0 };
+    bt_address_t addr;
+    uint8_t preferred_codec;
     int err;
 
     if (!ag) {
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         struct bt_conn* conn = Z_API(bt_hfp_ag_get_conn)(ag);
         if (!conn) {
             BT_LOGE("%s, failed to get conn for ag=%p", __func__, ag);
             return;
         }
         BT_LOGD("%s, connection not found for ag=%p, creating new", __func__, ag);
+        conn_list_lock();
         sal_conn = new_sal_connection(conn, ag);
         bt_conn_unref(conn);
         if (!sal_conn) {
+            conn_list_unlock();
             BT_LOGE("%s, failed to create new sal conn", __func__);
             return;
         }
 
-        hfp_ag_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_CONNECTING, 0, 0);
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
+
+        hfp_ag_on_connection_state_changed(&addr, PROFILE_STATE_CONNECTING, 0, 0);
+
+        conn_list_lock();
+        sal_conn = find_connection_by_ag(ag);
+        if (!sal_conn) {
+            conn_list_unlock();
+            BT_LOGE("%s, connection lost after creating", __func__);
+            return;
+        }
     }
 
     if (codec_ids & HFP_AG_CODEC_Z_BIT_MSBC) {
@@ -1483,17 +1745,21 @@ static void zblue_on_ag_available_codec(struct bt_hfp_ag* ag, uint32_t codec_ids
         sal_conn->preferred_codec = 0;
     }
 
-    err = hfp_codec_to_service_cfg(sal_conn->preferred_codec, &cfg);
+    preferred_codec = sal_conn->preferred_codec;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    err = hfp_codec_to_service_cfg(preferred_codec, &cfg);
     if (err != 0) {
         if (err == -EINVAL) {
             BT_LOGE("%s, invalid cfg pointer", __func__);
         } else {
-            BT_LOGE("%s, unsupported codec id: %d", __func__, sal_conn->preferred_codec);
+            BT_LOGE("%s, unsupported codec id: %d", __func__, preferred_codec);
         }
         return;
     }
 
-    hfp_ag_on_codec_changed(&sal_conn->addr, &cfg);
+    hfp_ag_on_codec_changed(&addr, &cfg);
 }
 
 static void zblue_on_ag_audio_connect_req(struct bt_hfp_ag* ag)
@@ -1501,6 +1767,7 @@ static void zblue_on_ag_audio_connect_req(struct bt_hfp_ag* ag)
     bt_hfp_ag_connection_t* sal_conn;
     hfp_codec_config_t cfg = { 0 };
     bt_hfp_ag_connect_sco_param_t* params;
+    bt_address_t addr;
     uint8_t codec;
     int err;
 
@@ -1509,13 +1776,17 @@ static void zblue_on_ag_audio_connect_req(struct bt_hfp_ag* ag)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
 
     codec = sal_conn->preferred_codec ? sal_conn->preferred_codec : BT_HFP_AG_CODEC_CVSD;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     BT_LOGD("%s, HF requested audio connect, using codec=%d", __func__, codec);
 
@@ -1531,7 +1802,7 @@ static void zblue_on_ag_audio_connect_req(struct bt_hfp_ag* ag)
     }
 
     /* Report the actual codec that will be used for this audio connection */
-    hfp_ag_on_codec_changed(&sal_conn->addr, &cfg);
+    hfp_ag_on_codec_changed(&addr, &cfg);
 
     params = (bt_hfp_ag_connect_sco_param_t*)zalloc(sizeof(bt_hfp_ag_connect_sco_param_t));
     if (!params) {
@@ -1553,94 +1824,122 @@ static void zblue_on_ag_codec_negotiation(struct bt_hfp_ag* ag, int zblue_err,
 {
     bt_hfp_ag_connection_t* sal_conn;
     hfp_codec_config_t cfg = { 0 };
+    bt_address_t addr;
+    uint8_t preferred_codec;
     int err;
 
     if (!ag) {
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
 
     BT_LOGD("%s, err=%d, codec_id=%u", __func__, zblue_err, codec_id);
     sal_conn->preferred_codec = zblue_err ? BT_HFP_AG_CODEC_CVSD : codec_id;
-    err = hfp_codec_to_service_cfg(sal_conn->preferred_codec, &cfg);
+    preferred_codec = sal_conn->preferred_codec;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    err = hfp_codec_to_service_cfg(preferred_codec, &cfg);
     if (err != 0) {
         BT_LOGE("%s, codec config failed: %d", __func__, err);
         return;
     }
-    hfp_ag_on_codec_changed(&sal_conn->addr, &cfg);
+    hfp_ag_on_codec_changed(&addr, &cfg);
 }
 
 static void zblue_on_ag_vgm(struct bt_hfp_ag* ag, uint8_t gain)
 {
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
 
     if (!ag) {
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_volume_changed(&sal_conn->addr, HFP_VOLUME_TYPE_MIC, gain);
+    hfp_ag_on_volume_changed(&addr, HFP_VOLUME_TYPE_MIC, gain);
 }
 
 static void zblue_on_ag_vgs(struct bt_hfp_ag* ag, uint8_t gain)
 {
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
 
     if (!ag) {
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_volume_changed(&sal_conn->addr, HFP_VOLUME_TYPE_SPK, gain);
+    hfp_ag_on_volume_changed(&addr, HFP_VOLUME_TYPE_SPK, gain);
 }
 
 static void zblue_on_ag_voice_recognition(struct bt_hfp_ag* ag, bool activate)
 {
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
 
     if (!ag) {
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_voice_recognition_state_changed(&sal_conn->addr, activate);
+    hfp_ag_on_voice_recognition_state_changed(&addr, activate);
 }
 
 static void zblue_on_ag_transmit_dtmf_code(struct bt_hfp_ag* ag, char code)
 {
     bt_hfp_ag_connection_t* sal_conn;
+    bt_address_t addr;
 
     if (!ag) {
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_ag(ag);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found for ag=%p", __func__, ag);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_ag_on_received_dtmf(&sal_conn->addr, code);
+    hfp_ag_on_received_dtmf(&addr, code);
 }
 
 static struct bt_hfp_ag_cb g_hfp_ag_cb = {
@@ -1678,21 +1977,36 @@ static struct bt_hfp_ag_cb g_hfp_ag_cb = {
 
 bt_status_t bt_sal_hfp_ag_init(uint32_t features, uint8_t max_connection)
 {
+    pthread_mutexattr_t attr;
+
     (void)features;
     (void)max_connection;
     BT_LOGD("%s, HFP AG init", __func__);
     g_sal_ag_conn_list = bt_list_new(free_connection);
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_register)(&g_hfp_ag_cb), 0);
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&g_sal_ag_conn_lock, &attr);
+    pthread_mutexattr_destroy(&attr);
+
+    if (Z_API(bt_hfp_ag_register)(&g_hfp_ag_cb) != 0) {
+        bt_list_free(g_sal_ag_conn_list);
+        g_sal_ag_conn_list = NULL;
+        pthread_mutex_destroy(&g_sal_ag_conn_lock);
+        return BT_STATUS_FAIL;
+    }
     return BT_STATUS_SUCCESS;
 }
 
 void bt_sal_hfp_ag_cleanup(void)
 {
+    conn_list_lock();
     if (g_sal_ag_conn_list) {
         bt_list_free(g_sal_ag_conn_list);
         g_sal_ag_conn_list = NULL;
     }
+    conn_list_unlock();
+    pthread_mutex_destroy(&g_sal_ag_conn_lock);
 
     if (Z_API(bt_hfp_ag_unregister)()) {
         BT_LOGE("%s, Failed to unregister HFP AG", __func__);
@@ -1706,22 +2020,28 @@ bt_status_t bt_sal_hfp_ag_connect(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, Connection already exists or in progress", __func__);
         return BT_STATUS_BUSY;
     }
+    conn_list_unlock();
 
     return bt_sal_profile_connect_request(addr, PROFILE_HFP_AG, CONN_ID_DEFAULT, 0, do_ag_sdp_discover, NULL);
 }
 
 bt_status_t bt_sal_hfp_ag_disconnect(bt_address_t* addr)
 {
+    conn_list_lock();
     bt_hfp_ag_connection_t* conn = find_connection_by_addr(addr);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_sal_profile_disconnect_request(addr, PROFILE_HFP_AG, CONN_ID_DEFAULT, 0, do_ag_disconnect, NULL);
     return BT_STATUS_SUCCESS;
@@ -1729,20 +2049,24 @@ bt_status_t bt_sal_hfp_ag_disconnect(bt_address_t* addr)
 
 bt_status_t bt_sal_hfp_ag_connect_audio(bt_address_t* addr)
 {
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
     bt_hfp_ag_connect_sco_param_t* params = (bt_hfp_ag_connect_sco_param_t*)zalloc(sizeof(bt_hfp_ag_connect_sco_param_t));
     if (!params) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to allocate memory", __func__);
         return BT_STATUS_NOMEM;
     }
 
     params->ag = sal_conn->ag;
     params->codec = sal_conn->preferred_codec ? sal_conn->preferred_codec : BT_HFP_AG_CODEC_CVSD;
+    conn_list_unlock();
 
     if (!service_loop_work(params, do_ag_sco_connect, NULL)) {
         free(params);
@@ -1754,29 +2078,35 @@ bt_status_t bt_sal_hfp_ag_connect_audio(bt_address_t* addr)
 
 bt_status_t bt_sal_hfp_ag_disconnect_audio(bt_address_t* addr)
 {
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
     if (!sal_conn->context) {
+        conn_list_unlock();
         BT_LOGE("%s, ACL conn context not initiated", __func__);
         return BT_STATUS_FAIL;
     }
 
     if (!sal_conn->sco_context) {
+        conn_list_unlock();
         BT_LOGE("%s, SCO connection not initiated", __func__);
         return BT_STATUS_FAIL;
     }
 
     bt_hfp_ag_disconnect_sco_param_t* params = (bt_hfp_ag_disconnect_sco_param_t*)zalloc(sizeof(bt_hfp_ag_disconnect_sco_param_t));
     if (!params) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to allocate memory", __func__);
         return BT_STATUS_NOMEM;
     }
 
     params->sco_context = sal_conn->sco_context;
+    conn_list_unlock();
 
     if (!service_loop_work(params, do_ag_sco_disconnect, NULL)) {
         free(params);
@@ -1788,11 +2118,14 @@ bt_status_t bt_sal_hfp_ag_disconnect_audio(bt_address_t* addr)
 
 bt_status_t bt_sal_hfp_ag_start_voice_recognition(bt_address_t* addr)
 {
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_voice_recognition_param_t* params = zalloc(sizeof(bt_hfp_ag_voice_recognition_param_t));
     if (!params) {
@@ -1814,11 +2147,14 @@ bt_status_t bt_sal_hfp_ag_start_voice_recognition(bt_address_t* addr)
 
 bt_status_t bt_sal_hfp_ag_stop_voice_recognition(bt_address_t* addr)
 {
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_voice_recognition_param_t* params = zalloc(sizeof(bt_hfp_ag_voice_recognition_param_t));
     if (!params) {
@@ -1877,8 +2213,10 @@ static void do_ag_call_op(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer valid, skip", __func__);
         free(params);
         return;
@@ -1891,6 +2229,7 @@ static void do_ag_call_op(service_work_t* work, void* userdata)
         /* new call path */
         const new_call_entry_t* entry = find_new_call_entry(new_state);
         if (!entry) {
+            conn_list_unlock();
             BT_LOGE("%s, no new_call_entry for state %d, number: %s",
                 __func__, params->call_state, params->number);
             free(params);
@@ -1900,12 +2239,14 @@ static void do_ag_call_op(service_work_t* work, void* userdata)
         call_info = build_sal_call(HFP_CALL_DIRECTION_INCOMING, params->call_state,
             params->type, params->number);
         if (!call_info) {
+            conn_list_unlock();
             BT_LOGE("%s, failed to build sal call", __func__);
             free(params);
             return;
         }
 
         bt_list_add_head(sal_conn->calls, call_info);
+        conn_list_unlock();
 
         hfp_ag_operation_context_t context = {
             .call_info = call_info,
@@ -1915,7 +2256,9 @@ static void do_ag_call_op(service_work_t* work, void* userdata)
         int ret = entry->op(&context);
         if (ret) {
             BT_LOGE("%s, new call op failed, err=%d, rolling back", __func__, ret);
+            conn_list_lock();
             bt_list_remove(sal_conn->calls, call_info);
+            conn_list_unlock();
         }
 
         free(params);
@@ -1935,9 +2278,11 @@ static void do_ag_call_op(service_work_t* work, void* userdata)
             BT_LOGE("%s, no valid transition from %d to %d",
                 __func__, call_info->state, params->call_state);
         }
+        conn_list_unlock();
         free(params);
         return;
     }
+    conn_list_unlock();
 
     hfp_ag_operation_context_t context = {
         .call_info = call_info,
@@ -1951,11 +2296,13 @@ static void do_ag_call_op(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     if (new_state == BT_HFP_AG_CALL_STATUS_UNKNOWN) {
         bt_list_remove(sal_conn->calls, call_info);
     } else {
         call_info->state = new_state;
     }
+    conn_list_unlock();
 
     free(params);
 }
@@ -2147,12 +2494,15 @@ bt_status_t bt_sal_hfp_ag_call_sync(bt_address_t* bd_addr,
     hfp_call_mode_t mode, hfp_call_mpty_type_t mpty,
     hfp_call_addrtype_t type, const char* number)
 {
+    conn_list_lock();
     bt_hfp_ag_connection_t* conn = find_connection_by_addr(bd_addr);
 
     if (!conn) {
+        conn_list_unlock();
         BT_LOGW("%s, no sync connection set, ignore", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     update_sal_call(conn, dir, call, mode, mpty, type, number);
     return BT_STATUS_SUCCESS;
@@ -2164,11 +2514,14 @@ bt_status_t bt_sal_hfp_ag_cind_response(bt_address_t* addr, hfp_ag_cind_resopnse
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_FAIL;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_cind_response_param_t* params = zalloc(sizeof(bt_hfp_ag_cind_response_param_t));
     if (!params) {
@@ -2209,11 +2562,14 @@ bt_status_t bt_sal_hfp_ag_dial_response(bt_address_t* addr, hfp_atcmd_result_t r
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_dial_response_param_t* params = zalloc(sizeof(bt_hfp_ag_dial_response_param_t));
     if (!params) {
@@ -2240,11 +2596,14 @@ bt_status_t bt_sal_hfp_ag_cops_response(bt_address_t* addr, const char* operator
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_cops_response_param_t* params = zalloc(sizeof(bt_hfp_ag_cops_response_param_t));
     if (!params) {
@@ -2271,11 +2630,14 @@ bt_status_t bt_sal_hfp_ag_notify_device_status_changed(bt_address_t* addr, hfp_n
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_device_status_param_t* params = zalloc(sizeof(bt_hfp_ag_device_status_param_t));
     if (!params) {
@@ -2304,11 +2666,14 @@ bt_status_t bt_sal_hfp_ag_set_inband_ring_enable(bt_address_t* addr, bool enable
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_inband_ring_param_t* params = zalloc(sizeof(bt_hfp_ag_inband_ring_param_t));
     if (!params) {
@@ -2336,11 +2701,14 @@ bt_status_t bt_sal_hfp_ag_set_volume(bt_address_t* addr, hfp_volume_type_t type,
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_set_volume_param_t* params = zalloc(sizeof(bt_hfp_ag_set_volume_param_t));
     if (!params) {
@@ -2425,11 +2793,14 @@ bt_status_t bt_sal_hfp_ag_send_at_cmd(bt_address_t* addr, const char* atcmd, uin
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     start = atcmd;
     end = atcmd + length;
@@ -2496,11 +2867,14 @@ bt_status_t bt_sal_hfp_ag_error_response(bt_address_t* addr, hfp_atcmd_result_t 
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
+        conn_list_unlock();
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_ag_error_response_param_t* params = zalloc(sizeof(bt_hfp_ag_error_response_param_t));
     if (!params) {

--- a/service/stacks/zephyr/sal_hfp_ag_interface.c
+++ b/service/stacks/zephyr/sal_hfp_ag_interface.c
@@ -88,14 +88,20 @@ typedef struct _bt_hfp_ag_slc_connect_param {
     uint8_t channel;
 } bt_hfp_ag_slc_connect_param_t;
 
-typedef struct _ag_connect_sco_params {
+typedef struct _bt_hfp_ag_connect_sco_param {
     struct bt_hfp_ag* ag;
     uint8_t codec; /* e.g., BT_HFP_AG_CODEC_CVSD */
-} ag_connect_sco_params_t;
+} bt_hfp_ag_connect_sco_param_t;
 
-typedef struct _ag_disconnect_sco_params {
+typedef struct _bt_hfp_ag_disconnect_sco_param {
     struct bt_conn* sco_context;
-} ag_disconnect_sco_params_t;
+} bt_hfp_ag_disconnect_sco_param_t;
+
+typedef struct _bt_hfp_ag_set_volume_param {
+    bt_address_t addr;
+    hfp_volume_type_t type;
+    uint8_t gain;
+} bt_hfp_ag_set_volume_param_t;
 
 static void free_connection(void* data)
 {
@@ -527,14 +533,14 @@ static int hfp_codec_to_service_cfg(uint8_t codec_id, hfp_codec_config_t* cfg)
 
 static void do_ag_sco_connect(service_work_t* work, void* userdata)
 {
-    ag_connect_sco_params_t* params;
+    bt_hfp_ag_connect_sco_param_t* params;
     struct bt_hfp_ag* ag;
     uint8_t codec;
     bt_hfp_ag_connection_t* sal_conn;
     hfp_codec_config_t cfg = { 0 };
     int err;
 
-    params = (ag_connect_sco_params_t*)userdata;
+    params = (bt_hfp_ag_connect_sco_param_t*)userdata;
     if (!params) {
         BT_LOGE("%s, Invalid parameters", __func__);
         return;
@@ -580,12 +586,12 @@ static void do_ag_sco_connect(service_work_t* work, void* userdata)
 
 static void do_ag_sco_disconnect(service_work_t* work, void* userdata)
 {
-    ag_disconnect_sco_params_t* params;
+    bt_hfp_ag_disconnect_sco_param_t* params;
     struct bt_conn* sco_context;
     bt_hfp_ag_connection_t* sal_conn;
     int err;
 
-    params = (ag_disconnect_sco_params_t*)userdata;
+    params = (bt_hfp_ag_disconnect_sco_param_t*)userdata;
     if (!params) {
         BT_LOGE("%s, Invalid parameters", __func__);
         return;
@@ -628,6 +634,44 @@ static void zblue_on_sdp_disconnected(struct bt_conn* conn, const struct bt_sdp_
     bt_list_remove(g_sal_ag_conn_list, sal_conn);
     hfp_ag_on_connection_state_changed(&bd_addr, PROFILE_STATE_DISCONNECTED, 0, 0);
     bt_sal_cm_profile_disconnected_callback(&bd_addr, PROFILE_HFP_AG, CONN_ID_DEFAULT);
+}
+
+static void do_ag_set_volume(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_set_volume_param_t* params = (bt_hfp_ag_set_volume_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+    int ret;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available, skip set volume", __func__);
+        free(params);
+        return;
+    }
+
+    switch (params->type) {
+    case HFP_VOLUME_TYPE_SPK:
+        ret = Z_API(bt_hfp_ag_vgs)(sal_conn->ag, params->gain);
+        break;
+    case HFP_VOLUME_TYPE_MIC:
+        ret = Z_API(bt_hfp_ag_vgm)(sal_conn->ag, params->gain);
+        break;
+    default:
+        BT_LOGE("%s, Unknown volume type: %d", __func__, params->type);
+        free(params);
+        return;
+    }
+
+    if (ret) {
+        BT_LOGE("%s, Failed to set volume, type=%d, ret=%d", __func__, params->type, ret);
+    }
+
+    free(params);
 }
 
 static uint8_t zblue_on_sdp_done(struct bt_conn* conn, struct bt_sdp_client_result* result,
@@ -1112,7 +1156,7 @@ static void zblue_on_ag_audio_connect_req(struct bt_hfp_ag* ag)
 {
     bt_hfp_ag_connection_t* sal_conn;
     hfp_codec_config_t cfg = { 0 };
-    ag_connect_sco_params_t* params;
+    bt_hfp_ag_connect_sco_param_t* params;
     uint8_t codec;
     int err;
 
@@ -1145,7 +1189,7 @@ static void zblue_on_ag_audio_connect_req(struct bt_hfp_ag* ag)
     /* Report the actual codec that will be used for this audio connection */
     hfp_ag_on_codec_changed(&sal_conn->addr, &cfg);
 
-    params = (ag_connect_sco_params_t*)zalloc(sizeof(ag_connect_sco_params_t));
+    params = (bt_hfp_ag_connect_sco_param_t*)zalloc(sizeof(bt_hfp_ag_connect_sco_param_t));
     if (!params) {
         BT_LOGE("%s, Failed to allocate memory", __func__);
         return;
@@ -1347,7 +1391,7 @@ bt_status_t bt_sal_hfp_ag_connect_audio(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
-    ag_connect_sco_params_t* params = (ag_connect_sco_params_t*)zalloc(sizeof(ag_connect_sco_params_t));
+    bt_hfp_ag_connect_sco_param_t* params = (bt_hfp_ag_connect_sco_param_t*)zalloc(sizeof(bt_hfp_ag_connect_sco_param_t));
     if (!params) {
         BT_LOGE("%s, Failed to allocate memory", __func__);
         return BT_STATUS_NOMEM;
@@ -1382,7 +1426,7 @@ bt_status_t bt_sal_hfp_ag_disconnect_audio(bt_address_t* addr)
         return BT_STATUS_FAIL;
     }
 
-    ag_disconnect_sco_params_t* params = (ag_disconnect_sco_params_t*)zalloc(sizeof(ag_disconnect_sco_params_t));
+    bt_hfp_ag_disconnect_sco_param_t* params = (bt_hfp_ag_disconnect_sco_param_t*)zalloc(sizeof(bt_hfp_ag_disconnect_sco_param_t));
     if (!params) {
         BT_LOGE("%s, Failed to allocate memory", __func__);
         return BT_STATUS_NOMEM;
@@ -1446,16 +1490,16 @@ static const new_call_entry_t* find_new_call_entry(enum bt_hfp_ag_call_status st
 static const call_transition_t* find_call_transition(
     enum bt_hfp_ag_call_status prev, hfp_ag_call_state_t next);
 
-typedef struct _ag_call_op_params {
+typedef struct _bt_hfp_ag_call_op_param {
     bt_address_t addr;
     char number[CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN + 1];
     hfp_ag_call_state_t call_state;
     hfp_call_addrtype_t type;
-} ag_call_op_params_t;
+} bt_hfp_ag_call_op_param_t;
 
 static void do_ag_call_op(service_work_t* work, void* userdata)
 {
-    ag_call_op_params_t* params = (ag_call_op_params_t*)userdata;
+    bt_hfp_ag_call_op_param_t* params = (bt_hfp_ag_call_op_param_t*)userdata;
     if (!params) {
         BT_LOGE("%s, Invalid parameters", __func__);
         return;
@@ -1704,7 +1748,7 @@ bt_status_t bt_sal_hfp_ag_phone_state_change(bt_address_t* addr, uint8_t num_act
         __func__, num_active, num_held, call_state, type,
         number ? number : "(null)", name ? name : "(null)");
 
-    ag_call_op_params_t* params = (ag_call_op_params_t*)zalloc(sizeof(ag_call_op_params_t));
+    bt_hfp_ag_call_op_param_t* params = (bt_hfp_ag_call_op_param_t*)zalloc(sizeof(bt_hfp_ag_call_op_param_t));
     if (!params) {
         BT_LOGE("%s, Failed to allocate memory", __func__);
         return BT_STATUS_NOMEM;
@@ -1946,13 +1990,20 @@ bt_status_t bt_sal_hfp_ag_set_volume(bt_address_t* addr, hfp_volume_type_t type,
         return BT_STATUS_PARM_INVALID;
     }
 
-    if (type == HFP_VOLUME_TYPE_SPK) {
-        SAL_CHECK_RET(Z_API(bt_hfp_ag_vgs)(sal_conn->ag, volume), 0);
-    } else if (type == HFP_VOLUME_TYPE_MIC) {
-        SAL_CHECK_RET(Z_API(bt_hfp_ag_vgm)(sal_conn->ag, volume), 0);
-    } else {
-        BT_LOGE("%s, invalid volume type: %d", __func__, type);
-        return BT_STATUS_PARM_INVALID;
+    bt_hfp_ag_set_volume_param_t* params = zalloc(sizeof(bt_hfp_ag_set_volume_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->type = type;
+    params->gain = volume > 15 ? 15 : volume;
+
+    if (!service_loop_work(params, do_ag_set_volume, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
     }
 
     return BT_STATUS_SUCCESS;

--- a/service/stacks/zephyr/sal_hfp_ag_interface.c
+++ b/service/stacks/zephyr/sal_hfp_ag_interface.c
@@ -103,6 +103,48 @@ typedef struct _bt_hfp_ag_set_volume_param {
     uint8_t gain;
 } bt_hfp_ag_set_volume_param_t;
 
+typedef struct _bt_hfp_ag_voice_recognition_param {
+    bt_address_t addr;
+    bool activate;
+} bt_hfp_ag_voice_recognition_param_t;
+
+typedef struct _bt_hfp_ag_cind_response_param {
+    bt_address_t addr;
+    hfp_ag_cind_resopnse_t response;
+} bt_hfp_ag_cind_response_param_t;
+
+typedef struct _bt_hfp_ag_dial_response_param {
+    bt_address_t addr;
+} bt_hfp_ag_dial_response_param_t;
+
+typedef struct _bt_hfp_ag_cops_response_param {
+    bt_address_t addr;
+    char operator_name[64];
+} bt_hfp_ag_cops_response_param_t;
+
+typedef struct _bt_hfp_ag_device_status_param {
+    bt_address_t addr;
+    hfp_network_state_t network;
+    hfp_roaming_state_t roam;
+    uint8_t signal;
+    uint8_t battery;
+} bt_hfp_ag_device_status_param_t;
+
+typedef struct _bt_hfp_ag_inband_ring_param {
+    bt_address_t addr;
+    bool enable;
+} bt_hfp_ag_inband_ring_param_t;
+
+typedef struct _bt_hfp_ag_send_at_cmd_param {
+    bt_address_t addr;
+    char line[HFP_AT_LEN_MAX + 1];
+} bt_hfp_ag_send_at_cmd_param_t;
+
+typedef struct _bt_hfp_ag_error_response_param {
+    bt_address_t addr;
+    hfp_atcmd_result_t result;
+} bt_hfp_ag_error_response_param_t;
+
 static void free_connection(void* data)
 {
     bt_hfp_ag_connection_t* sal_conn = (bt_hfp_ag_connection_t*)data;
@@ -669,6 +711,308 @@ static void do_ag_set_volume(service_work_t* work, void* userdata)
 
     if (ret) {
         BT_LOGE("%s, Failed to set volume, type=%d, ret=%d", __func__, params->type, ret);
+    }
+
+    free(params);
+}
+
+typedef struct {
+    struct bt_hfp_ag_ongoing_call* calls;
+    size_t* count;
+} call_list_context_t;
+
+static void fill_call_info(void* data, void* context)
+{
+    bt_hfp_ag_call_info_t* sal_call = (bt_hfp_ag_call_info_t*)data;
+    call_list_context_t* ctx = (call_list_context_t*)context;
+
+    if (*(ctx->count) >= HFP_CALL_LIST_MAX) {
+        return;
+    }
+
+    ctx->calls[*(ctx->count)].dir = sal_call->dir;
+    ctx->calls[*(ctx->count)].status = sal_call->state;
+    ctx->calls[*(ctx->count)].type = sal_call->type;
+    strlcpy(ctx->calls[*(ctx->count)].number, sal_call->number, sizeof(ctx->calls[*(ctx->count)].number));
+    (*(ctx->count))++;
+}
+
+static void do_ag_voice_recognition(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_voice_recognition_param_t* params = (bt_hfp_ag_voice_recognition_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_ag_voice_recognition)(sal_conn->ag, params->activate);
+    if (ret) {
+        BT_LOGE("%s, Failed to %s voice recognition, ret=%d", __func__,
+            params->activate ? "start" : "stop", ret);
+    }
+
+    free(params);
+}
+
+static void do_ag_cind_response(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_cind_response_param_t* params = (bt_hfp_ag_cind_response_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+    struct bt_hfp_ag_ongoing_call calls[HFP_CALL_LIST_MAX];
+    struct bt_hfp_ag_indicator_value indicators[4] = { 0 };
+    size_t count = 0;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    sal_conn->indicators.network = params->response.network ? 1 : 0;
+    sal_conn->indicators.roam = params->response.roam ? 1 : 0;
+    sal_conn->indicators.signal = params->response.signal > 5 ? 5 : (uint8_t)params->response.signal;
+    sal_conn->indicators.battery = params->response.battery > 5 ? 5 : (uint8_t)params->response.battery;
+
+    indicators[0].indicator = BT_HFP_AG_SERVICE_IND;
+    indicators[0].value = sal_conn->indicators.network;
+    indicators[1].indicator = BT_HFP_AG_ROAM_IND;
+    indicators[1].value = sal_conn->indicators.roam;
+    indicators[2].indicator = BT_HFP_AG_SIGNAL_IND;
+    indicators[2].value = sal_conn->indicators.signal;
+    indicators[3].indicator = BT_HFP_AG_BATTERY_IND;
+    indicators[3].value = sal_conn->indicators.battery;
+
+    memset(calls, 0, sizeof(calls));
+
+    call_list_context_t ctx = {
+        .calls = calls,
+        .count = &count
+    };
+
+    if (sal_conn->calls) {
+        bt_list_foreach(sal_conn->calls, fill_call_info, &ctx);
+    }
+
+    if (count > HFP_CALL_LIST_MAX) {
+        BT_LOGW("%s, reached max call list size", __func__);
+    }
+
+    int ret = Z_API(bt_hfp_ag_ongoing_calls)(sal_conn->ag, calls, count, indicators, 4);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_ag_ongoing_calls failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_ag_dial_response(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_dial_response_param_t* params = (bt_hfp_ag_dial_response_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, NULL);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_ag_send_vendor failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_ag_cops_response(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_cops_response_param_t* params = (bt_hfp_ag_cops_response_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_ag_set_operator)(sal_conn->ag, 0, params->operator_name);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_ag_set_operator failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_ag_device_status(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_device_status_param_t* params = (bt_hfp_ag_device_status_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+    uint8_t net_val;
+    uint8_t roam_val;
+    uint8_t sig_val;
+    uint8_t bat_val;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    net_val = params->network ? 1 : 0;
+    roam_val = params->roam ? 1 : 0;
+    sig_val = params->signal > 5 ? 5 : (uint8_t)params->signal;
+    bat_val = params->battery > 5 ? 5 : (uint8_t)params->battery;
+
+    if (net_val != sal_conn->indicators.network) {
+        int ret = Z_API(bt_hfp_ag_service_availability)(sal_conn->ag, params->network ? true : false);
+        if (ret) {
+            BT_LOGE("%s, bt_hfp_ag_service_availability failed, ret=%d", __func__, ret);
+        }
+        sal_conn->indicators.network = net_val;
+    }
+
+    if (roam_val != sal_conn->indicators.roam) {
+        int ret = Z_API(bt_hfp_ag_roaming_status)(sal_conn->ag, params->roam ? 1 : 0);
+        if (ret) {
+            BT_LOGE("%s, bt_hfp_ag_roaming_status failed, ret=%d", __func__, ret);
+        }
+        sal_conn->indicators.roam = roam_val;
+    }
+
+    if (sig_val != sal_conn->indicators.signal) {
+        int ret = Z_API(bt_hfp_ag_signal_strength)(sal_conn->ag, sig_val);
+        if (ret) {
+            BT_LOGE("%s, bt_hfp_ag_signal_strength failed, ret=%d", __func__, ret);
+        }
+        sal_conn->indicators.signal = sig_val;
+    }
+
+    if (bat_val != sal_conn->indicators.battery) {
+        int ret = Z_API(bt_hfp_ag_battery_level)(sal_conn->ag, bat_val);
+        if (ret) {
+            BT_LOGE("%s, bt_hfp_ag_battery_level failed, ret=%d", __func__, ret);
+        }
+        sal_conn->indicators.battery = bat_val;
+    }
+
+    free(params);
+}
+
+static void do_ag_inband_ring(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_inband_ring_param_t* params = (bt_hfp_ag_inband_ring_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_ag_inband_ringtone)(sal_conn->ag, params->enable);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_ag_inband_ringtone failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_ag_send_at_cmd(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_send_at_cmd_param_t* params = (bt_hfp_ag_send_at_cmd_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, params->line);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_ag_send_vendor failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_ag_error_response(service_work_t* work, void* userdata)
+{
+    bt_hfp_ag_error_response_param_t* params = (bt_hfp_ag_error_response_param_t*)userdata;
+    bt_hfp_ag_connection_t* sal_conn;
+    const char* line;
+    char buf[32] = { 0 };
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->ag) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    if (params->result >= HFP_ATCMD_RESULT_CMEERR) {
+        enum bt_at_cme cme = hfp_at_result_to_cme(params->result);
+        snprintf(buf, sizeof(buf), "+CME ERROR:%d", (int)cme);
+        line = buf;
+    } else if (params->result == HFP_ATCMD_RESULT_OK) {
+        line = NULL;
+    } else {
+        line = "ERROR";
+    }
+
+    int ret = Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, line);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_ag_send_vendor failed, ret=%d", __func__, ret);
     }
 
     free(params);
@@ -1450,7 +1794,21 @@ bt_status_t bt_sal_hfp_ag_start_voice_recognition(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_voice_recognition)(sal_conn->ag, true), 0);
+    bt_hfp_ag_voice_recognition_param_t* params = zalloc(sizeof(bt_hfp_ag_voice_recognition_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->activate = true;
+
+    if (!service_loop_work(params, do_ag_voice_recognition, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1462,7 +1820,21 @@ bt_status_t bt_sal_hfp_ag_stop_voice_recognition(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_voice_recognition)(sal_conn->ag, false), 0);
+    bt_hfp_ag_voice_recognition_param_t* params = zalloc(sizeof(bt_hfp_ag_voice_recognition_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->activate = false;
+
+    if (!service_loop_work(params, do_ag_voice_recognition, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1786,74 +2158,32 @@ bt_status_t bt_sal_hfp_ag_call_sync(bt_address_t* bd_addr,
     return BT_STATUS_SUCCESS;
 }
 
-typedef struct {
-    struct bt_hfp_ag_ongoing_call* calls;
-    size_t* count;
-} call_list_context_t;
-
-static void fill_call_info(void* data, void* context)
-{
-    bt_hfp_ag_call_info_t* sal_call = (bt_hfp_ag_call_info_t*)data;
-    call_list_context_t* ctx = (call_list_context_t*)context;
-
-    if (*(ctx->count) >= HFP_CALL_LIST_MAX) {
-        return;
-    }
-
-    ctx->calls[*(ctx->count)].dir = sal_call->dir;
-    ctx->calls[*(ctx->count)].status = sal_call->state;
-    ctx->calls[*(ctx->count)].type = sal_call->type;
-    strlcpy(ctx->calls[*(ctx->count)].number, sal_call->number, sizeof(ctx->calls[*(ctx->count)].number));
-    (*(ctx->count))++;
-}
-
 bt_status_t bt_sal_hfp_ag_cind_response(bt_address_t* addr, hfp_ag_cind_resopnse_t* response)
 {
-    bt_hfp_ag_connection_t* sal_conn;
-    struct bt_hfp_ag_ongoing_call calls[HFP_CALL_LIST_MAX];
-    struct bt_hfp_ag_indicator_value indicators[4] = { 0 };
-    size_t count = 0;
-
     if (!addr || !response) {
         return BT_STATUS_PARM_INVALID;
     }
 
-    sal_conn = find_connection_by_addr(addr);
+    bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_FAIL;
     }
 
-    sal_conn->indicators.network = response->network ? 1 : 0;
-    sal_conn->indicators.roam = response->roam ? 1 : 0;
-    sal_conn->indicators.signal = response->signal > 5 ? 5 : (uint8_t)response->signal;
-    sal_conn->indicators.battery = response->battery > 5 ? 5 : (uint8_t)response->battery;
-
-    indicators[0].indicator = BT_HFP_AG_SERVICE_IND;
-    indicators[0].value = sal_conn->indicators.network;
-    indicators[1].indicator = BT_HFP_AG_ROAM_IND;
-    indicators[1].value = sal_conn->indicators.roam;
-    indicators[2].indicator = BT_HFP_AG_SIGNAL_IND;
-    indicators[2].value = sal_conn->indicators.signal;
-    indicators[3].indicator = BT_HFP_AG_BATTERY_IND;
-    indicators[3].value = sal_conn->indicators.battery;
-
-    memset(calls, 0, sizeof(calls));
-
-    call_list_context_t ctx = {
-        .calls = calls,
-        .count = &count
-    };
-
-    if (sal_conn->calls) {
-        bt_list_foreach(sal_conn->calls, fill_call_info, &ctx);
+    bt_hfp_ag_cind_response_param_t* params = zalloc(sizeof(bt_hfp_ag_cind_response_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    if (count > HFP_CALL_LIST_MAX) {
-        BT_LOGW("%s, reached max call list size", __func__);
-    }
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    memcpy(&params->response, response, sizeof(hfp_ag_cind_resopnse_t));
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_ongoing_calls)(sal_conn->ag, calls, count, indicators, 4), 0);
+    if (!service_loop_work(params, do_ag_cind_response, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
 
     return BT_STATUS_SUCCESS;
 }
@@ -1875,84 +2205,94 @@ bt_status_t bt_sal_hfp_ag_clcc_response(bt_address_t* addr, uint32_t index,
 
 bt_status_t bt_sal_hfp_ag_dial_response(bt_address_t* addr, hfp_atcmd_result_t result)
 {
-    bt_hfp_ag_connection_t* sal_conn;
     if (!addr) {
         return BT_STATUS_PARM_INVALID;
     }
 
-    sal_conn = find_connection_by_addr(addr);
-
+    bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, NULL), 0);
+    bt_hfp_ag_dial_response_param_t* params = zalloc(sizeof(bt_hfp_ag_dial_response_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+
+    if (!service_loop_work(params, do_ag_dial_response, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
 
     return BT_STATUS_SUCCESS;
 }
 
 bt_status_t bt_sal_hfp_ag_cops_response(bt_address_t* addr, const char* operator_name, uint16_t length)
 {
-    bt_hfp_ag_connection_t* sal_conn;
     (void)length;
 
     if (!addr || !operator_name) {
         return BT_STATUS_PARM_INVALID;
     }
 
-    sal_conn = find_connection_by_addr(addr);
+    bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_set_operator)(sal_conn->ag, 0, (char*)operator_name), 0);
+    bt_hfp_ag_cops_response_param_t* params = zalloc(sizeof(bt_hfp_ag_cops_response_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    strlcpy(params->operator_name, operator_name, sizeof(params->operator_name));
+
+    if (!service_loop_work(params, do_ag_cops_response, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
 bt_status_t bt_sal_hfp_ag_notify_device_status_changed(bt_address_t* addr, hfp_network_state_t network,
     hfp_roaming_state_t roam, uint8_t signal, uint8_t battery)
 {
-    bt_hfp_ag_connection_t* sal_conn;
-    uint8_t net_val;
-    uint8_t roam_val;
-    uint8_t sig_val;
-    uint8_t bat_val;
-
     if (!addr) {
         return BT_STATUS_PARM_INVALID;
     }
 
-    sal_conn = find_connection_by_addr(addr);
+    bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    net_val = network ? 1 : 0;
-    roam_val = roam ? 1 : 0;
-    sig_val = signal > 5 ? 5 : (uint8_t)signal;
-    bat_val = battery > 5 ? 5 : (uint8_t)battery;
-
-    if (net_val != sal_conn->indicators.network) {
-        SAL_CHECK_RET(Z_API(bt_hfp_ag_service_availability)(sal_conn->ag, network ? true : false), 0);
-        sal_conn->indicators.network = net_val;
+    bt_hfp_ag_device_status_param_t* params = zalloc(sizeof(bt_hfp_ag_device_status_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    if (roam_val != sal_conn->indicators.roam) {
-        SAL_CHECK_RET(Z_API(bt_hfp_ag_roaming_status)(sal_conn->ag, roam ? 1 : 0), 0);
-        sal_conn->indicators.roam = roam_val;
-    }
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->network = network;
+    params->roam = roam;
+    params->signal = signal;
+    params->battery = battery;
 
-    if (sig_val != sal_conn->indicators.signal) {
-        SAL_CHECK_RET(Z_API(bt_hfp_ag_signal_strength)(sal_conn->ag, sig_val), 0);
-        sal_conn->indicators.signal = sig_val;
-    }
-
-    if (bat_val != sal_conn->indicators.battery) {
-        SAL_CHECK_RET(Z_API(bt_hfp_ag_battery_level)(sal_conn->ag, bat_val), 0);
-        sal_conn->indicators.battery = bat_val;
+    if (!service_loop_work(params, do_ag_device_status, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
     }
 
     return BT_STATUS_SUCCESS;
@@ -1960,19 +2300,31 @@ bt_status_t bt_sal_hfp_ag_notify_device_status_changed(bt_address_t* addr, hfp_n
 
 bt_status_t bt_sal_hfp_ag_set_inband_ring_enable(bt_address_t* addr, bool enable)
 {
-    bt_hfp_ag_connection_t* sal_conn;
-
     if (!addr) {
         return BT_STATUS_PARM_INVALID;
     }
 
-    sal_conn = find_connection_by_addr(addr);
+    bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_ag_inband_ringtone)(sal_conn->ag, enable), 0);
+    bt_hfp_ag_inband_ring_param_t* params = zalloc(sizeof(bt_hfp_ag_inband_ring_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->enable = enable;
+
+    if (!service_loop_work(params, do_ag_inband_ring, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -2065,17 +2417,15 @@ static enum bt_at_cme hfp_at_result_to_cme(hfp_atcmd_result_t result)
 
 bt_status_t bt_sal_hfp_ag_send_at_cmd(bt_address_t* addr, const char* atcmd, uint16_t length)
 {
-    bt_hfp_ag_connection_t* sal_conn;
     const char* start;
     const char* end;
     size_t line_len;
-    char* line;
 
     if (!addr || !atcmd || length == 0) {
         return BT_STATUS_PARM_INVALID;
     }
 
-    sal_conn = find_connection_by_addr(addr);
+    bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
@@ -2102,24 +2452,23 @@ bt_status_t bt_sal_hfp_ag_send_at_cmd(bt_address_t* addr, const char* atcmd, uin
         return BT_STATUS_PARM_INVALID;
     }
 
-    line = (char*)malloc(line_len + 1);
-    if (!line) {
-        BT_LOGE("%s, failed to allocate memory for AT command", __func__);
+    bt_hfp_ag_send_at_cmd_param_t* params = zalloc(sizeof(bt_hfp_ag_send_at_cmd_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
         return BT_STATUS_NOMEM;
     }
 
-    strlcpy(line, start, line_len + 1);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    strlcpy(params->line, start, line_len + 1);
 
-    BT_LOGD("%s, send vendor rsp: %s", __func__, line);
+    BT_LOGD("%s, send vendor rsp: %s", __func__, params->line);
 
-    int ret = Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, line);
-
-    free(line);
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    if (!service_loop_work(params, do_ag_send_at_cmd, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
     }
 
-    SAL_CHECK_RET(ret, 0);
     return BT_STATUS_SUCCESS;
 }
 
@@ -2143,35 +2492,30 @@ bt_status_t bt_sal_hfp_ag_model_id_response(bt_address_t* addr, const char* mode
 
 bt_status_t bt_sal_hfp_ag_error_response(bt_address_t* addr, hfp_atcmd_result_t result)
 {
-    bt_hfp_ag_connection_t* sal_conn;
-    const char* line;
-    char buf[32] = { 0 };
-
     if (!addr) {
         return BT_STATUS_PARM_INVALID;
     }
 
-    sal_conn = find_connection_by_addr(addr);
+    bt_hfp_ag_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn || !sal_conn->ag) {
         BT_LOGE("%s, connection not found", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    if (result >= HFP_ATCMD_RESULT_CMEERR) {
-        enum bt_at_cme cme = hfp_at_result_to_cme(result);
-        snprintf(buf, sizeof(buf), "+CME ERROR:%d", (int)cme);
-        line = buf;
-    } else if (result == HFP_ATCMD_RESULT_OK) {
-        line = NULL;
-    } else {
-        line = "ERROR";
+    bt_hfp_ag_error_response_param_t* params = zalloc(sizeof(bt_hfp_ag_error_response_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    int ret = Z_API(bt_hfp_ag_send_vendor)(sal_conn->ag, line);
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->result = result;
+
+    if (!service_loop_work(params, do_ag_error_response, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
     }
 
-    SAL_CHECK_RET(ret, 0);
     return BT_STATUS_SUCCESS;
 }

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -26,6 +26,7 @@
 #include "service_loop.h"
 #include <errno.h>
 #include <inttypes.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -38,6 +39,17 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 
 static bt_list_t* g_sal_hf_conn_list = NULL;
+static pthread_mutex_t g_sal_hf_conn_lock;
+
+static void conn_list_lock(void)
+{
+    pthread_mutex_lock(&g_sal_hf_conn_lock);
+}
+
+static void conn_list_unlock(void)
+{
+    pthread_mutex_unlock(&g_sal_hf_conn_lock);
+}
 
 extern struct net_buf_pool sdp_pool;
 
@@ -272,10 +284,13 @@ static bt_hfp_hf_connection_t* find_connection_by_call_context(
 {
     bt_list_node_t* node;
 
-    if (!g_sal_hf_conn_list || !z_context) {
+    if (!z_context) {
         return NULL;
     }
 
+    if (!g_sal_hf_conn_list) {
+        return NULL;
+    }
     for (node = bt_list_head(g_sal_hf_conn_list); node != NULL; node = bt_list_next(g_sal_hf_conn_list, node)) {
         bt_hfp_hf_connection_t* conn = bt_list_node(node);
 
@@ -297,7 +312,10 @@ static bt_hfp_hf_connection_t* find_connection_by_call_context(
 
 static inline bt_hfp_hf_connection_t* find_connection_by_context(struct bt_conn* conn)
 {
-    if (!g_sal_hf_conn_list || !conn) {
+    if (!conn) {
+        return NULL;
+    }
+    if (!g_sal_hf_conn_list) {
         return NULL;
     }
     return (bt_hfp_hf_connection_t*)bt_list_find(g_sal_hf_conn_list, sal_conn_context_cmp, conn);
@@ -305,7 +323,10 @@ static inline bt_hfp_hf_connection_t* find_connection_by_context(struct bt_conn*
 
 static inline bt_hfp_hf_connection_t* find_connection_by_addr(bt_address_t* addr)
 {
-    if (!g_sal_hf_conn_list || !addr) {
+    if (!addr) {
+        return NULL;
+    }
+    if (!g_sal_hf_conn_list) {
         return NULL;
     }
     return (bt_hfp_hf_connection_t*)bt_list_find(g_sal_hf_conn_list, sal_conn_addr_cmp, addr);
@@ -313,7 +334,10 @@ static inline bt_hfp_hf_connection_t* find_connection_by_addr(bt_address_t* addr
 
 static inline bt_hfp_hf_connection_t* find_connection_by_hf(struct bt_hfp_hf* hf)
 {
-    if (!g_sal_hf_conn_list || !hf) {
+    if (!hf) {
+        return NULL;
+    }
+    if (!g_sal_hf_conn_list) {
         return NULL;
     }
     return (bt_hfp_hf_connection_t*)bt_list_find(g_sal_hf_conn_list, sal_conn_hf_cmp, hf);
@@ -323,10 +347,13 @@ static bt_hfp_hf_connection_t* find_connection_by_sco(struct bt_conn* sco)
 {
     bt_list_node_t* node;
 
-    if (!g_sal_hf_conn_list || !sco) {
+    if (!sco) {
         return NULL;
     }
 
+    if (!g_sal_hf_conn_list) {
+        return NULL;
+    }
     for (node = bt_list_head(g_sal_hf_conn_list); node != NULL; node = bt_list_next(g_sal_hf_conn_list, node)) {
         bt_hfp_hf_connection_t* conn = bt_list_node(node);
         if (conn && conn->sco_conn == sco) {
@@ -392,8 +419,10 @@ static bt_status_t do_hf_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(addr);
     if (sal_conn != NULL) {
+        conn_list_unlock();
         BT_LOGI("%s, Connection already exists, skip", __func__);
         return BT_STATUS_SUCCESS;
     }
@@ -401,6 +430,7 @@ static bt_status_t do_hf_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
     conn = bt_conn_lookup_addr_br((bt_addr_t*)addr);
     /** Remeber to unref @p conn once SLC is initiated or cancelled */
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to lookup connection", __func__);
         hfp_hf_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
         bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
@@ -409,12 +439,14 @@ static bt_status_t do_hf_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
 
     sal_conn = new_hf_connection(conn, NULL);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, could not create new hf connection", __func__);
         hfp_hf_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
         bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
         bt_conn_unref(conn);
         return BT_STATUS_NOMEM;
     }
+    conn_list_unlock();
 
     BT_LOGD("%s, do sdp discover", __func__);
     if (bt_sdp_discover(conn, &sdp_discover) < 0) {
@@ -422,7 +454,9 @@ static bt_status_t do_hf_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
         hfp_hf_on_connection_state_changed(addr, PROFILE_STATE_DISCONNECTED, 0, 0);
         bt_sal_cm_profile_disconnected_callback(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
         bt_conn_unref(conn);
+        conn_list_lock();
         bt_list_remove(g_sal_hf_conn_list, sal_conn);
+        conn_list_unlock();
         return BT_STATUS_FAIL;
     }
 
@@ -432,13 +466,17 @@ static bt_status_t do_hf_sdp_discover(bt_controller_id_t id, bt_address_t* addr,
 
 bt_status_t do_hf_disconnect(bt_controller_id_t id, bt_address_t* addr, void* user_data)
 {
+    struct bt_hfp_hf* hf;
+
     if (!addr) {
         BT_LOGE("%s, addr is NULL", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
         bt_addr_ba2str(addr, addr_str);
         BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
@@ -448,10 +486,13 @@ bt_status_t do_hf_disconnect(bt_controller_id_t id, bt_address_t* addr, void* us
     if (!sal_conn->hf) {
         BT_LOGI("%s, HFP HF not connected", __func__);
         bt_list_remove(g_sal_hf_conn_list, sal_conn);
+        conn_list_unlock();
         return BT_STATUS_SUCCESS;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    SAL_CHECK_RET(Z_API(bt_hfp_hf_disconnect)(sal_conn->hf), 0);
+    SAL_CHECK_RET(Z_API(bt_hfp_hf_disconnect)(hf), 0);
     return BT_STATUS_SUCCESS;
 }
 
@@ -459,6 +500,7 @@ static void do_hf_sco_disconnect(service_work_t* work, void* userdata)
 {
     struct bt_conn* sco_conn = (struct bt_conn*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    bt_address_t addr;
     int err;
 
     if (!sco_conn) {
@@ -466,17 +508,26 @@ static void do_hf_sco_disconnect(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_sco(sco_conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, sco_conn no longer tracked, skip disconnect", __func__);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     err = bt_conn_disconnect(sco_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
     if (err) {
-        sal_conn->sco_conn = NULL;
+        conn_list_lock();
+        sal_conn = find_connection_by_sco(sco_conn);
+        if (sal_conn) {
+            sal_conn->sco_conn = NULL;
+        }
+        conn_list_unlock();
         BT_LOGE("%s, Failed to disconnect HFP HF SCO, err=%d", __func__, err);
-        hfp_hf_on_audio_connection_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_DISCONNECTED, 0);
+        hfp_hf_on_audio_connection_state_changed(&addr, HFP_AUDIO_STATE_DISCONNECTED, 0);
     }
 }
 
@@ -484,6 +535,7 @@ static void do_hf_sco_connect(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_connection_t* sal_conn;
     struct bt_hfp_hf* hf = (struct bt_hfp_hf*)userdata;
+    bt_address_t addr;
     int err;
 
     if (!hf) {
@@ -491,19 +543,23 @@ static void do_hf_sco_connect(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_hf(hf);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, hf no longer tracked, skip connect", __func__);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     err = Z_API(bt_hfp_hf_audio_connect)(hf);
     if (err == -EALREADY) {
         BT_LOGW("%s, Audio already connected", __func__);
-        hfp_hf_on_audio_connection_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_CONNECTED, 0);
+        hfp_hf_on_audio_connection_state_changed(&addr, HFP_AUDIO_STATE_CONNECTED, 0);
     } else if (err) {
         BT_LOGE("%s, Failed to connect HFP HF SCO, err=%d", __func__, err);
-        hfp_hf_on_audio_connection_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_DISCONNECTED, 0);
+        hfp_hf_on_audio_connection_state_changed(&addr, HFP_AUDIO_STATE_DISCONNECTED, 0);
     }
 }
 
@@ -511,6 +567,7 @@ static void do_hf_set_volume(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_set_volume_param_t* params = (bt_hfp_hf_set_volume_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
     int ret;
 
     if (!params) {
@@ -518,19 +575,23 @@ static void do_hf_set_volume(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available, skip set volume", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
     switch (params->type) {
     case HFP_VOLUME_TYPE_MIC:
-        ret = Z_API(bt_hfp_hf_vgm)(sal_conn->hf, params->gain);
+        ret = Z_API(bt_hfp_hf_vgm)(hf, params->gain);
         break;
     case HFP_VOLUME_TYPE_SPK:
-        ret = Z_API(bt_hfp_hf_vgs)(sal_conn->hf, params->gain);
+        ret = Z_API(bt_hfp_hf_vgs)(hf, params->gain);
         break;
     default:
         BT_LOGE("%s, Unknown volume type: %d", __func__, params->type);
@@ -549,14 +610,17 @@ static void do_hf_answer_call(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf_call* call_context;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
@@ -564,12 +628,15 @@ static void do_hf_answer_call(service_work_t* work, void* userdata)
 
     bt_hfp_hf_call_info_t* incoming = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_INCOMING);
     if (!incoming) {
+        conn_list_unlock();
         BT_LOGE("%s, No incoming call to answer", __func__);
         free(params);
         return;
     }
+    call_context = incoming->context;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_accept)(incoming->context);
+    int ret = Z_API(bt_hfp_hf_accept)(call_context);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_accept failed, ret=%d", __func__, ret);
     }
@@ -581,14 +648,17 @@ static void do_hf_reject_call(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf_call* call_context;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
@@ -596,12 +666,15 @@ static void do_hf_reject_call(service_work_t* work, void* userdata)
 
     bt_hfp_hf_call_info_t* incoming_call = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_INCOMING);
     if (!incoming_call) {
+        conn_list_unlock();
         BT_LOGE("%s, No incoming call to reject", __func__);
         free(params);
         return;
     }
+    call_context = incoming_call->context;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_reject)(incoming_call->context);
+    int ret = Z_API(bt_hfp_hf_reject)(call_context);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_reject failed, ret=%d", __func__, ret);
     }
@@ -613,20 +686,25 @@ static void do_hf_hold_call(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_hold_active_accept_other)(sal_conn->hf);
+    int ret = Z_API(bt_hfp_hf_hold_active_accept_other)(hf);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_hold_active_accept_other failed, ret=%d", __func__, ret);
     }
@@ -638,14 +716,19 @@ static void do_hf_hangup_call(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf_call* target_context;
+    struct bt_hfp_hf* hf;
+    int call_count;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
@@ -660,16 +743,22 @@ static void do_hf_hangup_call(service_work_t* work, void* userdata)
     }
 
     if (!target) {
+        conn_list_unlock();
         BT_LOGE("%s, No active/dialing/alerting call to hang up", __func__);
         free(params);
         return;
     }
 
+    target_context = target->context;
+    hf = sal_conn->hf;
+    call_count = count_call(sal_conn);
+    conn_list_unlock();
+
     int ret;
-    if (count_call(sal_conn) == 1) {
-        ret = Z_API(bt_hfp_hf_terminate)(target->context);
+    if (call_count == 1) {
+        ret = Z_API(bt_hfp_hf_terminate)(target_context);
     } else {
-        ret = Z_API(bt_hfp_hf_release_active_accept_other)(sal_conn->hf);
+        ret = Z_API(bt_hfp_hf_release_active_accept_other)(hf);
     }
 
     if (ret) {
@@ -683,24 +772,29 @@ static void do_hf_dial_number(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_dial_number_param_t* params = (bt_hfp_hf_dial_number_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
     int ret;
     if (!params->has_number) {
-        ret = Z_API(bt_hfp_hf_redial)(sal_conn->hf);
+        ret = Z_API(bt_hfp_hf_redial)(hf);
     } else {
-        ret = Z_API(bt_hfp_hf_number_call)(sal_conn->hf, params->number);
+        ret = Z_API(bt_hfp_hf_number_call)(hf, params->number);
     }
 
     if (ret) {
@@ -714,20 +808,25 @@ static void do_hf_dial_memory(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_dial_memory_param_t* params = (bt_hfp_hf_dial_memory_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_memory_dial)(sal_conn->hf, params->mem_in_str);
+    int ret = Z_API(bt_hfp_hf_memory_dial)(hf, params->mem_in_str);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_memory_dial failed, ret=%d", __func__, ret);
     }
@@ -739,30 +838,37 @@ static void do_hf_call_control(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_call_control_param_t* params = (bt_hfp_hf_call_control_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
 
     int ret = -ENOTSUP;
     switch (params->chld) {
     case HFP_HF_CALL_CONTROL_CHLD_0: {
         bt_hfp_hf_call_info_t* waiting = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_WAITING);
         if (waiting) {
-            ret = Z_API(bt_hfp_hf_set_udub)(sal_conn->hf);
+            conn_list_unlock();
+            ret = Z_API(bt_hfp_hf_set_udub)(hf);
         } else {
             bt_hfp_hf_call_info_t* held = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_HELD);
             if (held) {
-                ret = Z_API(bt_hfp_hf_release_all_held)(sal_conn->hf);
+                conn_list_unlock();
+                ret = Z_API(bt_hfp_hf_release_all_held)(hf);
             } else {
+                conn_list_unlock();
                 BT_LOGW("%s, No waiting/held call for CHLD=0", __func__);
             }
         }
@@ -772,35 +878,46 @@ static void do_hf_call_control(service_work_t* work, void* userdata)
         if (params->index > 0) {
             bt_hfp_hf_call_info_t* by_idx = find_call_by_index(sal_conn, (uint8_t)params->index);
             if (!by_idx) {
+                conn_list_unlock();
                 BT_LOGE("%s, No call with index %u for CHLD=1<idx>", __func__, (unsigned)params->index);
                 free(params);
                 return;
             }
-            ret = Z_API(bt_hfp_hf_release_specified_call)(by_idx->context);
+            struct bt_hfp_hf_call* call_ctx = by_idx->context;
+            conn_list_unlock();
+            ret = Z_API(bt_hfp_hf_release_specified_call)(call_ctx);
         } else {
-            ret = Z_API(bt_hfp_hf_release_active_accept_other)(sal_conn->hf);
+            conn_list_unlock();
+            ret = Z_API(bt_hfp_hf_release_active_accept_other)(hf);
         }
         break;
     case HFP_HF_CALL_CONTROL_CHLD_2:
         if (params->index > 0) {
             bt_hfp_hf_call_info_t* by_idx = find_call_by_index(sal_conn, (uint8_t)params->index);
             if (!by_idx) {
+                conn_list_unlock();
                 BT_LOGE("%s, No call with index %u for CHLD=2<idx>", __func__, (unsigned)params->index);
                 free(params);
                 return;
             }
-            ret = Z_API(bt_hfp_hf_private_consultation_mode)(by_idx->context);
+            struct bt_hfp_hf_call* call_ctx = by_idx->context;
+            conn_list_unlock();
+            ret = Z_API(bt_hfp_hf_private_consultation_mode)(call_ctx);
         } else {
-            ret = Z_API(bt_hfp_hf_hold_active_accept_other)(sal_conn->hf);
+            conn_list_unlock();
+            ret = Z_API(bt_hfp_hf_hold_active_accept_other)(hf);
         }
         break;
     case HFP_HF_CALL_CONTROL_CHLD_3:
-        ret = Z_API(bt_hfp_hf_join_conversation)(sal_conn->hf);
+        conn_list_unlock();
+        ret = Z_API(bt_hfp_hf_join_conversation)(hf);
         break;
     case HFP_HF_CALL_CONTROL_CHLD_4:
-        ret = Z_API(bt_hfp_hf_explicit_call_transfer)(sal_conn->hf);
+        conn_list_unlock();
+        ret = Z_API(bt_hfp_hf_explicit_call_transfer)(hf);
         break;
     default:
+        conn_list_unlock();
         BT_LOGE("%s, unsupported CHLD=%d", __func__, params->chld);
         break;
     }
@@ -816,20 +933,25 @@ static void do_hf_get_current_calls(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_query_list_of_current_calls)(sal_conn->hf);
+    int ret = Z_API(bt_hfp_hf_query_list_of_current_calls)(hf);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_query_list_of_current_calls failed, ret=%d", __func__, ret);
     }
@@ -841,20 +963,25 @@ static void do_hf_voice_recognition(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_voice_recognition_param_t* params = (bt_hfp_hf_voice_recognition_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_voice_recognition)(sal_conn->hf, params->activate);
+    int ret = Z_API(bt_hfp_hf_voice_recognition)(hf, params->activate);
     if (ret) {
         BT_LOGE("%s, Failed to %s voice recognition, ret=%d", __func__,
             params->activate ? "start" : "stop", ret);
@@ -867,20 +994,25 @@ static void do_hf_send_battery_level(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_battery_level_param_t* params = (bt_hfp_hf_battery_level_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_battery)(sal_conn->hf, params->level);
+    int ret = Z_API(bt_hfp_hf_battery)(hf, params->level);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_battery failed, ret=%d", __func__, ret);
     }
@@ -892,20 +1024,25 @@ static void do_hf_send_at_cmd(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_send_at_cmd_param_t* params = (bt_hfp_hf_send_at_cmd_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_send_vendor)(sal_conn->hf, params->cmd);
+    int ret = Z_API(bt_hfp_hf_send_vendor)(hf, params->cmd);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_send_vendor failed, ret=%d", __func__, ret);
     }
@@ -917,14 +1054,17 @@ static void do_hf_send_dtmf(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_send_dtmf_param_t* params = (bt_hfp_hf_send_dtmf_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf_call* active_context;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
@@ -932,12 +1072,15 @@ static void do_hf_send_dtmf(service_work_t* work, void* userdata)
 
     bt_hfp_hf_call_info_t* active = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_ACTIVE);
     if (!active) {
+        conn_list_unlock();
         BT_LOGE("%s, No active call for DTMF", __func__);
         free(params);
         return;
     }
+    active_context = active->context;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_transmit_dtmf_code)(active->context, params->dtmf);
+    int ret = Z_API(bt_hfp_hf_transmit_dtmf_code)(active_context, params->dtmf);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_transmit_dtmf_code failed, ret=%d", __func__, ret);
     }
@@ -949,20 +1092,25 @@ static void do_hf_get_subscriber_number(service_work_t* work, void* userdata)
 {
     bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
+    struct bt_hfp_hf* hf;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_addr(&params->addr);
     if (!sal_conn || !sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGW("%s, connection no longer available", __func__);
         free(params);
         return;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    int ret = Z_API(bt_hfp_hf_query_subscriber)(sal_conn->hf);
+    int ret = Z_API(bt_hfp_hf_query_subscriber)(hf);
     if (ret) {
         BT_LOGE("%s, bt_hfp_hf_query_subscriber failed, ret=%d", __func__, ret);
     }
@@ -975,6 +1123,7 @@ static void do_hf_slc_connect(service_work_t* work, void* userdata)
     bt_hfp_hf_slc_connect_param_t* params = (bt_hfp_hf_slc_connect_param_t*)userdata;
     bt_hfp_hf_connection_t* sal_conn;
     struct bt_hfp_hf* hf = NULL;
+    bt_address_t addr;
 
     if (!params) {
         BT_LOGE("%s, params is NULL", __func__);
@@ -987,8 +1136,10 @@ static void do_hf_slc_connect(service_work_t* work, void* userdata)
         return;
     }
 
+    conn_list_lock();
     sal_conn = find_connection_by_context(params->conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, no pending connection found for conn", __func__);
         bt_conn_unref(params->conn);
         free(params);
@@ -996,11 +1147,14 @@ static void do_hf_slc_connect(service_work_t* work, void* userdata)
     }
 
     if (sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGD("%s, already initiating SLC, skip SLC initiating", __func__);
         bt_conn_unref(params->conn);
         free(params);
         return;
     }
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     BT_LOGD("%s, SLC initiating", __func__);
     if (Z_API(bt_hfp_hf_connect)(params->conn, &hf, params->channel)) {
@@ -1008,11 +1162,17 @@ static void do_hf_slc_connect(service_work_t* work, void* userdata)
         goto error;
     }
 
+    conn_list_lock();
+    sal_conn = find_connection_by_context(params->conn);
+    if (sal_conn) {
+        sal_conn->hf = hf;
+    }
+    conn_list_unlock();
+
     bt_conn_unref(params->conn);
-    sal_conn->hf = hf;
     free(params);
 
-    hfp_hf_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_CONNECTING, 0, 0);
+    hfp_hf_on_connection_state_changed(&addr, PROFILE_STATE_CONNECTING, 0, 0);
 
     BT_LOGD("%s, HFP HF connecting", __func__);
     return;
@@ -1020,17 +1180,22 @@ static void do_hf_slc_connect(service_work_t* work, void* userdata)
 error:
     bt_conn_unref(params->conn);
     free(params);
-    hfp_hf_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_DISCONNECTED, 0, 0);
-    bt_sal_cm_profile_disconnected_callback(&sal_conn->addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
+    hfp_hf_on_connection_state_changed(&addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+    bt_sal_cm_profile_disconnected_callback(&addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
+    conn_list_lock();
     bt_list_remove(g_sal_hf_conn_list, sal_conn);
+    conn_list_unlock();
     return;
 }
 
 static void zblue_on_sdp_disconnected(struct bt_conn* conn, const struct bt_sdp_discover_params* params)
 {
     bt_address_t bd_addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_context(conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, no pending connection found", __func__);
         return;
     }
@@ -1038,6 +1203,8 @@ static void zblue_on_sdp_disconnected(struct bt_conn* conn, const struct bt_sdp_
 
     BT_LOGW("%s, SDP disconnected during discovery", __func__);
     bt_list_remove(g_sal_hf_conn_list, sal_conn);
+    conn_list_unlock();
+
     hfp_hf_on_connection_state_changed(&bd_addr, PROFILE_STATE_DISCONNECTED, 0, 0);
     bt_sal_cm_profile_disconnected_callback(&bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
 }
@@ -1049,12 +1216,16 @@ static uint8_t zblue_on_sdp_done(struct bt_conn* conn, struct bt_sdp_client_resu
     uint16_t port;
     bt_address_t bd_addr;
     bt_hfp_hf_slc_connect_param_t* params;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_context(conn);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, could not find sal_conn", __func__);
         return BT_SDP_DISCOVER_UUID_STOP;
     }
     memcpy(&bd_addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     if (!result) {
         BT_LOGE("%s, remote device does not support HFP AG feature", __func__);
@@ -1094,7 +1265,9 @@ static uint8_t zblue_on_sdp_done(struct bt_conn* conn, struct bt_sdp_client_resu
     return BT_SDP_DISCOVER_UUID_STOP;
 
 error:
+    conn_list_lock();
     bt_list_remove(g_sal_hf_conn_list, sal_conn);
+    conn_list_unlock();
     hfp_hf_on_connection_state_changed(&bd_addr, PROFILE_STATE_DISCONNECTED, 0, 0);
     bt_sal_cm_profile_disconnected_callback(&bd_addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
     return BT_SDP_DISCOVER_UUID_STOP;
@@ -1103,12 +1276,15 @@ error:
 static void zblue_on_connected(struct bt_conn* conn, struct bt_hfp_hf* hf)
 {
     bt_hfp_hf_connection_t* sal_conn;
+    bt_address_t addr;
 
+    conn_list_lock();
     sal_conn = find_connection_by_context(conn);
     if (!sal_conn) {
         BT_LOGD("%s, hf connection incoming", __func__);
         sal_conn = new_hf_connection(conn, hf);
         if (!sal_conn) {
+            conn_list_unlock();
             BT_LOGE("%s, Failed to create HFP HF connection", __func__);
             if (Z_API(bt_hfp_hf_disconnect)(hf)) {
                 BT_LOGE("%s, Failed to disconnect HFP HF connection", __func__);
@@ -1116,103 +1292,146 @@ static void zblue_on_connected(struct bt_conn* conn, struct bt_hfp_hf* hf)
             return;
         }
 
-        hfp_hf_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_CONNECTING, 0, 0);
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
+        hfp_hf_on_connection_state_changed(&addr, PROFILE_STATE_CONNECTING, 0, 0);
     } else {
         /* Override conn if both sides attempt to connect at the same time */
         sal_conn->conn = conn;
         sal_conn->hf = hf;
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
     }
 
-    bt_sal_cm_profile_connected_callback(&sal_conn->addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
-    bt_sal_profile_disconnect_register(&sal_conn->addr, PROFILE_HFP_HF, CONN_ID_DEFAULT, PRIMARY_ADAPTER, do_hf_disconnect, NULL);
+    bt_sal_cm_profile_connected_callback(&addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
+    bt_sal_profile_disconnect_register(&addr, PROFILE_HFP_HF, CONN_ID_DEFAULT, PRIMARY_ADAPTER, do_hf_disconnect, NULL);
 
-    hfp_hf_on_connection_state_changed(&sal_conn->addr, PROFILE_STATE_CONNECTED, 0, 0);
+    hfp_hf_on_connection_state_changed(&addr, PROFILE_STATE_CONNECTED, 0, 0);
 }
 
 static void zblue_hf_disconnected(struct bt_hfp_hf* hf)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
 
-    hfp_hf_on_connection_state_changed(&conn->addr, PROFILE_STATE_DISCONNECTING, 0, 0);
-    hfp_hf_on_connection_state_changed(&conn->addr, PROFILE_STATE_DISCONNECTED, 0, 0);
-    bt_sal_cm_profile_disconnected_callback(&conn->addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
 
     bt_list_remove(g_sal_hf_conn_list, conn);
+    conn_list_unlock();
+
+    hfp_hf_on_connection_state_changed(&addr, PROFILE_STATE_DISCONNECTING, 0, 0);
+    hfp_hf_on_connection_state_changed(&addr, PROFILE_STATE_DISCONNECTED, 0, 0);
+    bt_sal_cm_profile_disconnected_callback(&addr, PROFILE_HFP_HF, CONN_ID_DEFAULT);
 }
 
 static void zblue_on_sco_connected(struct bt_hfp_hf* hf, struct bt_conn* sco_conn)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection for SCO", __func__);
         return;
     }
 
     conn->sco_conn = sco_conn;
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_hf_on_audio_connection_state_changed(&conn->addr, HFP_AUDIO_STATE_CONNECTED, 0);
+    hfp_hf_on_audio_connection_state_changed(&addr, HFP_AUDIO_STATE_CONNECTED, 0);
 }
 
 static void zblue_on_sco_disconnected(struct bt_conn* sco_conn, uint8_t reason)
 {
+    bt_address_t addr;
     (void)reason;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_sco(sco_conn);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGW("%s, Failed to find connection for SCO disconn", __func__);
         return;
     }
 
-    hfp_hf_on_audio_connection_state_changed(&conn->addr, HFP_AUDIO_STATE_DISCONNECTED, 0);
-
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
     conn->sco_conn = NULL;
+    conn_list_unlock();
+
+    hfp_hf_on_audio_connection_state_changed(&addr, HFP_AUDIO_STATE_DISCONNECTED, 0);
 }
 
 static void zblue_on_outgoing_call(struct bt_hfp_hf* hf, struct bt_hfp_hf_call* call)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_hf(hf);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
 
     bt_hfp_hf_call_info_t* sal_call = find_or_create_call(sal_conn, call);
     if (!sal_call) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to track outgoing call", __func__);
         return;
     }
 
     set_call_state(sal_conn, sal_call, HFP_HF_CALL_STATE_DIALING);
-    hfp_hf_on_call_setup_state_changed(&sal_conn->addr, HFP_CALLSETUP_OUTGOING);
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    hfp_hf_on_call_setup_state_changed(&addr, HFP_CALLSETUP_OUTGOING);
 }
 
 static void zblue_on_incoming_call(struct bt_hfp_hf* hf, struct bt_hfp_hf_call* call)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_hf(hf);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
 
     bt_hfp_hf_call_info_t* sal_call = find_or_create_call(sal_conn, call);
     if (!sal_call) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to track incoming call", __func__);
         return;
     }
 
     set_call_state(sal_conn, sal_call, HFP_HF_CALL_STATE_INCOMING);
-    hfp_hf_on_call_setup_state_changed(&sal_conn->addr, HFP_CALLSETUP_INCOMING);
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    hfp_hf_on_call_setup_state_changed(&addr, HFP_CALLSETUP_INCOMING);
 }
 
 static void zblue_on_remote_ringing(struct bt_hfp_hf_call* call)
 {
     bt_hfp_hf_call_info_t* sal_call = NULL;
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_call_context(call, &sal_call);
 
     if (!conn) {
+        conn_list_unlock();
         BT_LOGW("%s, Failed to find connection for remote ringing", __func__);
         return;
     }
@@ -1220,109 +1439,155 @@ static void zblue_on_remote_ringing(struct bt_hfp_hf_call* call)
     if (sal_call) {
         set_call_state(conn, sal_call, HFP_HF_CALL_STATE_ALERTING);
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_hf_on_call_setup_state_changed(&conn->addr, HFP_CALLSETUP_ALERTING);
+    hfp_hf_on_call_setup_state_changed(&addr, HFP_CALLSETUP_ALERTING);
 }
 
 static void zblue_on_call_accept(struct bt_hfp_hf_call* call)
 {
     bt_hfp_hf_call_info_t* sal_call = NULL;
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_call_context(call, &sal_call);
 
     if (!conn || !sal_call) {
+        conn_list_unlock();
         BT_LOGW("%s, Failed to find call to accept", __func__);
         return;
     }
 
     set_call_state(conn, sal_call, HFP_HF_CALL_STATE_ACTIVE);
-    hfp_hf_on_call_active_state_changed(&conn->addr, HFP_CALL_CALLS_IN_PROGRESS);
-    hfp_hf_on_call_setup_state_changed(&conn->addr, HFP_CALLSETUP_NONE);
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    hfp_hf_on_call_active_state_changed(&addr, HFP_CALL_CALLS_IN_PROGRESS);
+    hfp_hf_on_call_setup_state_changed(&addr, HFP_CALLSETUP_NONE);
 }
 
 static void zblue_on_call_reject(struct bt_hfp_hf_call* call)
 {
     bt_hfp_hf_call_info_t* sal_call = NULL;
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_call_context(call, &sal_call);
 
     if (!sal_conn || !sal_call) {
+        conn_list_unlock();
         BT_LOGW("%s, Failed to find call to reject", __func__);
         return;
     }
 
     remove_call(sal_conn, sal_call);
-    hfp_hf_on_call_setup_state_changed(&sal_conn->addr, HFP_CALLSETUP_NONE);
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    hfp_hf_on_call_setup_state_changed(&addr, HFP_CALLSETUP_NONE);
 }
 
 static void zblue_on_call_terminate(struct bt_hfp_hf_call* call)
 {
     bt_hfp_hf_call_info_t* sal_call = NULL;
+    bt_address_t addr;
+    hfp_hf_call_state_t prev_state;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_call_context(call, &sal_call);
 
     if (!sal_conn || !sal_call) {
+        conn_list_unlock();
         BT_LOGW("%s, Failed to find call to terminate", __func__);
         return;
     }
 
-    if (sal_call->state == HFP_HF_CALL_STATE_ACTIVE) {
-        hfp_hf_on_call_active_state_changed(&sal_conn->addr, HFP_CALL_NO_CALLS_IN_PROGRESS);
-    } else if (sal_call->state == HFP_HF_CALL_STATE_HELD) {
-        hfp_hf_on_call_held_state_changed(&sal_conn->addr, HFP_CALLHELD_NONE);
-    } else {
-        BT_LOGW("Unknow previous state %d.", sal_call->state);
-    }
-
+    prev_state = sal_call->state;
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
     remove_call(sal_conn, sal_call);
+    conn_list_unlock();
+
+    if (prev_state == HFP_HF_CALL_STATE_ACTIVE) {
+        hfp_hf_on_call_active_state_changed(&addr, HFP_CALL_NO_CALLS_IN_PROGRESS);
+    } else if (prev_state == HFP_HF_CALL_STATE_HELD) {
+        hfp_hf_on_call_held_state_changed(&addr, HFP_CALLHELD_NONE);
+    } else {
+        BT_LOGW("Unknow previous state %d.", prev_state);
+    }
 }
 
 static void zblue_on_call_held(struct bt_hfp_hf_call* call)
 {
     bt_hfp_hf_call_info_t* sal_call = NULL;
+    bt_address_t addr;
+    hfp_hf_call_state_t prev_state;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_call_context(call, &sal_call);
 
     if (!sal_conn || !sal_call) {
+        conn_list_unlock();
         BT_LOGW("%s, Failed to find call to hold", __func__);
         return;
     }
 
-    hfp_hf_on_call_held_state_changed(&sal_conn->addr, HFP_CALLHELD_HELD);
-
-    if (sal_call->state == HFP_HF_CALL_STATE_ACTIVE) {
-        hfp_hf_on_call_active_state_changed(&sal_conn->addr, HFP_CALL_NO_CALLS_IN_PROGRESS);
-    } else {
-        BT_LOGW("Unexpected previous state %d.", sal_call->state);
-    }
-
+    prev_state = sal_call->state;
     set_call_state(sal_conn, sal_call, HFP_HF_CALL_STATE_HELD);
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    hfp_hf_on_call_held_state_changed(&addr, HFP_CALLHELD_HELD);
+
+    if (prev_state == HFP_HF_CALL_STATE_ACTIVE) {
+        hfp_hf_on_call_active_state_changed(&addr, HFP_CALL_NO_CALLS_IN_PROGRESS);
+    } else {
+        BT_LOGW("Unexpected previous state %d.", prev_state);
+    }
 }
 
 static void zblue_on_call_retrieve(struct bt_hfp_hf_call* call)
 {
     bt_hfp_hf_call_info_t* sal_call = NULL;
+    bt_address_t addr;
+    hfp_hf_call_state_t prev_state;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_call_context(call, &sal_call);
 
     if (!sal_conn || !sal_call) {
+        conn_list_unlock();
         BT_LOGW("%s, Failed to find call to retrieve", __func__);
         return;
     }
 
-    if (sal_call->state == HFP_HF_CALL_STATE_HELD) {
-        hfp_hf_on_call_held_state_changed(&sal_conn->addr, HFP_CALLHELD_NONE);
+    prev_state = sal_call->state;
+    set_call_state(sal_conn, sal_call, HFP_HF_CALL_STATE_ACTIVE);
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    if (prev_state == HFP_HF_CALL_STATE_HELD) {
+        hfp_hf_on_call_held_state_changed(&addr, HFP_CALLHELD_NONE);
     } else {
-        BT_LOGW("Unexpected previous state %d.", sal_call->state);
+        BT_LOGW("Unexpected previous state %d.", prev_state);
     }
 
-    hfp_hf_on_call_active_state_changed(&sal_conn->addr, HFP_CALL_CALLS_IN_PROGRESS);
-
-    set_call_state(sal_conn, sal_call, HFP_HF_CALL_STATE_ACTIVE);
+    hfp_hf_on_call_active_state_changed(&addr, HFP_CALL_CALLS_IN_PROGRESS);
 }
 
 static void zblue_on_subscriber_number(struct bt_hfp_hf* hf, const char* number, uint8_t type, uint8_t service)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     hfp_subscriber_number_service_t fw_service = 0;
     switch (service) {
@@ -1337,59 +1602,87 @@ static void zblue_on_subscriber_number(struct bt_hfp_hf* hf, const char* number,
         break;
     }
 
-    hfp_hf_on_subscriber_number_response(&conn->addr, number, fw_service);
+    hfp_hf_on_subscriber_number_response(&addr, number, fw_service);
 }
 
 static void zblue_on_vgm(struct bt_hfp_hf* hf, uint8_t gain)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_hf_on_volume_changed(&conn->addr, HFP_VOLUME_TYPE_MIC, gain);
+    hfp_hf_on_volume_changed(&addr, HFP_VOLUME_TYPE_MIC, gain);
 }
 
 static void zblue_on_vgs(struct bt_hfp_hf* hf, uint8_t gain)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_hf_on_volume_changed(&conn->addr, HFP_VOLUME_TYPE_SPK, gain);
+    hfp_hf_on_volume_changed(&addr, HFP_VOLUME_TYPE_SPK, gain);
 }
 
 static void zblue_on_voice_recognition(struct bt_hfp_hf* hf, bool activate)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_hf_on_voice_recognition_state_changed(&conn->addr, activate);
+    hfp_hf_on_voice_recognition_state_changed(&addr, activate);
 }
 
 static void zblue_on_ring_indication(struct bt_hfp_hf_call* call)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_call_context(call, NULL);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGW("%s, Failed to find connection for ring", __func__);
         return;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_hf_on_ring_active_state_changed(&conn->addr, true, HFP_IN_BAND_RINGTONE_NOT_PROVIDED);
+    hfp_hf_on_ring_active_state_changed(&addr, true, HFP_IN_BAND_RINGTONE_NOT_PROVIDED);
 }
 
 static void zblue_on_clip(struct bt_hfp_hf_call* call, char* number, uint8_t type)
 {
     bt_hfp_hf_call_info_t* sal_call = NULL;
     const char* num = number ? number : "";
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_call_context(call, &sal_call);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection for CLIP", __func__);
         return;
     }
@@ -1397,17 +1690,25 @@ static void zblue_on_clip(struct bt_hfp_hf_call* call, char* number, uint8_t typ
     if (sal_call) {
         sal_call->type = type;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
-    hfp_hf_on_clip(&conn->addr, num, "");
+    hfp_hf_on_clip(&addr, num, "");
 }
 
 static void zblue_on_vendor_specific(struct bt_hfp_hf* hf, const char* cmd, const char* value)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection for vendor specific response", __func__);
         return;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     if (!cmd || !value) {
         return;
@@ -1424,7 +1725,7 @@ static void zblue_on_vendor_specific(struct bt_hfp_hf* hf, const char* cmd, cons
     }
 
     snprintf(rsp, len + 1, "+%s:%s", cmd, value);
-    hfp_hf_on_received_at_cmd_resp(&conn->addr, rsp, len);
+    hfp_hf_on_received_at_cmd_resp(&addr, rsp, len);
     free(rsp);
 }
 
@@ -1447,25 +1748,37 @@ static hfp_atcmd_code_t zblue_at_cmd_to_service_cmd(
 static void zblue_on_at_cmd_complete(struct bt_hfp_hf* hf, enum bt_hfp_hf_at_cmd cmd,
     enum bt_at_result result, enum bt_at_cme err)
 {
+    bt_address_t addr;
     BT_LOGD("%s, AT cmd complete: cmd=%d, result=%d, err=%d", __func__, cmd, result, err);
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection for AT cmd complete", __func__);
         return;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     uint32_t result_code = result == BT_AT_RESULT_CME_ERROR ? err : result;
 
-    hfp_hf_on_at_command_result_response(&conn->addr, zblue_at_cmd_to_service_cmd(cmd), result_code);
+    hfp_hf_on_at_command_result_response(&addr, zblue_at_cmd_to_service_cmd(cmd), result_code);
 }
 
 static void zblue_on_codec_negotiate(struct bt_hfp_hf* hf, uint8_t id)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* conn = find_connection_by_hf(hf);
     if (!conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
+    memcpy(&addr, &conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
 
     int ret = Z_API(bt_hfp_hf_select_codec)(hf, id);
     if (ret) {
@@ -1487,20 +1800,26 @@ static void zblue_on_codec_negotiate(struct bt_hfp_hf* hf, uint8_t id)
         break;
     }
 
-    hfp_hf_on_codec_changed(&conn->addr, &cfg);
+    hfp_hf_on_codec_changed(&addr, &cfg);
 }
 
 static void zblue_on_current_call(struct bt_hfp_hf* hf, struct bt_hfp_hf_current_call* call)
 {
+    bt_address_t addr;
+
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_hf(hf);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return;
     }
 
     if (!call) {
-        BT_ADDR_LOG("CLCC finished from %s", &sal_conn->addr);
-        hfp_hf_on_current_call_response(&sal_conn->addr, 0, 0, 0, 0, NULL, 0);
+        memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+        conn_list_unlock();
+        BT_ADDR_LOG("CLCC finished from %s", &addr);
+        hfp_hf_on_current_call_response(&addr, 0, 0, 0, 0, NULL, 0);
         return;
     }
 
@@ -1552,10 +1871,15 @@ static void zblue_on_current_call(struct bt_hfp_hf* hf, struct bt_hfp_hf_current
 
     hfp_call_mpty_type_t mpty = call->multiparty ? HFP_CALL_MPTY_TYPE_MULTI : HFP_CALL_MPTY_TYPE_SINGLE;
 
-    sal_call->index = idx;
-    sal_call->state = status;
+    if (sal_call) {
+        sal_call->index = idx;
+        sal_call->state = status;
+    }
 
-    hfp_hf_on_current_call_response(&sal_conn->addr, idx, dir, status, mpty, call->number, call->type);
+    memcpy(&addr, &sal_conn->addr, sizeof(bt_address_t));
+    conn_list_unlock();
+
+    hfp_hf_on_current_call_response(&addr, idx, dir, status, mpty, call->number, call->type);
 }
 
 static struct bt_hfp_hf_cb hf_callbacks = {
@@ -1597,16 +1921,24 @@ static struct bt_hfp_hf_cb hf_callbacks = {
 
 bt_status_t bt_sal_hfp_hf_init(uint32_t hf_features, uint8_t max_connection)
 {
+    pthread_mutexattr_t attr;
+
     (void)hf_features;
     (void)max_connection;
     int err;
     g_sal_hf_conn_list = bt_list_new(free_connection);
+
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&g_sal_hf_conn_lock, &attr);
+    pthread_mutexattr_destroy(&attr);
 
     err = Z_API(bt_hfp_hf_register)(&hf_callbacks);
 
     if (err) {
         bt_list_free(g_sal_hf_conn_list);
         g_sal_hf_conn_list = NULL;
+        pthread_mutex_destroy(&g_sal_hf_conn_lock);
     }
 
     SAL_CHECK_RET(err, 0);
@@ -1619,10 +1951,13 @@ void bt_sal_hfp_hf_cleanup(void)
         BT_LOGE("%s, Failed to unregister HFP HF callbacks", __func__);
     }
 
+    conn_list_lock();
     if (g_sal_hf_conn_list) {
         bt_list_free(g_sal_hf_conn_list);
         g_sal_hf_conn_list = NULL;
     }
+    conn_list_unlock();
+    pthread_mutex_destroy(&g_sal_hf_conn_lock);
 
     return;
 }
@@ -1634,11 +1969,14 @@ bt_status_t bt_sal_hfp_hf_connect(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (sal_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, Connection already exists or in progress", __func__);
         return BT_STATUS_BUSY;
     }
+    conn_list_unlock();
 
     return bt_sal_profile_connect_request(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT, 0, do_hf_sdp_discover, NULL);
 }
@@ -1650,13 +1988,16 @@ bt_status_t bt_sal_hfp_hf_disconnect(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
         bt_addr_ba2str(addr, addr_str);
         BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
         return BT_STATUS_FAIL;
     }
+    conn_list_unlock();
 
     return bt_sal_profile_disconnect_request(addr, PROFILE_HFP_HF, CONN_ID_DEFAULT, 0, do_hf_disconnect, NULL);
 }
@@ -1664,25 +2005,31 @@ bt_status_t bt_sal_hfp_hf_disconnect(bt_address_t* addr)
 bt_status_t bt_sal_hfp_hf_connect_audio(bt_address_t* addr)
 {
     char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
+    struct bt_hfp_hf* hf;
     if (!addr) {
         BT_LOGE("%s, addr is NULL", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         bt_addr_ba2str(addr, addr_str);
         BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
         return BT_STATUS_FAIL;
     }
 
     if (!sal_conn->hf) {
+        conn_list_unlock();
         bt_addr_ba2str(addr, addr_str);
         BT_LOGE("%s, connection is initializing for address: %s", __func__, addr_str);
         return BT_STATUS_NOT_READY;
     }
+    hf = sal_conn->hf;
+    conn_list_unlock();
 
-    if (!service_loop_work(sal_conn->hf, do_hf_sco_connect, NULL)) {
+    if (!service_loop_work(hf, do_hf_sco_connect, NULL)) {
         BT_LOGE("%s, service loop work submit failed.", __func__);
         return BT_STATUS_FAIL;
     }
@@ -1692,13 +2039,16 @@ bt_status_t bt_sal_hfp_hf_connect_audio(bt_address_t* addr)
 
 bt_status_t bt_sal_hfp_hf_disconnect_audio(bt_address_t* addr)
 {
+    struct bt_conn* sco_conn;
     if (!addr) {
         BT_LOGE("%s, addr is NULL", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
         bt_addr_ba2str(addr, addr_str);
         BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
@@ -1706,11 +2056,14 @@ bt_status_t bt_sal_hfp_hf_disconnect_audio(bt_address_t* addr)
     }
 
     if (!sal_conn->sco_conn) {
+        conn_list_unlock();
         BT_LOGW("%s, SCO not connected", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    sco_conn = sal_conn->sco_conn;
+    conn_list_unlock();
 
-    if (!service_loop_work(sal_conn->sco_conn, do_hf_sco_disconnect, NULL)) {
+    if (!service_loop_work(sco_conn, do_hf_sco_disconnect, NULL)) {
         BT_LOGE("%s, service loop work submit failed.", __func__);
         return BT_STATUS_FAIL;
     }
@@ -1725,11 +2078,14 @@ bt_status_t bt_sal_hfp_hf_answer_call(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
     if (!params) {
@@ -1755,11 +2111,14 @@ bt_status_t bt_sal_hfp_hf_reject_call(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_FAIL;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
     if (!params) {
@@ -1785,11 +2144,14 @@ bt_status_t bt_sal_hfp_hf_hold_call(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_FAIL;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
     if (!params) {
@@ -1815,11 +2177,14 @@ bt_status_t bt_sal_hfp_hf_hangup_call(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_FAIL;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
     if (!params) {
@@ -1845,11 +2210,14 @@ bt_status_t bt_sal_hfp_hf_dial_number(bt_address_t* addr, const char* number)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_dial_number_param_t* params = zalloc(sizeof(bt_hfp_hf_dial_number_param_t));
     if (!params) {
@@ -1881,11 +2249,14 @@ bt_status_t bt_sal_hfp_hf_dial_memory(bt_address_t* addr, uint32_t memory)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_dial_memory_param_t* params = zalloc(sizeof(bt_hfp_hf_dial_memory_param_t));
     if (!params) {
@@ -1912,7 +2283,14 @@ bt_status_t bt_sal_hfp_hf_call_control(bt_address_t* addr, hfp_call_control_t ch
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
+    if (!sal_conn) {
+        conn_list_unlock();
+        BT_LOGE("%s, Failed to find connection", __func__);
+        return BT_STATUS_PARM_INVALID;
+    }
+    conn_list_unlock();
     if (!sal_conn) {
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
@@ -1944,11 +2322,14 @@ bt_status_t bt_sal_hfp_hf_get_current_calls(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
     if (!params) {
@@ -1974,8 +2355,10 @@ bt_status_t bt_sal_hfp_hf_set_volume(bt_address_t* addr, hfp_volume_type_t type,
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
         bt_addr_ba2str(addr, addr_str);
         BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
@@ -1983,9 +2366,11 @@ bt_status_t bt_sal_hfp_hf_set_volume(bt_address_t* addr, hfp_volume_type_t type,
     }
 
     if (!sal_conn->hf) {
+        conn_list_unlock();
         BT_LOGE("%s, connection is not ready", __func__);
         return BT_STATUS_NOT_READY;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_set_volume_param_t* params = zalloc(sizeof(bt_hfp_hf_set_volume_param_t));
     if (!params) {
@@ -2013,11 +2398,14 @@ bt_status_t bt_sal_hfp_hf_start_voice_recognition(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_voice_recognition_param_t* params = zalloc(sizeof(bt_hfp_hf_voice_recognition_param_t));
     if (!params) {
@@ -2044,11 +2432,14 @@ bt_status_t bt_sal_hfp_hf_stop_voice_recognition(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_voice_recognition_param_t* params = zalloc(sizeof(bt_hfp_hf_voice_recognition_param_t));
     if (!params) {
@@ -2075,11 +2466,14 @@ bt_status_t bt_sal_hfp_hf_send_battery_level(bt_address_t* addr, uint8_t value)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_battery_level_param_t* params = zalloc(sizeof(bt_hfp_hf_battery_level_param_t));
     if (!params) {
@@ -2106,11 +2500,14 @@ bt_status_t bt_sal_hfp_hf_send_at_cmd(bt_address_t* addr, const char* cmd, uint1
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     if (!cmd || len == 0) {
         BT_LOGE("%s, Invalid AT command", __func__);
@@ -2144,11 +2541,14 @@ bt_status_t bt_sal_hfp_hf_send_dtmf(bt_address_t* addr, char dtmf)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_send_dtmf_param_t* params = zalloc(sizeof(bt_hfp_hf_send_dtmf_param_t));
     if (!params) {
@@ -2175,11 +2575,14 @@ bt_status_t bt_sal_hfp_hf_get_subscriber_number(bt_address_t* addr)
         return BT_STATUS_PARM_INVALID;
     }
 
+    conn_list_lock();
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
+        conn_list_unlock();
         BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
+    conn_list_unlock();
 
     bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
     if (!params) {

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -63,6 +63,47 @@ typedef struct _bt_hfp_hf_set_volume_param {
     uint8_t gain;
 } bt_hfp_hf_set_volume_param_t;
 
+typedef struct _bt_hfp_hf_simple_addr_param {
+    bt_address_t addr;
+} bt_hfp_hf_simple_addr_param_t;
+
+typedef struct _bt_hfp_hf_call_control_param {
+    bt_address_t addr;
+    hfp_call_control_t chld;
+    uint32_t index;
+} bt_hfp_hf_call_control_param_t;
+
+typedef struct _bt_hfp_hf_dial_number_param {
+    bt_address_t addr;
+    char number[HFP_PHONENUM_DIGITS_MAX + 1];
+    bool has_number;
+} bt_hfp_hf_dial_number_param_t;
+
+typedef struct _bt_hfp_hf_dial_memory_param {
+    bt_address_t addr;
+    char mem_in_str[HFP_PHONENUM_DIGITS_MAX + 1];
+} bt_hfp_hf_dial_memory_param_t;
+
+typedef struct _bt_hfp_hf_voice_recognition_param {
+    bt_address_t addr;
+    bool activate;
+} bt_hfp_hf_voice_recognition_param_t;
+
+typedef struct _bt_hfp_hf_battery_level_param {
+    bt_address_t addr;
+    uint8_t level;
+} bt_hfp_hf_battery_level_param_t;
+
+typedef struct _bt_hfp_hf_send_at_cmd_param {
+    bt_address_t addr;
+    char cmd[HFP_AT_LEN_MAX + 1];
+} bt_hfp_hf_send_at_cmd_param_t;
+
+typedef struct _bt_hfp_hf_send_dtmf_param {
+    bt_address_t addr;
+    char dtmf;
+} bt_hfp_hf_send_dtmf_param_t;
+
 typedef struct _bt_hfp_hf_call_info {
     uint8_t index;
     uint8_t type;
@@ -499,6 +540,431 @@ static void do_hf_set_volume(service_work_t* work, void* userdata)
 
     if (ret) {
         BT_LOGE("%s, Failed to set volume, type=%d, ret=%d", __func__, params->type, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_answer_call(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    bt_hfp_hf_call_info_t* incoming = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_INCOMING);
+    if (!incoming) {
+        BT_LOGE("%s, No incoming call to answer", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_accept)(incoming->context);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_accept failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_reject_call(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    bt_hfp_hf_call_info_t* incoming_call = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_INCOMING);
+    if (!incoming_call) {
+        BT_LOGE("%s, No incoming call to reject", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_reject)(incoming_call->context);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_reject failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_hold_call(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_hold_active_accept_other)(sal_conn->hf);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_hold_active_accept_other failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_hangup_call(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    bt_hfp_hf_call_info_t* target = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_ACTIVE);
+    if (!target) {
+        target = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_DIALING);
+    }
+    if (!target) {
+        target = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_ALERTING);
+    }
+
+    if (!target) {
+        BT_LOGE("%s, No active/dialing/alerting call to hang up", __func__);
+        free(params);
+        return;
+    }
+
+    int ret;
+    if (count_call(sal_conn) == 1) {
+        ret = Z_API(bt_hfp_hf_terminate)(target->context);
+    } else {
+        ret = Z_API(bt_hfp_hf_release_active_accept_other)(sal_conn->hf);
+    }
+
+    if (ret) {
+        BT_LOGE("%s, hangup failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_dial_number(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_dial_number_param_t* params = (bt_hfp_hf_dial_number_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret;
+    if (!params->has_number) {
+        ret = Z_API(bt_hfp_hf_redial)(sal_conn->hf);
+    } else {
+        ret = Z_API(bt_hfp_hf_number_call)(sal_conn->hf, params->number);
+    }
+
+    if (ret) {
+        BT_LOGE("%s, dial failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_dial_memory(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_dial_memory_param_t* params = (bt_hfp_hf_dial_memory_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_memory_dial)(sal_conn->hf, params->mem_in_str);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_memory_dial failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_call_control(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_call_control_param_t* params = (bt_hfp_hf_call_control_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = -ENOTSUP;
+    switch (params->chld) {
+    case HFP_HF_CALL_CONTROL_CHLD_0: {
+        bt_hfp_hf_call_info_t* waiting = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_WAITING);
+        if (waiting) {
+            ret = Z_API(bt_hfp_hf_set_udub)(sal_conn->hf);
+        } else {
+            bt_hfp_hf_call_info_t* held = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_HELD);
+            if (held) {
+                ret = Z_API(bt_hfp_hf_release_all_held)(sal_conn->hf);
+            } else {
+                BT_LOGW("%s, No waiting/held call for CHLD=0", __func__);
+            }
+        }
+        break;
+    }
+    case HFP_HF_CALL_CONTROL_CHLD_1:
+        if (params->index > 0) {
+            bt_hfp_hf_call_info_t* by_idx = find_call_by_index(sal_conn, (uint8_t)params->index);
+            if (!by_idx) {
+                BT_LOGE("%s, No call with index %u for CHLD=1<idx>", __func__, (unsigned)params->index);
+                free(params);
+                return;
+            }
+            ret = Z_API(bt_hfp_hf_release_specified_call)(by_idx->context);
+        } else {
+            ret = Z_API(bt_hfp_hf_release_active_accept_other)(sal_conn->hf);
+        }
+        break;
+    case HFP_HF_CALL_CONTROL_CHLD_2:
+        if (params->index > 0) {
+            bt_hfp_hf_call_info_t* by_idx = find_call_by_index(sal_conn, (uint8_t)params->index);
+            if (!by_idx) {
+                BT_LOGE("%s, No call with index %u for CHLD=2<idx>", __func__, (unsigned)params->index);
+                free(params);
+                return;
+            }
+            ret = Z_API(bt_hfp_hf_private_consultation_mode)(by_idx->context);
+        } else {
+            ret = Z_API(bt_hfp_hf_hold_active_accept_other)(sal_conn->hf);
+        }
+        break;
+    case HFP_HF_CALL_CONTROL_CHLD_3:
+        ret = Z_API(bt_hfp_hf_join_conversation)(sal_conn->hf);
+        break;
+    case HFP_HF_CALL_CONTROL_CHLD_4:
+        ret = Z_API(bt_hfp_hf_explicit_call_transfer)(sal_conn->hf);
+        break;
+    default:
+        BT_LOGE("%s, unsupported CHLD=%d", __func__, params->chld);
+        break;
+    }
+
+    if (ret) {
+        BT_LOGE("%s, call control failed, chld=%d, ret=%d", __func__, params->chld, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_get_current_calls(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_query_list_of_current_calls)(sal_conn->hf);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_query_list_of_current_calls failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_voice_recognition(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_voice_recognition_param_t* params = (bt_hfp_hf_voice_recognition_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_voice_recognition)(sal_conn->hf, params->activate);
+    if (ret) {
+        BT_LOGE("%s, Failed to %s voice recognition, ret=%d", __func__,
+            params->activate ? "start" : "stop", ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_send_battery_level(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_battery_level_param_t* params = (bt_hfp_hf_battery_level_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_battery)(sal_conn->hf, params->level);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_battery failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_send_at_cmd(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_send_at_cmd_param_t* params = (bt_hfp_hf_send_at_cmd_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_send_vendor)(sal_conn->hf, params->cmd);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_send_vendor failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_send_dtmf(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_send_dtmf_param_t* params = (bt_hfp_hf_send_dtmf_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    bt_hfp_hf_call_info_t* active = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_ACTIVE);
+    if (!active) {
+        BT_LOGE("%s, No active call for DTMF", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_transmit_dtmf_code)(active->context, params->dtmf);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_transmit_dtmf_code failed, ret=%d", __func__, ret);
+    }
+
+    free(params);
+}
+
+static void do_hf_get_subscriber_number(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_simple_addr_param_t* params = (bt_hfp_hf_simple_addr_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available", __func__);
+        free(params);
+        return;
+    }
+
+    int ret = Z_API(bt_hfp_hf_query_subscriber)(sal_conn->hf);
+    if (ret) {
+        BT_LOGE("%s, bt_hfp_hf_query_subscriber failed, ret=%d", __func__, ret);
     }
 
     free(params);
@@ -1261,19 +1727,24 @@ bt_status_t bt_sal_hfp_hf_answer_call(bt_address_t* addr)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    bt_hfp_hf_call_info_t* incoming = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_INCOMING);
-    if (!incoming) {
-        BT_LOGE("%s, No incoming call to answer", __func__);
-        return BT_STATUS_PARM_INVALID;
+    bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_hf_accept)(incoming->context), 0);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+
+    if (!service_loop_work(params, do_hf_answer_call, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1286,19 +1757,24 @@ bt_status_t bt_sal_hfp_hf_reject_call(bt_address_t* addr)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_FAIL;
     }
 
-    bt_hfp_hf_call_info_t* incoming_call = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_INCOMING);
-    if (!incoming_call) {
-        BT_LOGE("%s, No incoming call to reject", __func__);
+    bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+
+    if (!service_loop_work(params, do_hf_reject_call, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
         return BT_STATUS_FAIL;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_hf_reject)(incoming_call->context), 0);
     return BT_STATUS_SUCCESS;
 }
 
@@ -1311,18 +1787,24 @@ bt_status_t bt_sal_hfp_hf_hold_call(bt_address_t* addr)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_FAIL;
     }
 
-    int ret = Z_API(bt_hfp_hf_hold_active_accept_other)(sal_conn->hf);
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    SAL_CHECK_RET(ret, 0);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+
+    if (!service_loop_work(params, do_hf_hold_call, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1335,29 +1817,22 @@ bt_status_t bt_sal_hfp_hf_hangup_call(bt_address_t* addr)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_FAIL;
     }
 
-    bt_hfp_hf_call_info_t* target = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_ACTIVE);
-    if (!target) {
-        target = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_DIALING);
-    }
-    if (!target) {
-        target = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_ALERTING);
+    bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    if (!target) {
-        BT_LOGE("%s, No active/dialing/alerting call to hang up", __func__);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+
+    if (!service_loop_work(params, do_hf_hangup_call, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
         return BT_STATUS_FAIL;
-    }
-
-    if (count_call(sal_conn) == 1) {
-        SAL_CHECK_RET(Z_API(bt_hfp_hf_terminate)(target->context), 0);
-    } else {
-        SAL_CHECK_RET(Z_API(bt_hfp_hf_release_active_accept_other)(sal_conn->hf), 0);
     }
 
     return BT_STATUS_SUCCESS;
@@ -1372,18 +1847,30 @@ bt_status_t bt_sal_hfp_hf_dial_number(bt_address_t* addr, const char* number)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    if (!number) {
-        SAL_CHECK_RET(Z_API(bt_hfp_hf_redial)(sal_conn->hf), 0);
-        return BT_STATUS_SUCCESS;
+    bt_hfp_hf_dial_number_param_t* params = zalloc(sizeof(bt_hfp_hf_dial_number_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_hf_number_call)(sal_conn->hf, number), 0);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    if (number) {
+        strlcpy(params->number, number, sizeof(params->number));
+        params->has_number = true;
+    } else {
+        params->has_number = false;
+    }
+
+    if (!service_loop_work(params, do_hf_dial_number, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1395,16 +1882,26 @@ bt_status_t bt_sal_hfp_hf_dial_memory(bt_address_t* addr, uint32_t memory)
     }
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
-    char mem_in_str[HFP_PHONENUM_DIGITS_MAX + 1];
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    snprintf(mem_in_str, sizeof(mem_in_str), "%" PRIu32, memory);
-    SAL_CHECK_RET(Z_API(bt_hfp_hf_memory_dial)(sal_conn->hf, mem_in_str), 0);
+    bt_hfp_hf_dial_memory_param_t* params = zalloc(sizeof(bt_hfp_hf_dial_memory_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    snprintf(params->mem_in_str, sizeof(params->mem_in_str), "%" PRIu32, memory);
+
+    if (!service_loop_work(params, do_hf_dial_memory, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1417,68 +1914,26 @@ bt_status_t bt_sal_hfp_hf_call_control(bt_address_t* addr, hfp_call_control_t ch
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    int ret = -ENOTSUP;
-    switch (chld) {
-    case HFP_HF_CALL_CONTROL_CHLD_0: {
-        bt_hfp_hf_call_info_t* waiting = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_WAITING);
-        if (waiting) {
-            ret = Z_API(bt_hfp_hf_set_udub)(sal_conn->hf);
-        } else {
-            bt_hfp_hf_call_info_t* held = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_HELD);
-            if (held) {
-                ret = Z_API(bt_hfp_hf_release_all_held)(sal_conn->hf);
-            } else {
-                BT_LOGW("%s, No waiting/held call for CHLD=0", __func__);
-                return BT_STATUS_PARM_INVALID;
-            }
-        }
-        break;
-    }
-    case HFP_HF_CALL_CONTROL_CHLD_1:
-        if (index > 0) {
-            bt_hfp_hf_call_info_t* by_idx = find_call_by_index(sal_conn, (uint8_t)index);
-            if (!by_idx) {
-                BT_LOGE("%s, No call with index %u for CHLD=1<idx>", __func__, (unsigned)index);
-                return BT_STATUS_PARM_INVALID;
-            }
-            ret = Z_API(bt_hfp_hf_release_specified_call)(by_idx->context);
-        } else {
-            ret = Z_API(bt_hfp_hf_release_active_accept_other)(sal_conn->hf);
-        }
-        break;
-    case HFP_HF_CALL_CONTROL_CHLD_2:
-        if (index > 0) {
-            bt_hfp_hf_call_info_t* by_idx = find_call_by_index(sal_conn, (uint8_t)index);
-            if (!by_idx) {
-                BT_LOGE("%s, No call with index %u for CHLD=2<idx>", __func__, (unsigned)index);
-                return BT_STATUS_PARM_INVALID;
-            }
-            ret = Z_API(bt_hfp_hf_private_consultation_mode)(by_idx->context);
-        } else {
-            ret = Z_API(bt_hfp_hf_hold_active_accept_other)(sal_conn->hf);
-        }
-        break;
-    case HFP_HF_CALL_CONTROL_CHLD_3:
-        ret = Z_API(bt_hfp_hf_join_conversation)(sal_conn->hf);
-        break;
-    case HFP_HF_CALL_CONTROL_CHLD_4:
-        ret = Z_API(bt_hfp_hf_explicit_call_transfer)(sal_conn->hf);
-        break;
-    default:
-        return BT_STATUS_UNSUPPORTED;
+    bt_hfp_hf_call_control_param_t* params = zalloc(sizeof(bt_hfp_hf_call_control_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->chld = chld;
+    params->index = index;
+
+    if (!service_loop_work(params, do_hf_call_control, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
     }
 
-    SAL_CHECK_RET(ret, 0);
     return BT_STATUS_SUCCESS;
 }
 
@@ -1491,13 +1946,23 @@ bt_status_t bt_sal_hfp_hf_get_current_calls(bt_address_t* addr)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_hf_query_list_of_current_calls)(sal_conn->hf), 0);
+    bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+
+    if (!service_loop_work(params, do_hf_get_current_calls, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
 
     return BT_STATUS_SUCCESS;
 }
@@ -1550,18 +2015,25 @@ bt_status_t bt_sal_hfp_hf_start_voice_recognition(bt_address_t* addr)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    int ret = Z_API(bt_hfp_hf_voice_recognition)(sal_conn->hf, true);
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    bt_hfp_hf_voice_recognition_param_t* params = zalloc(sizeof(bt_hfp_hf_voice_recognition_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    SAL_CHECK_RET(ret, 0);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->activate = true;
+
+    if (!service_loop_work(params, do_hf_voice_recognition, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1574,18 +2046,25 @@ bt_status_t bt_sal_hfp_hf_stop_voice_recognition(bt_address_t* addr)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    int ret = Z_API(bt_hfp_hf_voice_recognition)(sal_conn->hf, false);
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    bt_hfp_hf_voice_recognition_param_t* params = zalloc(sizeof(bt_hfp_hf_voice_recognition_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    SAL_CHECK_RET(ret, 0);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->activate = false;
+
+    if (!service_loop_work(params, do_hf_voice_recognition, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1598,20 +2077,25 @@ bt_status_t bt_sal_hfp_hf_send_battery_level(bt_address_t* addr, uint8_t value)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    uint8_t level = (value > 100) ? 100 : value;
-
-    int ret = Z_API(bt_hfp_hf_battery)(sal_conn->hf, level);
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    bt_hfp_hf_battery_level_param_t* params = zalloc(sizeof(bt_hfp_hf_battery_level_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    SAL_CHECK_RET(ret, 0);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->level = (value > 100) ? 100 : value;
+
+    if (!service_loop_work(params, do_hf_send_battery_level, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1624,9 +2108,7 @@ bt_status_t bt_sal_hfp_hf_send_at_cmd(bt_address_t* addr, const char* cmd, uint1
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
@@ -1635,14 +2117,23 @@ bt_status_t bt_sal_hfp_hf_send_at_cmd(bt_address_t* addr, const char* cmd, uint1
         return BT_STATUS_PARM_INVALID;
     }
 
-    BT_LOGD("%s, Sending AT command: %.*s", __func__, len, cmd);
-
-    int ret = Z_API(bt_hfp_hf_send_vendor)(sal_conn->hf, cmd);
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    bt_hfp_hf_send_at_cmd_param_t* params = zalloc(sizeof(bt_hfp_hf_send_at_cmd_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    SAL_CHECK_RET(ret, 0);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    strlcpy(params->cmd, cmd, sizeof(params->cmd));
+
+    BT_LOGD("%s, Sending AT command: %.*s", __func__, len, cmd);
+
+    if (!service_loop_work(params, do_hf_send_at_cmd, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 
@@ -1655,24 +2146,25 @@ bt_status_t bt_sal_hfp_hf_send_dtmf(bt_address_t* addr, char dtmf)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    bt_hfp_hf_call_info_t* active = find_call_by_state(sal_conn, HFP_HF_CALL_STATE_ACTIVE);
-    if (!active) {
-        BT_LOGE("%s, No active call for DTMF", __func__);
-        return BT_STATUS_PARM_INVALID;
+    bt_hfp_hf_send_dtmf_param_t* params = zalloc(sizeof(bt_hfp_hf_send_dtmf_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    int ret = Z_API(bt_hfp_hf_transmit_dtmf_code)(active->context, dtmf);
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->dtmf = dtmf;
+
+    if (!service_loop_work(params, do_hf_send_dtmf, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
     }
 
-    SAL_CHECK_RET(ret, 0);
     return BT_STATUS_SUCCESS;
 }
 
@@ -1685,13 +2177,23 @@ bt_status_t bt_sal_hfp_hf_get_subscriber_number(bt_address_t* addr)
 
     bt_hfp_hf_connection_t* sal_conn = find_connection_by_addr(addr);
     if (!sal_conn) {
-        char addr_str[BT_ADDR_STR_LENGTH] = { 0 };
-        bt_addr_ba2str(addr, addr_str);
-        BT_LOGE("%s, Failed to find connection for address: %s", __func__, addr_str);
+        BT_LOGE("%s, Failed to find connection", __func__);
         return BT_STATUS_PARM_INVALID;
     }
 
-    SAL_CHECK_RET(Z_API(bt_hfp_hf_query_subscriber)(sal_conn->hf), 0);
+    bt_hfp_hf_simple_addr_param_t* params = zalloc(sizeof(bt_hfp_hf_simple_addr_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
+    }
+
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+
+    if (!service_loop_work(params, do_hf_get_subscriber_number, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
 
     return BT_STATUS_SUCCESS;
 }

--- a/service/stacks/zephyr/sal_hfp_hf_interface.c
+++ b/service/stacks/zephyr/sal_hfp_hf_interface.c
@@ -57,6 +57,12 @@ typedef struct _bt_hfp_hf_slc_connect_param {
     uint8_t channel;
 } bt_hfp_hf_slc_connect_param_t;
 
+typedef struct _bt_hfp_hf_set_volume_param {
+    bt_address_t addr;
+    hfp_volume_type_t type;
+    uint8_t gain;
+} bt_hfp_hf_set_volume_param_t;
+
 typedef struct _bt_hfp_hf_call_info {
     uint8_t index;
     uint8_t type;
@@ -458,6 +464,44 @@ static void do_hf_sco_connect(service_work_t* work, void* userdata)
         BT_LOGE("%s, Failed to connect HFP HF SCO, err=%d", __func__, err);
         hfp_hf_on_audio_connection_state_changed(&sal_conn->addr, HFP_AUDIO_STATE_DISCONNECTED, 0);
     }
+}
+
+static void do_hf_set_volume(service_work_t* work, void* userdata)
+{
+    bt_hfp_hf_set_volume_param_t* params = (bt_hfp_hf_set_volume_param_t*)userdata;
+    bt_hfp_hf_connection_t* sal_conn;
+    int ret;
+
+    if (!params) {
+        BT_LOGE("%s, params is NULL", __func__);
+        return;
+    }
+
+    sal_conn = find_connection_by_addr(&params->addr);
+    if (!sal_conn || !sal_conn->hf) {
+        BT_LOGW("%s, connection no longer available, skip set volume", __func__);
+        free(params);
+        return;
+    }
+
+    switch (params->type) {
+    case HFP_VOLUME_TYPE_MIC:
+        ret = Z_API(bt_hfp_hf_vgm)(sal_conn->hf, params->gain);
+        break;
+    case HFP_VOLUME_TYPE_SPK:
+        ret = Z_API(bt_hfp_hf_vgs)(sal_conn->hf, params->gain);
+        break;
+    default:
+        BT_LOGE("%s, Unknown volume type: %d", __func__, params->type);
+        free(params);
+        return;
+    }
+
+    if (ret) {
+        BT_LOGE("%s, Failed to set volume, type=%d, ret=%d", __func__, params->type, ret);
+    }
+
+    free(params);
 }
 
 static void do_hf_slc_connect(service_work_t* work, void* userdata)
@@ -1473,26 +1517,27 @@ bt_status_t bt_sal_hfp_hf_set_volume(bt_address_t* addr, hfp_volume_type_t type,
         return BT_STATUS_PARM_INVALID;
     }
 
-    uint8_t gain = volume > 15 ? 15 : volume;
-
-    int ret;
-    switch (type) {
-    case HFP_VOLUME_TYPE_MIC:
-        ret = Z_API(bt_hfp_hf_vgm)(sal_conn->hf, gain);
-        break;
-    case HFP_VOLUME_TYPE_SPK:
-        ret = Z_API(bt_hfp_hf_vgs)(sal_conn->hf, gain);
-        break;
-    default:
-        BT_LOGE("%s, Unknown volume type: %d", __func__, type);
-        return BT_STATUS_PARM_INVALID;
+    if (!sal_conn->hf) {
+        BT_LOGE("%s, connection is not ready", __func__);
+        return BT_STATUS_NOT_READY;
     }
 
-    if (ret == -ENOTSUP) {
-        return BT_STATUS_UNSUPPORTED;
+    bt_hfp_hf_set_volume_param_t* params = zalloc(sizeof(bt_hfp_hf_set_volume_param_t));
+    if (!params) {
+        BT_LOGE("%s, Failed to allocate params", __func__);
+        return BT_STATUS_NOMEM;
     }
 
-    SAL_CHECK_RET(ret, 0);
+    memcpy(&params->addr, addr, sizeof(bt_address_t));
+    params->type = type;
+    params->gain = volume > 15 ? 15 : volume;
+
+    if (!service_loop_work(params, do_hf_set_volume, NULL)) {
+        BT_LOGE("%s, service loop work submit failed", __func__);
+        free(params);
+        return BT_STATUS_FAIL;
+    }
+
     return BT_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
bug: v/87673

Rootcause: bt_sal_hfp_hf_set_volume and bt_sal_hfp_ag_set_volume directly call zblue API (bt_hfp_hf_vgm/vgs, bt_hfp_ag_vgm/vgs) in the caller's context. During volume adjustment stress testing on iOS calls, rapid consecutive invocations can cause deadlock. Move the actual zblue API calls into service_loop_work to serialize execution in the service loop, preventing concurrent access issues.


