### PR TITLE
bluetooth: fix GATT server DB exhaustion on disable/enable cycles

### DIFF
--- a/service/profiles/gatt/gatts_service.c
+++ b/service/profiles/gatt/gatts_service.c
@@ -472,12 +472,13 @@ static bt_status_t if_gatts_shutdown(profile_on_shutdown_t cb)
         return BT_STATUS_SUCCESS;
     }
 
+    bt_sal_gatt_server_disable();
+
     bt_list_free(manager->services);
     manager->services = NULL;
     bt_list_free(manager->pend_ops);
     manager->pend_ops = NULL;
     manager->started = false;
-    bt_sal_gatt_server_disable();
     cb(PROFILE_GATTS, true);
 
     return BT_STATUS_SUCCESS;

--- a/service/stacks/zephyr/sal_gatt_server_interface.c
+++ b/service/stacks/zephyr/sal_gatt_server_interface.c
@@ -190,6 +190,9 @@ static struct bt_gatt_service server_svcs[CONFIG_GATT_SERVER_MAX_SERVICES];
 static struct bt_gatt_attr server_db[CONFIG_GATT_SERVER_MAX_ATTRIBUTES];
 static sal_gatt_sdp_record_t gatt_sdp_records[CONFIG_GATT_SERVER_MAX_SERVICES];
 
+/* Forward declarations */
+static sal_gatt_sdp_record_t* get_sdp_from_service(struct bt_gatt_service* srv);
+
 static int find_free_service_index(void)
 {
     int i;
@@ -1168,6 +1171,39 @@ bt_status_t bt_sal_gatt_server_enable(void)
 
 bt_status_t bt_sal_gatt_server_disable(void)
 {
+    size_t i;
+
+    /* Unregister and clean up all registered GATT services to prevent
+     * server_db/server_svcs resource exhaustion across disable/enable cycles.
+     */
+    for (i = 0; i < ARRAY_SIZE(server_svcs); i++) {
+        struct bt_gatt_service* svc = &server_svcs[i];
+        sal_gatt_sdp_record_t* record;
+
+        if (!svc->attrs) {
+            continue;
+        }
+
+        record = get_sdp_from_service(svc);
+        if (record && record->record) {
+            bt_sdp_unregister_service(record->record);
+            gatt_sdp_delete_record(record->record);
+        }
+
+        bt_gatt_service_unregister(svc);
+    }
+
+    /* Free all attribute resources in server_db */
+    for (i = 0; i < attr_count; i++) {
+        free(server_db[i].user_data);
+        free((void*)server_db[i].uuid);
+    }
+
+    memset(server_db, 0, sizeof(server_db));
+    memset(server_svcs, 0, sizeof(server_svcs));
+    attr_count = 0;
+    svc_attr_count = 0;
+
     bt_gatt_cb_unregister(&zblue_gatt_callbacks);
     bt_att_conn_cb_unregister(&zblue_att_callbacks);
 


### PR DESCRIPTION
## Summary

Fix GATT server static DB exhaustion across disable/enable cycles.

`bt_sal_gatt_server_disable()` previously only unregistered GATT/ATT callbacks without cleaning up the `server_db[]` and `server_svcs[]` static arrays. Each disable/enable cycle left stale attributes occupying slots, so `attr_count` kept growing until it reached `CONFIG_GATT_SERVER_MAX_ATTRIBUTES` and new service registrations failed.

Changes:
- `bt_sal_gatt_server_disable()` now iterates `server_svcs[]` and unregisters every active GATT service from the zephyr stack, deletes the associated SDP records, frees each attribute's `user_data`/`uuid` memory, and resets `server_db`/`server_svcs`/`attr_count`/`svc_attr_count` to their initial state before unregistering callbacks.
- `if_gatts_shutdown()` is reordered to call `bt_sal_gatt_server_disable()` before freeing the upper-layer service list, ensuring zephyr-side unregistration completes while the static DB is still consistent.

## Impact

- Build: no Kconfig or API change
- Hardware: applies to all targets using the zephyr GATT server backend
- Compatibility: behavior change only on the disable path — resources are now fully released; no functional impact on normal enable/register/use flows
- Memory: slightly more work in the disable path; prevents long-term slot leakage and eventual registration failures

## Testing

- Reviewed the `user_data`/`uuid` lifecycle in `gatt_db_add()` and `remove_from_server_db()` — the new free pattern matches existing cleanup semantics, no UAF/double-free introduced
- Verified that `bt_gatt_service_unregister()` is synchronous in zephyr, so freeing attribute memory after unregistration is safe
- Manual scenario verification (from the original bug log): repeated `gatts register → disable → enable` cycles no longer leave stale `server_db` entries
