### PR TITLE
Notify BR/EDR CONNECTING state on outgoing ACL

### DIFF
--- a/service/stacks/zephyr/sal_adapter_interface.c
+++ b/service/stacks/zephyr/sal_adapter_interface.c
@@ -1416,12 +1416,19 @@ static void STACK_CALL(connect)(void* args)
 {
     sal_adapter_req_t* req = args;
     struct bt_conn* conn;
+    acl_state_param_t state;
 
     conn = bt_conn_create_br((const bt_addr_t*)&req->addr, BT_BR_CONN_PARAM_DEFAULT);
     if (!conn) {
         BT_LOGW("bt_conn_create_br Connection failed");
         return;
     }
+
+    memset(&state, 0, sizeof(state));
+    state.transport = BT_TRANSPORT_BREDR;
+    state.connection_state = CONNECTION_STATE_CONNECTING;
+    memcpy(&state.addr, &req->addr, sizeof(bt_address_t));
+    adapter_on_connection_state_changed(&state);
 
     bt_conn_unref(conn);
 }


### PR DESCRIPTION
after bt_conn_create_br succeeds (conn enters BT_CONN_INITIATING internally, which maps to BT_CONN_STATE_CONNECTING publicly), send CONNECTION_STATE_CONNECTING event to upper layers via adapter_on_connection_state_changed.

Previously only incoming connections (zblue_on_connect_req) notified CONNECTING state; outgoing connections jumped directly from DISCONNECTED to CONNECTED, causing upper layers to miss the intermediate state.

