### PR TITLE
adv: add on_advertising_terminated callback with bt_le_address_t

### DIFF
--- a/framework/include/bt_le_advertiser.h
+++ b/framework/include/bt_le_advertiser.h
@@ -98,46 +98,51 @@ typedef void bt_advertiser_t;
 /**
  * @brief Callback for advertising started notification.
  *
- * This callback is used to notify the application of the adverter handle, ID, and
- * start status of the advertiser. It will be triggered in the following cases:
- * 1. Advertiser ID allocates failed or the return value of the function "bt_sal_le_start_adv"
- *    is not "BT_STATUS_SUCCESS" within the advertiser starting event.
- * 2. 1 second after the successful notification of the start of LE advertising to the
- *    Bluetooth protocol stack.
+ * Always triggered to report the result of an advertising start attempt.
+ * - BT_ADV_STATUS_SUCCESS: protocol stack confirmed advertising started.
+ * - BT_ADV_STATUS_START_NOMEM: advertiser ID allocation failed.
+ * - BT_ADV_STATUS_STACK_ERR: bt_sal_le_start_adv returned an error.
+ * - BT_ADV_STATUS_START_TIMEOUT: protocol stack did not respond within 1 second.
  *
- * @param adv - Notifies the allocated Advertiser handle.
- * @param adv_id - Notifies the allocated Advertiser ID.
- * @param status - Notifies the starting status of the advertiser. BT_ADV_STATUS_SUCCESS
- *                 indicates that the advertiser has started successfully.
- *
- * **Example:**
- * @code
-void on_advertising_start(bt_advertiser_t* adv, uint8_t adv_id, uint8_t status)
-{
-    printf("on_advertising_start, adv_id: %d, status: %d\n", adv_id, status);
-}
- * @endcode
+ * @param adv - Advertiser handle.
+ * @param adv_id - Advertiser ID (0 on allocation failure).
+ * @param status - Starting status code.
  */
 typedef void (*on_advertising_start_cb_t)(bt_advertiser_t* adv, uint8_t adv_id, uint8_t status);
 
 /**
  * @brief Callback for advertising stopped notification.
  *
- * This callback is used to notify the application of the handle and ID corresponding to
- * the stopped advertising.
+ * Triggered when the Host explicitly stops advertising via bt_le_stop_advertising()
+ * or bt_le_stop_advertising_id(). This callback is mutually exclusive with
+ * on_advertising_terminated — they will never both fire for the same advertising set.
  *
  * @param adv - Advertiser handle.
  * @param adv_id - Advertiser ID.
- *
- * **Example:**
- * @code
-void on_advertising_stopped(bt_advertiser_t* adv, uint8_t adv_id)
-{
-    printf("on_advertising_stopped, adv_id: %d\n", adv_id);
-}
- * @endcode
  */
 typedef void (*on_advertising_stopped_cb_t)(bt_advertiser_t* adv, uint8_t adv_id);
+
+/**
+ * @brief Callback for advertising terminated notification.
+ *
+ * Triggered when the Controller autonomously terminates advertising. This happens
+ * in three cases defined by HCI LE Advertising Set Terminated event:
+ * - A connection is established (addr is non-NULL, carrying the peer address).
+ * - The advertising duration expires.
+ * - The maximum number of advertising events is reached.
+ *
+ * This callback is NOT triggered when the Host explicitly stops advertising.
+ * It is mutually exclusive with on_advertising_stopped.
+ *
+ * If this callback is not registered (NULL), the stack falls back to
+ * on_advertising_stopped for backward compatibility.
+ *
+ * @param adv - Advertiser handle.
+ * @param adv_id - Advertiser ID.
+ * @param addr - Peer BLE address (with address type) if terminated due to connection,
+ *               NULL if terminated due to duration/max events.
+ */
+typedef void (*on_advertising_terminated_cb_t)(bt_advertiser_t* adv, uint8_t adv_id, bt_le_address_t* addr);
 
 /**
  * @cond
@@ -151,6 +156,7 @@ typedef struct {
     uint32_t size;
     on_advertising_start_cb_t on_advertising_start;
     on_advertising_stopped_cb_t on_advertising_stopped;
+    on_advertising_terminated_cb_t on_advertising_terminated;
 } advertiser_callback_t;
 
 /* * BLE ADV Parameters */

