### PR TITLE
cmake: add CONFIG_BLUETOOTH_LE_CS build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ if(CONFIG_BLUETOOTH)
     ${BLUETOOTH_DIR}/framework/api/bt_adapter.c
     ${BLUETOOTH_DIR}/framework/api/bt_device.c)
 
+    if(CONFIG_BLUETOOTH_LE_CS)
+      list(APPEND CSRCS ${BLUETOOTH_DIR}/framework/api/bt_cs.c)
+    endif()
+
   if(CONFIG_BLUETOOTH_A2DP_SINK)
     list(APPEND CSRCS ${BLUETOOTH_DIR}/framework/api/bt_a2dp_sink.c)
   endif()
@@ -190,6 +194,11 @@ if(CONFIG_BLUETOOTH)
       list(APPEND CSRCS ${BLUETOOTH_DIR}/service/ipc/socket/src/bt_socket_log.c)
     endif()
 
+    if(CONFIG_BLUETOOTH_LE_CS)
+      list(APPEND CSRCS ${BLUETOOTH_DIR}/framework/socket/bt_cs.c)
+      list(APPEND CSRCS ${BLUETOOTH_DIR}/service/ipc/socket/src/bt_socket_cs.c)
+    endif()
+
     list(APPEND INCDIR ${BLUETOOTH_DIR}/service/ipc/socket/include)
 
     if (CONFIG_BLUETOOTH_FRAMEWORK_ASYNC)
@@ -324,6 +333,10 @@ if(CONFIG_BLUETOOTH)
 
       if(CONFIG_BLUETOOTH_GATT_SERVER)
         list(APPEND CSRCS ${BLUETOOTH_DIR}/service/stacks/zephyr/sal_gatt_server_interface.c)
+      endif()
+
+      if(CONFIG_BLUETOOTH_LE_CS)
+        list(APPEND CSRCS ${BLUETOOTH_DIR}/service/stacks/zephyr/sal_le_cs_interface.c)
       endif()
     endif()
 
@@ -498,6 +511,12 @@ if(CONFIG_BLUETOOTH)
       list(APPEND CSRCS ${BLUETOOTH_DIR}/service/utils/btsnoop_filter.c)
     endif()
 
+    if(CONFIG_BLUETOOTH_LE_CS)
+      file(GLOB APPEND_FILES ${BLUETOOTH_DIR}/service/profiles/cs/*.c)
+      list(APPEND CSRCS ${APPEND_FILES})
+      list(APPEND INCDIR ${BLUETOOTH_DIR}/service/profiles/cs)
+    endif()
+
     if(CONFIG_BLUETOOTH_HCI_FILTER)
       list(APPEND CSRCS ${BLUETOOTH_DIR}/service/vhal/bt_hci_filter.c)
     endif()
@@ -648,6 +667,10 @@ if(CONFIG_BLUETOOTH)
 
     if(CONFIG_BLUETOOTH_STORAGE_UPDATE)
       list(APPEND CSRCS ${BLUETOOTH_DIR}/tools/storage_update/storage_tool.c)
+    endif()
+
+    if(CONFIG_BLUETOOTH_LE_CS)
+      list(APPEND CSRCS ${BLUETOOTH_DIR}/tools/le_cs.c)
     endif()
   endif()
 


### PR DESCRIPTION
bug: v/88558

Add conditional compilation for Bluetooth LE Channel Sounding (CS) feature across framework API, socket IPC, Zephyr SAL, CS profiles, and le_cs tool.