### PR TITLE
bluetooth: add MAC address privacy protection in logs

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -860,6 +860,16 @@ config BLUETOOTH_SERVICE_LOG_LEVEL
 	depends on BLUETOOTH_SERVICE
 	help
 		Set BT Service log level <0~7>
+
+config BLUETOOTH_LOG_PRIVACY
+	int "Default log privacy mask"
+	default 0
+	help
+		Bitmask for log privacy. Can be changed at runtime via
+		bttool log privacy <bit> <0|1>.
+		Privacy Bit Enum:
+		  ADDR: 0
+
 endif #BLUETOOTH_LOG
 
 endmenu #Debug

--- a/framework/common/bt_addr.c
+++ b/framework/common/bt_addr.c
@@ -26,6 +26,7 @@ static const bt_address_t bt_addr_empty = {
 };
 
 static char g_bdaddr_str[18];
+static bool g_addr_privacy = false;
 
 static int bachk(const char* str)
 {
@@ -71,6 +72,10 @@ int bt_addr_compare(const bt_address_t* a, const bt_address_t* b)
 
 int bt_addr_ba2str(const bt_address_t* addr, char* str)
 {
+    if (g_addr_privacy)
+        return sprintf(str, "XX:XX:XX:XX:%2.2X:%2.2X",
+            addr->addr[1], addr->addr[0]);
+
     return sprintf(str, "%2.2X:%2.2X:%2.2X:%2.2X:%2.2X:%2.2X",
         addr->addr[5], addr->addr[4], addr->addr[3],
         addr->addr[2], addr->addr[1], addr->addr[0]);
@@ -112,4 +117,14 @@ void bt_addr_swap(const bt_address_t* src, bt_address_t* dest)
 {
     for (int i = 0; i < 6; i++)
         dest->addr[5 - i] = src->addr[i];
+}
+
+void bt_addr_set_privacy(bool enable)
+{
+    g_addr_privacy = enable;
+}
+
+bool bt_addr_get_privacy(void)
+{
+    return g_addr_privacy;
 }

--- a/framework/include/bt_addr.h
+++ b/framework/include/bt_addr.h
@@ -210,6 +210,25 @@ void bt_addr_set(bt_address_t* addr, const uint8_t* bd);
  */
 void bt_addr_swap(const bt_address_t* src, bt_address_t* dest);
 
+/**
+ * @brief Enable or disable address privacy in logging.
+ *
+ * When enabled, bt_addr_ba2str() and bt_addr_bastr() return masked addresses
+ * in the format "xx:xx:xx:xx:XX:XX" (only last 2 octets visible).
+ * Privacy is enabled by default.
+ *
+ * @param enable - true to enable privacy (masked), false to show full address.
+ */
+void bt_addr_set_privacy(bool enable);
+
+/**
+ * @brief Get current address privacy state.
+ *
+ * @return true - Privacy is enabled (addresses are masked).
+ * @return false - Privacy is disabled (full addresses shown).
+ */
+bool bt_addr_get_privacy(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/service/utils/log.h
+++ b/service/utils/log.h
@@ -36,6 +36,11 @@
 #define LOG_ID_STACK 1
 #define LOG_ID_FRAMEWORK 2
 
+enum bt_log_privacy_ {
+    BT_LOG_PRIVACY_NONE = 0,
+    BT_LOG_PRIVACY_ADDR = (1 << 0),
+};
+
 enum bt_log_level_ {
     BT_LOG_LEVEL_OFF = 0x0,
     BT_LOG_LEVEL_ERROR = LOG_ERR,
@@ -43,6 +48,12 @@ enum bt_log_level_ {
     BT_LOG_LEVEL_INFO = LOG_INFO,
     BT_LOG_LEVEL_DEBUG = LOG_DEBUG,
 };
+
+#ifdef CONFIG_BLUETOOTH_LOG_PRIVACY
+#define DEFAULT_BT_LOG_PRIVACY CONFIG_BLUETOOTH_LOG_PRIVACY
+#else
+#define DEFAULT_BT_LOG_PRIVACY BT_LOG_PRIVACY_NONE
+#endif
 
 #ifndef CONFIG_BLUETOOTH_SERVICE_LOG_LEVEL
 #define DEFAULT_BT_LOG_LEVEL BT_LOG_LEVEL_OFF
@@ -100,4 +111,5 @@ void bt_log_server_init(void);
 void bt_log_server_cleanup(void);
 void bt_log_module_enable(int id, bool changed);
 void bt_log_module_disable(int id, bool changed);
+void bt_log_set_privacy(uint32_t flags);
 #endif

--- a/service/utils/log_server.c
+++ b/service/utils/log_server.c
@@ -23,6 +23,7 @@
 #include <kvdb.h>
 #endif
 
+#include "bt_addr.h"
 #include "bt_status.h"
 #include "btsnoop_log.h"
 #include "log.h"
@@ -34,6 +35,7 @@ enum {
     STACK_LOG_EN_CHANGED,
     STACK_LOG_MASK_CHANGED,
     SNOOP_LOG_EN_CHANGED,
+    ADDR_PRIVACY_CHANGED,
 };
 
 #define PERSIST_BT_LOG_CHANGED "persist.bluetooth.log.changed"
@@ -42,6 +44,7 @@ enum {
 #define PERSIST_BT_STACK_LOG_MASK "persist.bluetooth.log.stack_mask"
 #define PERSIST_BT_SNOOP_LOG_EN "persist.bluetooth.log.snoop_enable"
 #define PERSIST_BT_SNOOP_FILE_PATH "persist.bluetooth.log.snoop_path"
+#define PERSIST_BT_LOG_PRIVACY "persist.bluetooth.log.privacy"
 
 // #define PERSIST_BT_SNOOP_LOG_CID_MASK "persist.bluetooth.log.snoop_cid_mask"
 // #define PERSIST_BT_SNOOP_LOG_PKT_MASK "persist.bluetooth.log.snoop_pkt_mask"
@@ -54,12 +57,13 @@ struct bt_logger {
     int stack_mask;
     int snoop_cid_mask;
     int snoop_pkt_mask;
+    uint32_t privacy_flags;
 
     int monitor_fd;
     service_poll_t* poll;
 };
 
-static struct bt_logger g_logger = { 0, 0, BT_LOG_LEVEL_OFF, 0, 0, 0, -1 };
+static struct bt_logger g_logger = { 0, 0, BT_LOG_LEVEL_OFF, 0, 0, 0, 0, -1 };
 
 static const char* log_id_str(uint8_t id)
 {
@@ -238,6 +242,14 @@ static void property_monitor_cb(service_poll_t* poll,
                     bt_log_module_disable(LOG_ID_SNOOP, true);
             }
         }
+
+        if (changed & (1 << ADDR_PRIVACY_CHANGED)) {
+            new = property_get_int32(PERSIST_BT_LOG_PRIVACY, DEFAULT_BT_LOG_PRIVACY);
+            if (new != g_logger.privacy_flags) {
+                bt_log_set_privacy(new);
+                syslog(LOG_INFO, "log privacy flags: 0x%x\n", new);
+            }
+        }
     }
 }
 #endif
@@ -249,6 +261,9 @@ void bt_log_server_init(void)
 
     /** framework log init */
     g_logger.framework_level = property_get_int32(PERSIST_BT_FRAMEWORK_LOG_LEVEL, DEFAULT_BT_LOG_LEVEL);
+
+    /** log privacy init */
+    bt_log_set_privacy(property_get_int32(PERSIST_BT_LOG_PRIVACY, DEFAULT_BT_LOG_PRIVACY));
 
     /** stack log init */
     bt_sal_debug_init();
@@ -308,6 +323,16 @@ void bt_log_server_cleanup(void)
     if (g_logger.stack_enable)
         bt_sal_debug_disable();
     bt_sal_debug_cleanup();
+}
+
+void bt_log_set_privacy(uint32_t flags)
+{
+    uint32_t changed = g_logger.privacy_flags ^ flags;
+
+    g_logger.privacy_flags = flags;
+
+    if (changed & BT_LOG_PRIVACY_ADDR)
+        bt_addr_set_privacy((flags & BT_LOG_PRIVACY_ADDR) != 0);
 }
 
 bool bt_log_print_check(uint8_t level)

--- a/tools/log.c
+++ b/tools/log.c
@@ -49,6 +49,7 @@ static int filter_cmd(void* handle, int argc, char* argv[]);
 static int unfilter_cmd(void* handle, int argc, char* argv[]);
 static int unmask_cmd(void* handle, int argc, char* argv[]);
 static int level_cmd(void* handle, int argc, char* argv[]);
+static int privacy_cmd(void* handle, int argc, char* argv[]);
 
 static bt_command_t g_log_tables[] = {
     { "enable", enable_cmd, 0, "\"Enable param: (\"snoop\" or \"stack\")\"" },
@@ -77,6 +78,11 @@ static bt_command_t g_log_tables[] = {
                                "\t\t\tSPP data:                 3\n" },
     { "unfilter", unfilter_cmd, 0, "\"Disable Stack Profile & Protocol Log <bit>\"" },
     { "level", level_cmd, 0, "\"Set framework log level, (OFF:0,ERR:3,WARN:4,INFO:6,DBG:7)\"" },
+    { "privacy", privacy_cmd, 0, "\"Set log privacy bit, usage: privacy <bit> <0|1>\"\n"
+                                 "\t\t\tExample enable addr privacy: \"bttool> log privacy 0 1\"\n"
+                                 "\t\t\tExample disable addr privacy: \"bttool> log privacy 0 0\"\n"
+                                 "\t\t\tPrivacy Bit Enum:\n"
+                                 "\t\t\t  ADDR: 0\n" },
 };
 
 static void usage(void)
@@ -231,6 +237,36 @@ static int level_cmd(void* handle, int argc, char* argv[])
 #ifdef CONFIG_KVDB
     property_set_int32("persist.bluetooth.log.level", level);
     property_change_commit(0);
+
+    return CMD_OK;
+#else
+    return CMD_ERROR;
+#endif
+}
+
+static int privacy_cmd(void* handle, int argc, char* argv[])
+{
+    if (argc < 2)
+        return CMD_PARAM_NOT_ENOUGH;
+
+    int bit = atoi(argv[0]);
+    int enable = atoi(argv[1]);
+
+    if (bit < 0 || bit > 31)
+        return CMD_INVALID_PARAM;
+
+    if (enable != 0 && enable != 1)
+        return CMD_INVALID_PARAM;
+
+#ifdef CONFIG_KVDB
+    int mask = property_get_int32("persist.bluetooth.log.addr_privacy", 0x0);
+    if (enable)
+        mask |= (1 << bit);
+    else
+        mask &= ~(1 << bit);
+
+    property_set_int32("persist.bluetooth.log.addr_privacy", mask);
+    property_change_commit(4);
 
     return CMD_OK;
 #else


### PR DESCRIPTION
## Summary
Add log privacy as bitmask enum to support multiple privacy types. Currently supports address privacy (BIT 0), extensible for future types (e.g., name privacy).

- bt_addr.c/h: bt_addr_set_privacy()/bt_addr_get_privacy() for address masking
- log.h: enum bt_log_privacy_ bitmask, DEFAULT_BT_LOG_PRIVACY macro, bt_log_set_privacy() declaration
- log_server.c: privacy_flags in g_logger, bt_log_set_privacy() dispatches by changed bits
- tools/log.c: bttool log privacy <bit> <0|1>
- Kconfig: BLUETOOTH_LOG_PRIVACY (int, default 0)

## Impact
No breaking changes. Existing behavior preserved when privacy mask is 0 (default).

## Testing
Build verified on sim target. Runtime tested via bttool log privacy 0 1 / bttool log privacy 0 0.