--- a/service/ipc/socket/include/bt_message_advertiser.h
+++ b/service/ipc/socket/include/bt_message_advertiser.h
@@ -47,7 +47,8 @@ BT_ADVERTISER_MESSAGE_START,
 #define BT_IPC_CODE_COMMAND_BLE_ADVERTISER_END BT_IPC_CODE(BT_IPC_CODE_TYPE_COMMAND, BT_IPC_CODE_GROUP_BLE_ADVERTISER, BT_IPC_CODE_SUBCODE_MAX_NUM)
 
 #define BT_IPC_CODE_CALLBACK_BLE_ADVERTISER_BEGIN BT_IPC_CODE(BT_IPC_CODE_TYPE_CALLBACK, BT_IPC_CODE_GROUP_BLE_ADVERTISER, 0)
-// TODO: Add new BT IPC Code sequentially
+#define ADV_SUBCODE_CB_TERMINATED 1
+#define BT_LE_ON_ADVERTISER_TERMINATED BT_IPC_CODE(BT_IPC_CODE_TYPE_CALLBACK, BT_IPC_CODE_GROUP_BLE_ADVERTISER, ADV_SUBCODE_CB_TERMINATED)
 #define BT_IPC_CODE_CALLBACK_BLE_ADVERTISER_END BT_IPC_CODE(BT_IPC_CODE_TYPE_CALLBACK, BT_IPC_CODE_GROUP_BLE_ADVERTISER, BT_IPC_CODE_SUBCODE_MAX_NUM)
 
     typedef union {
@@ -57,11 +58,11 @@ BT_ADVERTISER_MESSAGE_START,
         uint64_t remote;
     } bt_advertiser_result_t;
 
-    typedef struct
-    {
+    typedef struct {
         bt_instance_t* ins;
         advertiser_callback_t* callbacks;
         uint64_t remote;
+        bool terminated_received;
     } bt_advertiser_remote_t;
 
     typedef union {
@@ -96,6 +97,13 @@ BT_ADVERTISER_MESSAGE_START,
             uint64_t adver;
             uint8_t adv_id;
         } _on_advertising_stopped;
+
+        struct {
+            uint64_t adver;
+            uint8_t adv_id;
+            bool has_addr;
+            bt_le_address_t addr;
+        } _on_advertising_terminated;
     } bt_message_advertiser_callbacks_t;
 
 #ifdef __cplusplus

--- a/service/ipc/socket/src/bt_socket_advertiser.c
+++ b/service/ipc/socket/src/bt_socket_advertiser.c
@@ -34,6 +34,7 @@
 #include <sys/un.h>
 
 #include "bt_internal.h"
+#include "utils/log.h"
 
 #include "advertising.h"
 #include "bluetooth.h"
@@ -82,10 +83,38 @@ static void on_advertising_stopped_cb(bt_advertiser_t* adv, uint8_t adv_id)
     free(adv);
 }
 
