### PR TITLE
bluetooth/scan: add UUID filter support and enable scan filter

### DIFF
--- a/service/src/scan_record.c
+++ b/service/src/scan_record.c
@@ -56,8 +56,12 @@ void scan_record_parse(scan_record_t* record, const uint8_t* eir_data, uint8_t e
         data_len = field_len - 1;
 
         switch (eir_data[1]) {
+        case BT_EIR_UUID16_INCOMPLETE:
+        case BT_EIR_UUID16_COMPLETE:
         case BT_EIR_SVC_DATA_16:
-            record_parse_uuid16(record, data, data_len);
+            if (data_len >= 2) {
+                record_parse_uuid16(record, data, data_len);
+            }
             break;
 
         /* TODO: handle other eir data */

--- a/service/src/scan_record.h
+++ b/service/src/scan_record.h
@@ -19,6 +19,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define BT_EIR_UUID16_INCOMPLETE 0x02 // 16-bit UUID, more available
+#define BT_EIR_UUID16_COMPLETE 0x03 // 16-bit UUID, all listed
 #define BT_EIR_SVC_DATA_16 0x16 // 16-bit UUID
 
 typedef struct {


### PR DESCRIPTION
## Summary

Add UUID_SOME and UUID_ALL scan filter support for BLE scanning, and enable the scan filter mechanism to prevent system oops under high pressure scenarios.

Changes:
- Enable BLUETOOTH_BLE_SCAN_FILTER config option to activate vhal hash filter
- Add UUID_SOME and UUID_ALL macro definitions for scan record parsing
- Handle uuid16_some/uuid_all EIR data types in scan result processing

## Impact

- Improves BLE scan stability under high pressure scenarios
- Extends scan filter capability to support power meter devices via UUID filtering
- No breaking changes to existing APIs

## Testing

- Built and verified on target device
- Tested BLE scan with power meter devices using UUID_SOME/UUID_ALL filters
- Verified no regression in existing SVC_DATA_16 filter functionality