### PR TITLE
bluetooth: fix CM_RECONNECT_TIMES mismatch with reconnect interval

### DIFF
--- a/service/src/connection_manager.c
+++ b/service/src/connection_manager.c
@@ -49,7 +49,7 @@
 
 #define CM_RECONNECT_INTERVAL (12000) /* reconnect Interval */
 #define PROFILE_CONNECT_INTERVAL (500) /* Interval between HFP and A2DP */
-#define CM_RECONNECT_TIMES ((60 * 30) / 8) /* Continuous 30-mins reconnect */
+#define CM_RECONNECT_TIMES ((60 * 30 * 1000) / CM_RECONNECT_INTERVAL) /* Continuous 30-mins reconnect */
 #define CM_RSSI_UPDATE_INTERVAL_MS (5 * 1000)
 #define CM_RSSI_DUMP_INTERVAL_MS (60 * 1000)
 


### PR DESCRIPTION
## Summary
CM_RECONNECT_INTERVAL was previously changed from 8s to 12s for power optimization,
but CM_RECONNECT_TIMES was not updated accordingly. It was still calculated as
(60*30)/8=225, resulting in an actual reconnect window of 225×12s=45 minutes,
exceeding the designed 30-minute window.

Fix by updating the divisor from 8 to 12, so CM_RECONNECT_TIMES becomes
(60*30)/12=150, restoring the 30-minute reconnect window.

## Impact
Reconnect window after supervision timeout disconnect is corrected from 45 minutes
back to the designed 30 minutes.

## Testing
Code review and calculation verification.