+static void on_advertising_terminated_cb(bt_advertiser_t* adv,
+    uint8_t adv_id, bt_le_address_t* addr)
+{
+    bt_advertiser_remote_t* adver = adv;
+    bt_message_packet_t packet = { 0 };
+
+    /* Send stopped first for backward compatibility */
+    BT_LOGD("adv_id:%d ipc send stopped+terminated, has_addr:%d", adv_id, (addr != NULL));
+    packet.adv_cb._on_advertising_stopped.adver = adver->remote;
+    packet.adv_cb._on_advertising_stopped.adv_id = adv_id;
+    bt_socket_server_send(adver->ins, &packet, BT_LE_ON_ADVERTISER_STOPPED);
+
+    /* Then send terminated for new clients */
+    memset(&packet, 0, sizeof(packet));
+    packet.adv_cb._on_advertising_terminated.adver = adver->remote;
+    packet.adv_cb._on_advertising_terminated.adv_id = adv_id;
+    packet.adv_cb._on_advertising_terminated.has_addr = (addr != NULL);
+    if (addr) {
+        memcpy(&packet.adv_cb._on_advertising_terminated.addr,
+               addr, sizeof(bt_le_address_t));
+    }
+    bt_socket_server_send(adver->ins, &packet,
+        BT_LE_ON_ADVERTISER_TERMINATED);
+
+    free(adv);
+}
+
 static advertiser_callback_t g_advertiser_socket_cb = {
     sizeof(g_advertiser_socket_cb),
     on_advertising_start_cb,
     on_advertising_stopped_cb,
+    on_advertising_terminated_cb,
 };
 
 /****************************************************************************
@@ -151,9 +180,30 @@ int bt_socket_client_advertiser_callback(service_poll_t* poll,
     case BT_LE_ON_ADVERTISER_STOPPED: {
         bt_advertiser_remote_t* adver = INT2PTR(bt_advertiser_remote_t*) packet->adv_cb._on_advertising_stopped.adver;
 
+        if (adver->terminated_received) {
+            BT_LOGD("adv stopped skipped, terminated already received");
+            adver->terminated_received = false;
+            break;
+        }
+
         CALLBACK_REMOTE(adver, advertiser_callback_t,
             on_advertising_stopped,
             packet->adv_cb._on_advertising_stopped.adv_id);
+        free(adver);
+        break;
+    }
+    case BT_LE_ON_ADVERTISER_TERMINATED: {
+        bt_advertiser_remote_t* adver = INT2PTR(bt_advertiser_remote_t*) packet->adv_cb._on_advertising_terminated.adver;
+
+        adver->terminated_received = true;
+
+        bt_le_address_t* addr =
+            packet->adv_cb._on_advertising_terminated.has_addr
+            ? &packet->adv_cb._on_advertising_terminated.addr : NULL;
+
+        CALLBACK_REMOTE(adver, advertiser_callback_t,
+            on_advertising_terminated,
+            packet->adv_cb._on_advertising_terminated.adv_id, addr);
         free(adver);
         break;
     }

--- a/service/src/advertising.c
+++ b/service/src/advertising.c
@@ -59,6 +59,8 @@ typedef struct {
     uint8_t adv_id;
     advertising_info_t* adv_info;
     uint8_t state;
+    bt_le_address_t addr;
+    bool has_addr;
 } adv_event_t;
 
 static adv_manager_t adv_manager;
@@ -267,6 +269,19 @@ static void advertiser_notify_state(void* data)
         delete_advertiser(adver);
         adver->callbacks.on_advertising_stopped(get_adver(adver), advstate->adv_id);
         destroy_advertiser(adver);
+    } else if (advstate->state == LE_ADVERTISING_TERMINATED) {
+        delete_advertiser(adver);
+        if (adver->callbacks.on_advertising_terminated) {
+            BT_LOGD("adv_id:%d notify terminated, has_addr:%d", advstate->adv_id, advstate->has_addr);
+            adver->callbacks.on_advertising_terminated(
+                get_adver(adver), advstate->adv_id,
+                advstate->has_addr ? &advstate->addr : NULL);
+        } else if (adver->callbacks.on_advertising_stopped) {
+            BT_LOGD("adv_id:%d terminated fallback to stopped", advstate->adv_id);
+            adver->callbacks.on_advertising_stopped(
+                get_adver(adver), advstate->adv_id);
+        }
+        destroy_advertiser(adver);
     }
 
 exit:
@@ -306,6 +321,27 @@ void advertising_on_state_changed(uint8_t adv_id, uint8_t state)
 
     advstate->adv_id = adv_id;
     advstate->state = state;
+    advstate->has_addr = false;
+    do_in_service_loop(advertiser_notify_state, advstate);
+}
+
+void advertising_on_terminated(uint8_t adv_id, bt_le_address_t* addr)
+{
+    adv_event_t* advstate = malloc(sizeof(adv_event_t));
+
+    if (!advstate) {
+        BT_LOGE("adv_id: %d terminated malloc failed", adv_id);
+        return;
+    }
+
+    advstate->adv_id = adv_id;
+    advstate->state = LE_ADVERTISING_TERMINATED;
+    if (addr) {
+        memcpy(&advstate->addr, addr, sizeof(bt_le_address_t));
+        advstate->has_addr = true;
+    } else {
+        advstate->has_addr = false;
+    }
     do_in_service_loop(advertiser_notify_state, advstate);
 }
 

--- a/service/src/advertising.h
+++ b/service/src/advertising.h
@@ -22,10 +22,12 @@
 
 enum advertising_state {
     LE_ADVERTISING_STARTED = 0,
-    LE_ADVERTISING_STOPPED
+    LE_ADVERTISING_STOPPED,
+    LE_ADVERTISING_TERMINATED,
 };
 
 void advertising_on_state_changed(uint8_t adv_id, uint8_t state);
+void advertising_on_terminated(uint8_t adv_id, bt_le_address_t* addr);
 bt_advertiser_t* start_advertising(void* remote,
     ble_adv_params_t* params,
     uint8_t* adv_data,

--- a/service/stacks/zephyr/sal_le_advertise_interface.c
+++ b/service/stacks/zephyr/sal_le_advertise_interface.c
@@ -18,6 +18,7 @@
 #include "include/sal_le_advertise_interface.h"
 
 #include "advertising.h"
+#include "bt_addr.h"
 #include "sal_interface.h"
 #include "service_loop.h"
 #include "utils/log.h"
@@ -122,7 +123,7 @@ static bt_status_t parse_bt_adv_data(uint8_t* raw, uint16_t raw_len,
     return BT_STATUS_SUCCESS;
 }
 
-static void ext_adv_terminated_cb(struct bt_le_ext_adv* adv)
+static void ext_adv_sent(struct bt_le_ext_adv* adv, struct bt_le_ext_adv_sent_info* info)
 {
     int index;
 
@@ -134,22 +135,36 @@ static void ext_adv_terminated_cb(struct bt_le_ext_adv* adv)
         return;
     }
 
-    advertising_on_state_changed(g_adv_sets[index]->adv_id, LE_ADVERTISING_STOPPED);
+    BT_LOGD("%s, adv_id:%d terminated by timeout/max_events", __func__,
+        g_adv_sets[index]->adv_id);
+    advertising_on_terminated(g_adv_sets[index]->adv_id, NULL);
     zblue_le_ext_delete(g_adv_sets[index]);
-}
-
-static void ext_adv_sent(struct bt_le_ext_adv* adv, struct bt_le_ext_adv_sent_info* info)
-{
-    BT_LOGD("%s ", __func__);
-
-    ext_adv_terminated_cb(adv);
 }
 
 static void ext_adv_connected(struct bt_le_ext_adv* adv, struct bt_le_ext_adv_connected_info* info)
 {
+    int index;
+
     BT_LOGD("%s ", __func__);
 
-    ext_adv_terminated_cb(adv);
+    index = bt_le_ext_adv_get_index(adv);
+    if (!g_adv_sets[index]) {
+        BT_LOGE("%s, adv set index:%d null", __func__, index);
+        return;
+    }
+
+    const bt_addr_le_t *dst = bt_conn_get_dst(info->conn);
+    bt_le_address_t peer_addr;
+    memcpy(peer_addr.addr, dst->a.val, BT_ADDR_LENGTH);
+    peer_addr.addr_type = dst->type;
+
+    BT_LOGD("%s, adv_id:%d terminated by connection, peer:%02x:%02x:%02x:%02x:%02x:%02x type:%d",
+        __func__, g_adv_sets[index]->adv_id,
+        peer_addr.addr[5], peer_addr.addr[4], peer_addr.addr[3],
+        peer_addr.addr[2], peer_addr.addr[1], peer_addr.addr[0],
+        peer_addr.addr_type);
+    advertising_on_terminated(g_adv_sets[index]->adv_id, &peer_addr);
+    zblue_le_ext_delete(g_adv_sets[index]);
 }
 
 static bt_status_t zblue_le_ext_convert_param(ble_adv_params_t* params, struct bt_le_adv_param* param)


### PR DESCRIPTION
bug: v/88589

Add on_advertising_terminated to advertiser_callback_t for Controller- initiated advertising termination. Use bt_le_address_t to carry peer address with type when terminated due to connection establishment.

Falls back to on_advertising_stopped if terminated callback is not registered. IPC sends both stopped and terminated for backward compatibility with old clients.

