### PR TITLE
bluetooth: fix Make.defs include path for external app headers

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -17,7 +17,7 @@
 ifeq ($(CONFIG_BLUETOOTH), y)
 CONFIGURED_APPS += $(APPDIR)/frameworks/connectivity/bluetooth
 
-CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/include
-CXXFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/include
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/framework/include
+CXXFLAGS += ${INCDIR_PREFIX}$(APPDIR)/frameworks/connectivity/bluetooth/framework/include
 
 endif


### PR DESCRIPTION
## Summary

Fix the bluetooth framework Make.defs exported include path: the original path pointed to an empty directory `bluetooth/include`, changed to the actual header location `bluetooth/framework/include`.

## Features

- Fix the CFLAGS/CXXFLAGS include path exported in Make.defs
- External apps (e.g. `vendor/allwinnertech/apps/bt_instance`) can now correctly find `bluetooth.h`, `bt_config.h`, `bt_device.h`, `bt_gattc.h` and other public headers
- Resolve compilation failure on Gemini-S1 `nsh_minidisplay` (2.8-inch) config when `CONFIG_BT_LIGHTCTRL` is enabled

## Files

| File | Description |
|---|---|
| `Make.defs` | Change include path from `bluetooth/include` to `bluetooth/framework/include` |

## Testing

- Gemini-S1 `nsh_minidisplay` config: `bt_instance/gattc_op.c` compiles successfully (before fix: `fatal error: bluetooth.h: No such file or directory`, after fix: only unrelated warnings)
- Full `distclean` build verification: all `.c` files compiled, reached link stage
- No impact on `nsh` (7-inch) config: `BT_LIGHTCTRL` not enabled, `bt_instance` not compiled