### PR TITLE
avoid removing bond on generic security failures

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -141,6 +141,8 @@ static void zblue_on_br_pairing_complete_ctkd(struct bt_conn* conn, bool is_link
 static void zblue_on_br_pairing_complete(struct bt_conn* conn, bool bonding_flag);
 static void zblue_on_br_pairing_failed(struct bt_conn* conn, enum bt_security_err reason);
 static void zblue_on_br_bond_deleted(uint8_t id, const bt_addr_le_t* peer);
+bt_status_t bt_sal_disconnect_internal(bt_controller_id_t id, bt_address_t* addr, uint8_t reason);
+bt_status_t bt_sal_remove_bond_internal(bt_controller_id_t id, bt_address_t* addr);
 static void zblue_register_callback(void);
 static void zblue_unregister_callback(void);
 #if defined(CONFIG_SETTINGS_ZBLUE)
@@ -308,7 +310,7 @@ static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,
 {
     bt_address_t addr;
     struct bt_conn_info info;
-    int ret;
+    bt_status_t ret;
     bool encrypted = false;
 
     if (bt_conn_get_info(conn, &info) < 0) {
@@ -321,7 +323,8 @@ static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,
 
     bt_addr_set(&addr, info.br.dst->val);
 
-    BT_LOGD("%s, level: %d, required level: %d, err: %d", __func__, level, g_security_level, err);
+    BT_LOGD("%s, state: %d, level: %d, required level: %d, err: %d",
+        __func__, info.state, level, g_security_level, err);
 
     if (level >= g_security_level && err == BT_SECURITY_ERR_SUCCESS) {
         encrypted = true;
@@ -329,14 +332,23 @@ static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,
         return;
     }
 
-    adapter_on_bond_state_changed(&addr, BOND_STATE_NONE, BT_TRANSPORT_BREDR, BT_STATUS_FAIL, false);
-    ret = bt_br_unpair((bt_addr_t*)info.br.dst);
-    if (ret < 0) {
-        BT_LOGE("%s, Failed to remove old BR key: %d", __func__, ret);
+    if ((level < g_security_level) && (err == BT_SECURITY_ERR_AUTH_FAIL || err == BT_SECURITY_ERR_PIN_OR_KEY_MISSING)) {
+        adapter_on_bond_state_changed(&addr, BOND_STATE_NONE, BT_TRANSPORT_BREDR, BT_STATUS_FAIL, false);
+        BT_LOGD("%s, err: %d, remove old key async", __func__, err);
+        ret = bt_sal_remove_bond_internal(PRIMARY_ADAPTER, &addr);
+        if (ret != BT_STATUS_SUCCESS) {
+            BT_LOGE("%s, Failed to remove old BR key async: %d", __func__, ret);
+        }
+    } else if (err != BT_SECURITY_ERR_SUCCESS) {
+        BT_LOGW("%s, preserve bond on BR security failure, state: %d, level: %d, required: %d, err: %d",
+            __func__, info.state, level, g_security_level, err);
     }
 
-    if (err == BT_SECURITY_ERR_AUTH_FAIL || (err == BT_SECURITY_ERR_SUCCESS && level < g_security_level)) {
-        bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+    if (err == BT_SECURITY_ERR_AUTH_FAIL || err == BT_SECURITY_ERR_PIN_OR_KEY_MISSING || (err == BT_SECURITY_ERR_SUCCESS && level < g_security_level)) {
+        ret = bt_sal_disconnect_internal(PRIMARY_ADAPTER, &addr, BT_HCI_ERR_AUTH_FAIL);
+        if (ret != BT_STATUS_SUCCESS) {
+            BT_LOGE("%s, disconnect async failed: %d", __func__, ret);
+        }
         return;
     }
 

--- a/service/stacks/zephyr/sal_adapter_le_interface.c
+++ b/service/stacks/zephyr/sal_adapter_le_interface.c
@@ -571,12 +571,14 @@ static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,
     bt_address_t* remote_addr;
     bool encrypted = false;
 
-    BT_LOGD("%s", __func__);
     bt_conn_get_info(conn, &info);
 
     if (info.type != BT_CONN_TYPE_LE) {
         return;
     }
+
+    BT_LOGD("%s, state: %d, level: %d, required level: %d, err: %d",
+        __func__, info.state, level, g_security_level, err);
 
     memcpy(&le_addr, info.le.dst->a.val, sizeof(le_addr.addr));
     remote_addr = adapter_get_le_remote_address(&le_addr, info.le.dst->type);
@@ -586,14 +588,22 @@ static void zblue_on_security_changed(struct bt_conn* conn, bt_security_t level,
         memcpy(&addr, info.le.remote->a.val, sizeof(addr.addr));
     }
 
-    if (err && !adapter_get_pts_mode()) {
+    if (level >= g_security_level && err == BT_SECURITY_ERR_SUCCESS) {
+        encrypted = true;
+        adapter_on_encryption_state_changed(&addr, encrypted, BT_TRANSPORT_BLE);
+        return;
+    }
+
+    if (!adapter_get_pts_mode() && (level < g_security_level) && (err == BT_SECURITY_ERR_AUTH_FAIL || err == BT_SECURITY_ERR_PIN_OR_KEY_MISSING)) {
         adapter_on_bond_state_changed(&addr, BOND_STATE_NONE, BT_TRANSPORT_BLE, BT_STATUS_FAIL, false);
         BT_LOGD("%s, err: %d, remove old key async", __func__, err);
         bt_sal_le_remove_bond(PRIMARY_ADAPTER, &addr);
-    }
-
-    if (level >= BT_SECURITY_L2 && err == BT_SECURITY_ERR_SUCCESS) {
-        encrypted = true;
+    } else if (err != BT_SECURITY_ERR_SUCCESS) {
+        BT_LOGW("%s, preserve bond on LE security failure, state: %d, level: %d, required: %d, err: %d",
+            __func__, info.state, level, g_security_level, err);
+    } else if (level < g_security_level) {
+        BT_LOGW("%s, security level insufficient: achieved %d, required %d",
+            __func__, level, g_security_level);
     }
 
     adapter_on_encryption_state_changed(&addr, encrypted, BT_TRANSPORT_BLE);


### PR DESCRIPTION
bug: v/88179

Restrict BR/LE security_changed bond cleanup to authentication failure and missing-key cases only. Preserve existing bond information for other security errors, and move BR bond removal plus ACL disconnect handling to the service work queue to match the async LE flow.

- rootcause: BR/LE security_changed treated generic security failures as stale key failures, so delayed teardown or non-key-related errors could incorrectly delete the stored bond and break the next reconnect.
- include connection state in security_changed logs to improve failure diagnosis.
- route BR remove_bond and disconnect through the internal async SAL path instead of operating directly in the callback.

